### PR TITLE
Fix invitations not sent during group creation (fixes #24)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/nostr/InvitationTransport.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/nostr/InvitationTransport.kt
@@ -81,6 +81,17 @@ class InvitationTransport(private val keyManager: KeyManager) {
         }
     }
 
+    fun ensureConnected(relayURLs: List<String>) {
+        if (connections.none { it.isConnected } && relayURLs.isNotEmpty()) {
+            if (chat.onym.android.BuildConfig.DEBUG) {
+                android.util.Log.d("InvitationTransport", "ensureConnected: no active connections, reconnecting to ${relayURLs.size} relays")
+            }
+            connections.forEach { it.disconnect() }
+            connections.clear()
+            connect(relayURLs)
+        }
+    }
+
     fun disconnect() {
         subscriptionJobs.values.forEach { it.cancel() }
         subscriptionJobs.clear()

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
@@ -260,7 +260,7 @@ private fun InputContent(
                     onClick = { viewModel.addParticipant(keyManager.keyAgreementPublicKeyHex) },
                     enabled = viewModel.keyInput.trim().length == 64
                 ) {
-                    Text("Add", style = MaterialTheme.typography.bodySmall)
+                    Text("Add Participant", style = MaterialTheme.typography.bodySmall)
                 }
             }
 
@@ -317,7 +317,10 @@ private fun InputContent(
         modifier = Modifier.fillMaxWidth(),
         enabled = viewModel.groupName.isNotBlank()
     ) {
-        Text("Create Group")
+        Text(
+            if (viewModel.participantKeys.isNotEmpty()) "Create Group & Send Invitations"
+            else "Create Group"
+        )
     }
 }
 
@@ -365,7 +368,7 @@ private fun ProgressContent(
                             }
                             Spacer(modifier = Modifier.width(8.dp))
                             TextButton(onClick = {
-                                viewModel.skipOnChainAndContinue(invitationTransport, keyManager)
+                                viewModel.skipOnChainAndContinue(invitationTransport, keyManager, groupListViewModel.relayURLs.toList())
                             }) {
                                 Text("Skip", color = Color(0xFFFF9800))
                             }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/CreateGroupViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/CreateGroupViewModel.kt
@@ -165,7 +165,7 @@ class CreateGroupViewModel : ViewModel() {
                 }
 
                 // Send invitations
-                sendInvitations(group, invitationTransport, keyManager)
+                sendInvitations(group, invitationTransport, keyManager, groupListViewModel.relayURLs.toList())
                 phase = CreationPhase.DONE
             } catch (e: Exception) {
                 errorMessage = e.message
@@ -191,7 +191,7 @@ class CreateGroupViewModel : ViewModel() {
             result.fold(
                 onSuccess = {
                     onChainStatus = OnChainPublishStatus.Published
-                    sendInvitations(group, invitationTransport, keyManager)
+                    sendInvitations(group, invitationTransport, keyManager, groupListViewModel.relayURLs.toList())
                     phase = CreationPhase.DONE
                 },
                 onFailure = {
@@ -203,11 +203,12 @@ class CreateGroupViewModel : ViewModel() {
 
     fun skipOnChainAndContinue(
         invitationTransport: InvitationTransport,
-        keyManager: KeyManager
+        keyManager: KeyManager,
+        relayURLs: List<String>
     ) {
         val group = createdGroup ?: return
         viewModelScope.launch {
-            sendInvitations(group, invitationTransport, keyManager)
+            sendInvitations(group, invitationTransport, keyManager, relayURLs)
             phase = CreationPhase.DONE
         }
     }
@@ -215,10 +216,15 @@ class CreateGroupViewModel : ViewModel() {
     private suspend fun sendInvitations(
         group: ChatGroup,
         invitationTransport: InvitationTransport,
-        keyManager: KeyManager
+        keyManager: KeyManager,
+        relayURLs: List<String>
     ) {
         if (participantKeys.isEmpty()) return
         phase = CreationPhase.INVITING
+
+        withContext(Dispatchers.IO) {
+            invitationTransport.ensureConnected(relayURLs)
+        }
 
         for ((index, key) in participantKeys.withIndex()) {
             if (index > 0) delay(500) // Space out relay publishes to avoid rate limiting

--- a/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
@@ -70,7 +70,7 @@ struct CreateGroupView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     switch phase {
                     case .input:
-                        Button("Create") { startCreation() }
+                        Button(participantKeys.isEmpty ? "Create" : "Create & Invite") { startCreation() }
                             .disabled(groupName.trimmingCharacters(in: .whitespaces).isEmpty)
                     case .done:
                         Button("Done") {


### PR DESCRIPTION
Android's sendInvitations() did not ensure relay connections were active
before sending, unlike iOS which calls connect() in fireInvitations().
If connections had dropped or weren't ready, invitations silently failed.

Added ensureConnected() to InvitationTransport that reconnects when no
active relay connections exist, and call it before sending invitations
during group creation. Also clarified button labels: "Add" → "Add
Participant", "Create Group" → "Create Group & Send Invitations" when
participants are present (iOS: "Create" → "Create & Invite").

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
