### PR TITLE
Fix date separators appearing below first message of each group (fixes #22)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ChatScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ChatScreen.kt
@@ -395,11 +395,6 @@ fun ChatScreen(
                         itemsIndexed(viewModel.messages.asReversed(), key = { _, msg -> msg.id }) { reversedIndex, message ->
                             val index = viewModel.messages.size - 1 - reversedIndex
 
-                            // Date separator
-                            if (shouldShowDateSeparator(viewModel.messages, index)) {
-                                DateSeparator(message.timestamp)
-                            }
-
                             // Unread message separator
                             if (message.id == viewModel.firstUnreadMessageID) {
                                 UnreadSeparator()
@@ -440,6 +435,12 @@ fun ChatScreen(
                                         )
                                     }
                                 }
+                            }
+
+                            // Date separator — rendered after message content so that
+                            // reverseLayout places it visually above the message
+                            if (shouldShowDateSeparator(viewModel.messages, index)) {
+                                DateSeparator(message.timestamp)
                             }
                         }
                     }


### PR DESCRIPTION
In a LazyColumn with reverseLayout=true, composables emitted later in each
item appear higher visually. Move DateSeparator after message content so it
renders above the first message of each date group instead of below it.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
