### PR TITLE
Add member alias support to group info and fork views (fixes #23)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
@@ -423,6 +423,8 @@ fun StellarChatNavHost(
                             notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                         }
                     },
+                    contactAliasStore = groupListViewModel.contactAliasStore,
+                    dao = groupListViewModel.store.dao,
                     onBack = { navController.popBackStack() }
                 )
             }
@@ -447,6 +449,7 @@ fun StellarChatNavHost(
                             popUpTo("fork/$groupId") { inclusive = true }
                         }
                     },
+                    contactAliasStore = groupListViewModel.contactAliasStore,
                     onBack = { navController.popBackStack() }
                 )
             }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ForkGroupScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ForkGroupScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import chat.onym.android.model.ChatGroup
 import chat.onym.android.model.EpochSnapshot
 import chat.onym.android.model.toHex
+import chat.onym.android.persistence.ContactAliasStore
 import com.stellarmls.mls.SEPGroupMemberLeaf
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -51,6 +52,7 @@ fun ForkGroupScreen(
     removedByPubkeyHex: String? = null,
     onCreateFork: (excludingMembers: List<ByteArray>, forkName: String?, onResult: (Result<ChatGroup>) -> Unit) -> Unit,
     onNavigateToGroup: (String) -> Unit,
+    contactAliasStore: ContactAliasStore? = null,
     onBack: () -> Unit
 ) {
     // Find the latest epoch where user was a member
@@ -156,6 +158,7 @@ fun ForkGroupScreen(
                         val hex = member.publicKeyCompressed.toHex()
                         val isExcluded = excludedMembers.containsKey(hex)
                         val isRemover = hex == removedByPubkeyHex
+                        val alias = contactAliasStore?.displayName(hex)
 
                         Row(
                             modifier = Modifier
@@ -168,9 +171,17 @@ fun ForkGroupScreen(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Column(modifier = Modifier.weight(1f)) {
+                                if (alias != null) {
+                                    Text(
+                                        alias,
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
                                 Text(
                                     hex.take(16) + "...",
-                                    style = MaterialTheme.typography.bodySmall
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = if (alias != null) MaterialTheme.colorScheme.onSurfaceVariant
+                                        else MaterialTheme.colorScheme.onSurface
                                 )
                                 if (isMe) {
                                     Text(

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupInfoScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupInfoScreen.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.unit.dp
 import chat.onym.android.model.ChatGroup
 import chat.onym.android.model.EpochSnapshot
 import chat.onym.android.model.toHex
+import chat.onym.android.persistence.ContactAliasStore
+import chat.onym.android.persistence.StellarChatDao
 import chat.onym.android.ui.components.QRScannerView
 import com.stellarmls.mls.SEPGroupMemberLeaf
 import kotlinx.coroutines.delay
@@ -76,6 +78,8 @@ fun GroupInfoScreen(
     onSendInvitation: ((recipientKeyHex: String, onResult: (Result<Unit>) -> Unit) -> Unit)? = null,
     inviteLink: String? = null,
     onTogglePushNotifications: ((Boolean) -> Unit)? = null,
+    contactAliasStore: ContactAliasStore? = null,
+    dao: StellarChatDao? = null,
     onBack: () -> Unit
 ) {
     val isMember = group.members.any { it.publicKeyCompressed.contentEquals(myBlsPubkey) }
@@ -93,6 +97,9 @@ fun GroupInfoScreen(
     var inviteStatus by remember { mutableStateOf<String?>(null) }
     var inviteLinkCopied by remember { mutableStateOf(false) }
     var showScanner by remember { mutableStateOf(false) }
+    // Member alias
+    var aliasTarget by remember { mutableStateOf<String?>(null) }
+    var aliasText by remember { mutableStateOf("") }
 
     if (showScanner) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -186,16 +193,30 @@ fun GroupInfoScreen(
 
                     for (member in group.members) {
                         val isMe = member.publicKeyCompressed.contentEquals(myBlsPubkey)
+                        val hex = member.publicKeyCompressed.toHex()
+                        val alias = contactAliasStore?.displayName(hex)
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .clickable {
+                                    aliasText = alias ?: ""
+                                    aliasTarget = hex
+                                }
                                 .padding(vertical = 4.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Column(modifier = Modifier.weight(1f)) {
+                                if (alias != null) {
+                                    Text(
+                                        alias,
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
                                 Text(
-                                    member.publicKeyCompressed.toHex().take(16) + "...",
-                                    style = MaterialTheme.typography.bodySmall
+                                    hex.take(16) + "...",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = if (alias != null) MaterialTheme.colorScheme.onSurfaceVariant
+                                        else MaterialTheme.colorScheme.onSurface
                                 )
                                 if (isMe) {
                                     Text(
@@ -563,6 +584,46 @@ fun GroupInfoScreen(
             },
             dismissButton = {
                 TextButton(onClick = { showRotateKeyDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    if (aliasTarget != null && contactAliasStore != null && dao != null) {
+        AlertDialog(
+            onDismissRequest = { aliasTarget = null },
+            title = { Text("Set Name") },
+            text = {
+                Column {
+                    Text(
+                        (aliasTarget?.take(16) ?: "") + "...",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = aliasText,
+                        onValueChange = { aliasText = it },
+                        label = { Text("Display name") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val pubkey = aliasTarget ?: return@TextButton
+                    scope.launch {
+                        contactAliasStore.setAlias(pubkey, aliasText, dao)
+                    }
+                    aliasTarget = null
+                }) {
+                    Text("Save")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { aliasTarget = null }) {
                     Text("Cancel")
                 }
             }

--- a/clients/ios/StellarChat/StellarChat/Views/ForkGroupView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ForkGroupView.swift
@@ -42,6 +42,7 @@ struct ForkGroupView: View {
                             let isExcluded = excludedMembers.contains(member.publicKeyCompressed)
                             let pubkeyHex = member.publicKeyCompressed.map { String(format: "%02x", $0) }.joined()
                             let isRemover = pubkeyHex == originalGroup.removedByPubkeyHex
+                            let alias = appState.contactAliasStore.displayName(for: pubkeyHex)
                             Button {
                                 if !isMe {
                                     if isExcluded {
@@ -53,9 +54,14 @@ struct ForkGroupView: View {
                             } label: {
                                 HStack {
                                     VStack(alignment: .leading) {
+                                        if let alias {
+                                            Text(alias)
+                                                .font(.caption)
+                                        }
                                         Text(pubkeyHex.prefix(16) + "...")
-                                            .font(.caption)
+                                            .font(.caption2)
                                             .monospaced()
+                                            .foregroundStyle(alias != nil ? .secondary : .primary)
                                         if isMe {
                                             Text("You")
                                                 .font(.caption2)

--- a/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
@@ -21,6 +21,10 @@ struct GroupInfoView: View {
     // Copy invite link
     @State private var inviteLinkCopied = false
 
+    // Member alias
+    @State private var aliasTarget: String?
+    @State private var aliasText = ""
+
     // Epoch pin confirmation
     @State private var epochToPin: UInt64?
     @State private var showPinConfirmation = false
@@ -134,12 +138,18 @@ struct GroupInfoView: View {
 
                 Section("Members") {
                     ForEach(group.members, id: \.publicKeyCompressed) { member in
+                        let pubkeyHex = member.publicKeyCompressed.map { String(format: "%02x", $0) }.joined()
+                        let alias = appState.contactAliasStore.displayName(for: pubkeyHex)
                         HStack {
                             VStack(alignment: .leading) {
-                                let pubkeyHex = member.publicKeyCompressed.map { String(format: "%02x", $0) }.joined()
+                                if let alias {
+                                    Text(alias)
+                                        .font(.caption)
+                                }
                                 Text(pubkeyHex.prefix(16) + "...")
-                                    .font(.caption)
+                                    .font(.caption2)
                                     .monospaced()
+                                    .foregroundStyle(alias != nil ? .secondary : .primary)
 
                                 if isMyKey(member) {
                                     Text("You")
@@ -158,6 +168,21 @@ struct GroupInfoView: View {
                                     Image(systemName: "person.badge.minus")
                                 }
                                 .disabled(isRemovingMember)
+                            }
+                        }
+                        .contextMenu {
+                            Button {
+                                aliasText = alias ?? ""
+                                aliasTarget = pubkeyHex
+                            } label: {
+                                Label("Set Name", systemImage: "pencil")
+                            }
+                            if alias != nil {
+                                Button(role: .destructive) {
+                                    appState.contactAliasStore.removeAlias(pubkey: pubkeyHex)
+                                } label: {
+                                    Label("Remove Name", systemImage: "trash")
+                                }
                             }
                         }
                     }
@@ -336,6 +361,23 @@ struct GroupInfoView: View {
                     removalStatusIsError = false
                 }
                 Button("Cancel", role: .cancel) {}
+            }
+            .alert("Set Name", isPresented: .init(
+                get: { aliasTarget != nil },
+                set: { if !$0 { aliasTarget = nil } }
+            )) {
+                TextField("Display name", text: $aliasText)
+                Button("Save") {
+                    if let pubkey = aliasTarget {
+                        appState.contactAliasStore.setAlias(pubkey: pubkey, name: aliasText)
+                    }
+                    aliasTarget = nil
+                }
+                Button("Cancel", role: .cancel) { aliasTarget = nil }
+            } message: {
+                if let pubkey = aliasTarget {
+                    Text(String(pubkey.prefix(16)) + "...")
+                }
             }
             .sheet(isPresented: $showScanner) {
                 QRScannerView { scannedCode in


### PR DESCRIPTION
Display user-set aliases above BLS public keys in member lists on both
iOS and Android. Members can long-press (iOS) or tap (Android) to assign
a human-readable name, stored via the existing ContactAliasStore.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
