### PR TITLE
Sort incoming messages by timestamp to fix reverse order after joining group (fixes #31)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -2271,9 +2271,9 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                     epoch = epoch,
                     replyToID = replyToID
                 )
-                // Append to trigger Compose recomposition. Arrival order prevents
-                // messages received after epoch transition from jumping into the middle.
-                chatMessages[groupID] = (chatMessages[groupID] ?: emptyList()) + msg
+                val updated = (chatMessages[groupID] ?: emptyList()) + msg
+                chatMessages[groupID] = updated.sortedWith(
+                    compareBy<chat.onym.android.model.ChatMessage> { it.timestamp }.thenBy { it.id })
                 viewModelScope.launch {
                     try { store.saveMessage(msg) } catch (_: Exception) { }
                 }


### PR DESCRIPTION
When a user joins a group via QR invitation, historical messages arriving
from relays were appended without sorting, causing them to display in
arrival order rather than chronological order. Apply the same timestamp
sort already used for voice messages to all incoming messages.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
