### PR TITLE
Fix onboarding messaging clarity for issue #17

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupListScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupListScreen.kt
@@ -20,9 +20,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -391,9 +391,9 @@ fun GroupListScreen(
 fun OnboardingSheet(onDismiss: () -> Unit, isRevisit: Boolean = false) {
     val pages = remember {
         listOf(
-            Triple(Icons.Default.Lock, "Your messages are encrypted.\nYour metadata isn't.", "Most messengers encrypt your messages but still collect who you talk to, when, and how often. That metadata tells a complete story about you."),
-            Triple(Icons.Default.Person, "Private by design.\nAnonymous by default.", "No phone numbers. No accounts. No social graph. You prove you belong to a group without revealing who you are."),
-            Triple(Icons.Default.Refresh, "Shared control.\nNo single admin.", "When someone leaves, encryption keys rotate automatically. No one person holds the keys to your group.")
+            Triple(Icons.Default.VisibilityOff, "Now your messages and metadata are encrypted", "Most messengers encrypt your messages but still collect who you talk to, when, and how often. That metadata tells a complete story about you."),
+            Triple(Icons.Default.Person, "Private by design.\nAnonymous by default.", "No phone numbers. No accounts. No social graph. Even other group members won't know anything about you beyond what you choose to share."),
+            Triple(Icons.Default.Refresh, "Truly shared ownership.\nNo super-admin.", "Your group's legacy doesn't depend on a single super-admin. From the start, set transparent rules for adding and removing members — like via voting.")
         )
     }
     val totalPages = pages.size + 1 // +1 for differentiator page

--- a/clients/ios/StellarChat/StellarChat/Views/ContentView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ContentView.swift
@@ -76,9 +76,9 @@ struct OnboardingView: View {
     @State private var currentPage = 0
 
     private let pages: [(icon: String, title: String, subtitle: String)] = [
-        ("eye.trianglebadge.exclamationmark", "Your messages are encrypted.\nYour metadata isn't.", "Most messengers encrypt your messages but still collect who you talk to, when, and how often. That metadata tells a complete story about you."),
-        ("person.badge.shield.checkmark", "Private by design.\nAnonymous by default.", "No phone numbers. No accounts. No social graph. You prove you belong to a group without revealing who you are."),
-        ("person.3.sequence", "Shared control.\nNo single admin.", "When someone leaves, encryption keys rotate automatically. No one person holds the keys to your group.")
+        ("eye.trianglebadge.exclamationmark", "Now your messages and metadata are encrypted", "Most messengers encrypt your messages but still collect who you talk to, when, and how often. That metadata tells a complete story about you."),
+        ("person.badge.shield.checkmark", "Private by design.\nAnonymous by default.", "No phone numbers. No accounts. No social graph. Even other group members won't know anything about you beyond what you choose to share."),
+        ("person.3.sequence", "Truly shared ownership.\nNo super-admin.", "Your group's legacy doesn't depend on a single super-admin. From the start, set transparent rules for adding and removing members — like via voting.")
     ]
 
     private let totalPages = 4


### PR DESCRIPTION
## Summary
- update onboarding Screen A/B/C messaging copy on iOS and Android to match issue #17
- change Android Screen A icon to `VisibilityOff` as requested

## Validation
- attempted Android compile with `:app:compileDebugKotlin`, but this environment is missing Java (`JAVA_HOME` not set)

Closes #17

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://app.warp.dev/conversation/7d0b6a39-cc06-4c65-b362-6c2c3bfc1638_
_Run: https://oz.warp.dev/runs/019d829c-a511-7bba-8924-f717077c8166_
_This PR was generated with [Oz](https://warp.dev/oz)._
