### PR TITLE
Filter system messages from contacts list to fix phantom contact (fixes #27)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ContactsScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ContactsScreen.kt
@@ -61,7 +61,7 @@ fun ContactsScreen(
         val map = mutableMapOf<String, Pair<MutableSet<String>, Date>>()
         for ((groupID, messages) in chatMessages) {
             for (msg in messages) {
-                if (msg.isMine) continue
+                if (msg.isMine || msg.isSystemMessage) continue
                 val entry = map.getOrPut(msg.senderPubkey) { Pair(mutableSetOf(), Date(0)) }
                 entry.first.add(groupID)
                 if (msg.timestamp.after(entry.second)) {

--- a/clients/ios/StellarChat/StellarChat/Views/ContactsView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ContactsView.swift
@@ -9,7 +9,7 @@ struct ContactsView: View {
         var map: [String: (groups: Set<String>, lastSeen: Date)] = [:]
 
         for (groupID, messages) in appState.chatMessages {
-            for message in messages where !message.isMine {
+            for message in messages where !message.isMine && !message.isSystemMessage {
                 var entry = map[message.senderPubkey] ?? (Set(), .distantPast)
                 entry.groups.insert(groupID)
                 entry.lastSeen = max(entry.lastSeen, message.timestamp)


### PR DESCRIPTION
System messages (member joins, key rotations, etc.) have an empty
senderPubkey, which caused a phantom contact with name "..." and a red
icon to appear in the Contacts list. Skip system messages when building
the contacts map on both iOS and Android.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
