### PR TITLE
Use ephemeral Nostr keys for kind 44114/34113 events

### DIFF
--- a/clients/android/StellarChat/app/src/androidTest/java/chat/onym/android/EphemeralNostrSignerTests.kt
+++ b/clients/android/StellarChat/app/src/androidTest/java/chat/onym/android/EphemeralNostrSignerTests.kt
@@ -1,0 +1,44 @@
+package chat.onym.android
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stellarmls.mls.RustBackedNostrSigner
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Mirrors swift-mls' ephemeralNostrSignersAreUniqueAndProduceValidKeys and
+ * rustBackedNostrSignerProducesValidSizedOutputs. Must run instrumented because
+ * the signer bottoms out in the Rust JNI (`nostrDerivePublicKey` /
+ * `nostrSignEventId`) shipped as .so files.
+ */
+@RunWith(AndroidJUnit4::class)
+class EphemeralNostrSignerTests {
+
+    @Test
+    fun ephemeralSignersProduceDistinctPublicKeys() {
+        val a = RustBackedNostrSigner.ephemeral()
+        val b = RustBackedNostrSigner.ephemeral()
+
+        val pubA = a.publicKey()
+        val pubB = b.publicKey()
+
+        assertEquals(32, pubA.size)
+        assertEquals(32, pubB.size)
+        assertFalse(
+            "Two ephemeral signers must not produce the same pubkey",
+            pubA.contentEquals(pubB)
+        )
+    }
+
+    @Test
+    fun ephemeralSignerSignsEventIdWithSchnorrSignature() {
+        val signer = RustBackedNostrSigner.ephemeral()
+        val eventId = ByteArray(32) { i -> i.toByte() }
+
+        val signature = signer.signEventId(eventId)
+
+        assertEquals(64, signature.size)
+    }
+}

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/crypto/NostrEventBuilder.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/crypto/NostrEventBuilder.kt
@@ -1,6 +1,7 @@
 package chat.onym.android.crypto
 
 import chat.onym.android.model.toHex
+import com.stellarmls.mls.RustBackedNostrSigner
 import org.json.JSONArray
 import java.security.MessageDigest
 
@@ -51,14 +52,20 @@ data class NostrEvent(
 
 object NostrEventBuilder {
     /** Build a NIP-01 event with computed ID and real Schnorr signature.
-     *  Appends an app-specific `["ms", "<unix_ms>"]` tag for sub-second ordering. */
+     *  Appends an app-specific `["ms", "<unix_ms>"]` tag for sub-second ordering.
+     *
+     *  When [ephemeralSigner] is non-null, the outer pubkey and Schnorr signature come
+     *  from that per-event key instead of the device identity. Used for kinds 44114/34113
+     *  to prevent relays from clustering co-membership via stable sender pubkeys —
+     *  inner sender authentication is proven by BLS inside ciphertext. */
     fun build(
         kind: Int,
         tags: List<List<String>>,
         content: String,
-        keyManager: KeyManager
+        keyManager: KeyManager,
+        ephemeralSigner: RustBackedNostrSigner? = null
     ): NostrEvent {
-        val pubkeyHex = keyManager.publicKeyHex
+        val pubkeyHex = ephemeralSigner?.publicKey()?.toHex() ?: keyManager.publicKeyHex
         val unixMs = System.currentTimeMillis()
         val createdAt = unixMs / 1000
 
@@ -79,7 +86,7 @@ object NostrEventBuilder {
         val eventIDHex = hash.toHex()
 
         // Real secp256k1 Schnorr signature via Rust FFI
-        val signature = keyManager.signEventID(hash)
+        val signature = ephemeralSigner?.signEventId(hash) ?: keyManager.signEventID(hash)
         val sigHex = signature.toHex()
 
         return NostrEvent(

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/nostr/InvitationTransport.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/nostr/InvitationTransport.kt
@@ -6,6 +6,7 @@ import chat.onym.android.crypto.NostrEvent
 import chat.onym.android.crypto.NostrEventBuilder
 import chat.onym.android.model.BootstrapPayload
 import chat.onym.android.model.PendingInvitation
+import com.stellarmls.mls.RustBackedNostrSigner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -146,7 +147,8 @@ class InvitationTransport(private val keyManager: KeyManager) {
             kind = PRIMARY_KIND,
             tags = tags,
             content = contentBase64,
-            keyManager = keyManager
+            keyManager = keyManager,
+            ephemeralSigner = RustBackedNostrSigner.ephemeral()
         )
 
         check(connections.isNotEmpty()) { "No relay connections available for sendInvitation" }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/nostr/NostrMessageTransport.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/nostr/NostrMessageTransport.kt
@@ -7,6 +7,7 @@ import chat.onym.android.crypto.NostrEvent
 import chat.onym.android.crypto.NostrEventBuilder
 import chat.onym.android.model.ChatGroup
 import chat.onym.android.model.toHex
+import com.stellarmls.mls.RustBackedNostrSigner
 import com.stellarmls.mls.SEPGroupMemberLeaf
 import com.stellarmls.mls.SEPGroupRenamed
 import com.stellarmls.mls.SEPGroupStateUpdate
@@ -59,10 +60,14 @@ class NostrMessageTransport(
     /** Called when any relay's connection state changes. */
     var onConnectionChange: (() -> Unit)? = null
 
+    /** senderPubkey is the sender's BLS12-381 compressed pubkey as hex (stable identity from the encrypted wrapper).
+     *  The outer Nostr event pubkey is ephemeral per-event and MUST NOT be used as sender identity. */
     var onMessage: ((groupID: String, senderPubkey: String, text: String, eventID: String, timestamp: Long, epoch: Long?, replyToID: String?) -> Unit)? = null
-    /** Called when a decrypted message is a protocol message (state update, salt request/response). */
-    var onProtocolMessage: ((groupID: String, json: String, eventID: String, senderPubkey: String, senderBlsPubkeyHex: String?) -> Unit)? = null
-    /** Called when a decrypted message is an image message with media attachment. */
+    /** Called when a decrypted message is a protocol message (state update, salt request/response).
+     *  senderPubkey is the sender's BLS12-381 compressed pubkey as hex. */
+    var onProtocolMessage: ((groupID: String, json: String, eventID: String, senderPubkey: String) -> Unit)? = null
+    /** Called when a decrypted message is an image message with media attachment.
+     *  senderPubkey is the sender's BLS12-381 compressed pubkey as hex. */
     var onImageMessage: ((groupID: String, text: String, media: chat.onym.android.model.MediaAttachment, eventID: String, senderPubkey: String, timestamp: Long, epoch: Long?, replyToID: String?) -> Unit)? = null
     /** Callback for received call signaling messages (offer, answer, ice, hangup, busy, reject). */
     var onCallSignal: ((groupID: String, callJson: JSONObject, senderPubkey: ByteArray, eventID: String) -> Unit)? = null
@@ -175,7 +180,8 @@ class NostrMessageTransport(
             kind = 44114,
             tags = tags,
             content = content,
-            keyManager = keyManager
+            keyManager = keyManager,
+            ephemeralSigner = RustBackedNostrSigner.ephemeral()
         )
 
         var published = false
@@ -216,7 +222,8 @@ class NostrMessageTransport(
             kind = 44114,
             tags = tags,
             content = content,
-            keyManager = keyManager
+            keyManager = keyManager,
+            ephemeralSigner = RustBackedNostrSigner.ephemeral()
         )
 
         var published = false
@@ -333,21 +340,21 @@ class NostrMessageTransport(
                         ?.let { android.util.Base64.decode(it, android.util.Base64.NO_WRAP) },
                     duration = duration
                 )
-                onImageMessage?.invoke(groupID, innerText, media, event.id, event.pubkey, event.displayMilliseconds, eventEpoch, replyToID)
+                onImageMessage?.invoke(groupID, innerText, media, event.id, blsPubkey.toHex(), event.displayMilliseconds, eventEpoch, replyToID)
             } else {
                 // Check inner text for protocol messages (state updates, salt, etc.)
                 if (isProtocolMessage(innerText)) {
                     // Update currentMembers SYNCHRONOUSLY before processing the next event,
                     // so that chat messages arriving right after are not rejected.
                     applyMemberChanges(innerText)
-                    val senderBlsHex = try { android.util.Base64.decode(blsPubkeyB64, android.util.Base64.NO_WRAP).toHex() } catch (_: Exception) { null }
-                    onProtocolMessage?.invoke(groupID, innerText, event.id, event.pubkey, senderBlsHex)
+                    val senderBlsHex = try { android.util.Base64.decode(blsPubkeyB64, android.util.Base64.NO_WRAP).toHex() } catch (_: Exception) { "" }
+                    onProtocolMessage?.invoke(groupID, innerText, event.id, senderBlsHex)
                 } else {
                     // Chat message — verify BLS pubkey is in member list (H-4)
                     val blsPubkey = android.util.Base64.decode(blsPubkeyB64, android.util.Base64.NO_WRAP)
                     val isMember = currentMembers.any { it.publicKeyCompressed.contentEquals(blsPubkey) }
                     if (isMember) {
-                        onMessage?.invoke(groupID, event.pubkey, innerText,
+                        onMessage?.invoke(groupID, blsPubkey.toHex(), innerText,
                             event.id, event.displayMilliseconds, eventEpoch, replyToID)
                     } else {
                         if (chat.onym.android.BuildConfig.DEBUG) android.util.Log.w("MsgTransport", "BLS rejected: members=${currentMembers.size}")

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -38,6 +38,7 @@ import chat.onym.android.persistence.PersistenceStore
 import chat.onym.android.crypto.StorageEncryption
 import chat.onym.android.push.PushNotificationManager
 import chat.onym.android.push.PushTokenProviderFactory
+import com.stellarmls.mls.RustBackedNostrSigner
 import com.stellarmls.mls.SEPCommitmentBuilder
 import com.stellarmls.mls.SEPGroupMemberLeaf
 import com.stellarmls.mls.SEPGroupRenamed
@@ -663,7 +664,10 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                 val contentBase64 = android.util.Base64.encodeToString(sealed.toByteArray(), android.util.Base64.NO_WRAP)
                 val recipientInboxTag = GroupCrypto.hiddenInboxTag(requesterBundle.x25519InboxPubkey)
                 val tags = InvitationTransport.eventTags(recipientInboxTag)
-                val event = chat.onym.android.crypto.NostrEventBuilder.build(34113, tags, contentBase64, keyManager)
+                val event = chat.onym.android.crypto.NostrEventBuilder.build(
+                    34113, tags, contentBase64, keyManager,
+                    ephemeralSigner = RustBackedNostrSigner.ephemeral()
+                )
                 publishEvent(event, relayURLs.toList())
                 if (BuildConfig.DEBUG) Log.d("GroupListVM", "Re-sent rekey envelope epoch=$epoch to requester")
             } catch (e: Exception) {
@@ -720,7 +724,10 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                     val contentBase64 = android.util.Base64.encodeToString(sealed.toByteArray(), android.util.Base64.NO_WRAP)
                     val recipientInboxTag = GroupCrypto.hiddenInboxTag(bundle.x25519InboxPubkey)
                     val tags = InvitationTransport.eventTags(recipientInboxTag)
-                    val event = chat.onym.android.crypto.NostrEventBuilder.build(34113, tags, contentBase64, keyManager)
+                    val event = chat.onym.android.crypto.NostrEventBuilder.build(
+                        34113, tags, contentBase64, keyManager,
+                        ephemeralSigner = RustBackedNostrSigner.ephemeral()
+                    )
                     publishEvent(event, relayURLs.toList())
                 } catch (e: Exception) {
                     if (BuildConfig.DEBUG) Log.e("GroupListVM", "Resend failed for ${hex.take(8)}: ${e.message}")
@@ -1442,7 +1449,10 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                     val contentBase64 = android.util.Base64.encodeToString(sealed.toByteArray(), android.util.Base64.NO_WRAP)
                     val recipientInboxTag = GroupCrypto.hiddenInboxTag(bundle.x25519InboxPubkey)
                     val tags = InvitationTransport.eventTags(recipientInboxTag)
-                    val event = chat.onym.android.crypto.NostrEventBuilder.build(34113, tags, contentBase64, keyManager)
+                    val event = chat.onym.android.crypto.NostrEventBuilder.build(
+                        34113, tags, contentBase64, keyManager,
+                        ephemeralSigner = RustBackedNostrSigner.ephemeral()
+                    )
                     publishEvent(event, relayURLs.toList())
                     sentCount++
                     if (BuildConfig.DEBUG) Log.d("Rekey", "ENVELOPE_SENT groupID=${groupID.take(8)} epoch=${candidate.epoch} recipient=${hex.take(8)} eventID=${event.id.take(12)}")
@@ -2267,7 +2277,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                     senderPubkey = senderPubkey,
                     text = text,
                     timestamp = Date(timestampMs),
-                    isMine = senderPubkey == keyManager.publicKeyHex,
+                    isMine = senderPubkey == keyManager.blsPublicKey().toHex(),
                     epoch = epoch,
                     replyToID = replyToID
                 )
@@ -2316,7 +2326,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                     senderPubkey = senderPubkey,
                     text = text,
                     timestamp = Date(timestampMs),
-                    isMine = senderPubkey == keyManager.publicKeyHex,
+                    isMine = senderPubkey == keyManager.blsPublicKey().toHex(),
                     mediaAttachment = media,
                     epoch = epoch,
                     replyToID = replyToID
@@ -2394,7 +2404,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         val msg = ChatMessage(
             id = event.id,
             groupID = groupID,
-            senderPubkey = keyManager.publicKeyHex,
+            senderPubkey = keyManager.blsPublicKey().toHex(),
             text = trimmed,
             timestamp = Date(event.displayMilliseconds),
             isMine = true,
@@ -2507,7 +2517,8 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                     kind = 44114,
                     tags = tags,
                     content = content,
-                    keyManager = keyManager
+                    keyManager = keyManager,
+                    ephemeralSigner = RustBackedNostrSigner.ephemeral()
                 )
 
                 // Publish to all relays
@@ -2516,7 +2527,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                 val msg = ChatMessage(
                     id = event.id,
                     groupID = groupID,
-                    senderPubkey = keyManager.publicKeyHex,
+                    senderPubkey = keyManager.blsPublicKey().toHex(),
                     text = "\uD83D\uDDBC\uFE0F Image",
                     timestamp = Date(event.displayMilliseconds),
                     isMine = true,
@@ -2620,7 +2631,8 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                     kind = 44114,
                     tags = tags,
                     content = content,
-                    keyManager = keyManager
+                    keyManager = keyManager,
+                    ephemeralSigner = RustBackedNostrSigner.ephemeral()
                 )
 
                 transport.publish(event)
@@ -2628,7 +2640,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                 val msg = ChatMessage(
                     id = event.id,
                     groupID = groupID,
-                    senderPubkey = keyManager.publicKeyHex,
+                    senderPubkey = keyManager.blsPublicKey().toHex(),
                     text = "Sent a video",
                     timestamp = Date(event.displayMilliseconds),
                     isMine = true,
@@ -2712,14 +2724,15 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                 val tags = mutableListOf(listOf("t", effTopicTag))
                 tags.add(listOf("epoch", effEpoch.toString()))
                 val event = chat.onym.android.crypto.NostrEventBuilder.build(
-                    kind = 44114, tags = tags, content = content, keyManager = keyManager)
+                    kind = 44114, tags = tags, content = content, keyManager = keyManager,
+                    ephemeralSigner = RustBackedNostrSigner.ephemeral())
 
                 transport.publish(event)
 
                 val msg = chat.onym.android.model.ChatMessage(
                     id = event.id,
                     groupID = groupID,
-                    senderPubkey = keyManager.publicKeyHex,
+                    senderPubkey = keyManager.blsPublicKey().toHex(),
                     text = "Sent a voice message",
                     timestamp = java.util.Date(event.displayMilliseconds),
                     isMine = true,
@@ -2764,7 +2777,8 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             envelopeJson.toByteArray(), android.util.Base64.NO_WRAP)
         val tags = listOf(listOf("t", effectiveTopicTag(group)))
         val event = NostrEventBuilder.build(
-            kind = 44114, tags = tags, content = content, keyManager = keyManager)
+            kind = 44114, tags = tags, content = content, keyManager = keyManager,
+            ephemeralSigner = RustBackedNostrSigner.ephemeral())
         transport.publish(event)
     }
 
@@ -2782,7 +2796,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
 
     /** Set up handler for protocol messages received on the group channel. */
     private fun setupProtocolMessageHandler() {
-        transport.onProtocolMessage = { groupID, json, eventID, senderPubkey, senderBlsPubkeyHex ->
+        transport.onProtocolMessage = { groupID, json, eventID, senderPubkey ->
             // Replay protection: skip already-processed protocol events (H-7)
             // N-8: Evict oldest entries when set exceeds max size
             val isNew = synchronized(processedProtocolEventIDs) {
@@ -2867,7 +2881,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                             if (selfRemoved) {
                                 val noticeEpoch = obj.getLong("epoch")
                                 // Use BLS pubkey from the message wrapper (extracted by transport)
-                                val removerBlsHex = senderBlsPubkeyHex
+                                val removerBlsHex = senderPubkey
                                 val idx = groups.indexOfFirst { it.id == groupID }
                                 if (idx >= 0) {
                                     var g = cloneGroup(groups[idx])

--- a/clients/ios/StellarChat/StellarChat/Nostr/InvitationTransport.swift
+++ b/clients/ios/StellarChat/StellarChat/Nostr/InvitationTransport.swift
@@ -133,7 +133,8 @@ final class InvitationTransport {
             kind: Self.primaryKind,
             tags: tags,
             content: content,
-            keyManager: keyManager
+            keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
         )
 
         let conns = Array(connections.values)

--- a/clients/ios/StellarChat/StellarChat/Nostr/NostrEvent.swift
+++ b/clients/ios/StellarChat/StellarChat/Nostr/NostrEvent.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import SwiftMLS
 
 struct NostrEvent: Codable, Identifiable {
     let id: String
@@ -54,13 +55,24 @@ struct NostrEvent: Codable, Identifiable {
 
     /// Build a NIP-01 event, computing the event ID and signing it.
     /// Appends an app-specific `["ms", "<unix_ms>"]` tag for sub-second ordering.
+    ///
+    /// When `ephemeralSigner` is non-nil, the outer pubkey and Schnorr signature come
+    /// from that per-event key instead of the device identity. Used for kinds 44114/34113
+    /// to prevent relays from clustering co-membership via stable sender pubkeys —
+    /// inner sender authentication is proven by BLS inside ciphertext.
     static func build(
         kind: Int,
         tags: [[String]],
         content: String,
-        keyManager: KeyManager
+        keyManager: KeyManager,
+        ephemeralSigner: RustBackedNostrSigner? = nil
     ) throws -> NostrEvent {
-        let pubkeyHex = keyManager.publicKeyHex
+        let pubkeyHex: String
+        if let signer = ephemeralSigner {
+            pubkeyHex = try signer.publicKey().map { String(format: "%02x", $0) }.joined()
+        } else {
+            pubkeyHex = keyManager.publicKeyHex
+        }
         let unixMs = Int64(Date().timeIntervalSince1970 * 1000)
         let createdAt = unixMs / 1000
 
@@ -75,7 +87,12 @@ struct NostrEvent: Codable, Identifiable {
         let eventID = Data(hash)
         let eventIDHex = eventID.map { String(format: "%02x", $0) }.joined()
 
-        let signature = try keyManager.signEventID(eventID)
+        let signature: Data
+        if let signer = ephemeralSigner {
+            signature = try signer.signEventID(eventID)
+        } else {
+            signature = try keyManager.signEventID(eventID)
+        }
         let sigHex = signature.map { String(format: "%02x", $0) }.joined()
 
         return NostrEvent(

--- a/clients/ios/StellarChat/StellarChat/Nostr/NostrMessageTransport.swift
+++ b/clients/ios/StellarChat/StellarChat/Nostr/NostrMessageTransport.swift
@@ -31,8 +31,11 @@ final class NostrMessageTransport {
     /// Parameters: (groupID, text fallback, media attachment, senderBlsPubkeyHex, event, replyToID)
     var onImageMessage: ((String, String, MediaAttachment, String, NostrEvent, String?) -> Void)?
     /// Callback for received protocol messages (state updates, salt requests/responses).
-    /// Parameters: (groupID, json, event, senderBlsPubkeyHex)
-    var onProtocolMessage: ((String, String, NostrEvent, String?) -> Void)?
+    /// Parameters: (groupID, json, eventID, senderBlsPubkeyHex)
+    /// The outer NostrEvent is deliberately not exposed — event.pubkey is an ephemeral
+    /// per-event transport key and MUST NOT be used as sender identity. Use
+    /// senderBlsPubkeyHex (from the BLS-authenticated inner wrapper) instead.
+    var onProtocolMessage: ((String, String, String, String?) -> Void)?
     /// Callback for received call signaling messages (offer, answer, ice, hangup, busy, reject).
     /// Parameters: (groupID, call JSON dict, senderBlsPubkey, event)
     var onCallSignal: ((String, [String: Any], Data, NostrEvent) -> Void)?
@@ -214,7 +217,7 @@ final class NostrMessageTransport {
             } else if SEPProtocolMessage.parse(innerText) != nil {
                 applyMemberChanges(from: innerText)
                 let senderBlsHex = blsPubkey.map { String(format: "%02x", $0) }.joined()
-                onProtocolMessage?(groupID, innerText, event, senderBlsHex)
+                onProtocolMessage?(groupID, innerText, event.id, senderBlsHex)
             } else {
                 let isMember = currentMembers.contains { $0.publicKeyCompressed == blsPubkey }
                 if isMember {

--- a/clients/ios/StellarChat/StellarChat/Nostr/NostrMessageTransport.swift
+++ b/clients/ios/StellarChat/StellarChat/Nostr/NostrMessageTransport.swift
@@ -23,11 +23,13 @@ final class NostrMessageTransport {
     }
 
     /// Callback for received and decrypted plain-text chat messages.
-    /// Parameters: (groupID, plaintext, event, replyToID)
-    var onMessage: ((String, String, NostrEvent, String?) -> Void)?
+    /// Parameters: (groupID, plaintext, senderBlsPubkeyHex, event, replyToID)
+    /// senderBlsPubkeyHex is the stable sender identity from the encrypted wrapper.
+    /// The outer event.pubkey is ephemeral per-event and MUST NOT be used as sender identity.
+    var onMessage: ((String, String, String, NostrEvent, String?) -> Void)?
     /// Callback for received image messages with media attachment metadata.
-    /// Parameters: (groupID, text fallback, media attachment, event, replyToID)
-    var onImageMessage: ((String, String, MediaAttachment, NostrEvent, String?) -> Void)?
+    /// Parameters: (groupID, text fallback, media attachment, senderBlsPubkeyHex, event, replyToID)
+    var onImageMessage: ((String, String, MediaAttachment, String, NostrEvent, String?) -> Void)?
     /// Callback for received protocol messages (state updates, salt requests/responses).
     /// Parameters: (groupID, json, event, senderBlsPubkeyHex)
     var onProtocolMessage: ((String, String, NostrEvent, String?) -> Void)?
@@ -204,7 +206,8 @@ final class NostrMessageTransport {
                         encryptedThumbnail: encryptedThumbnail,
                         duration: duration
                     )
-                    onImageMessage?(groupID, innerText, media, event, replyToID)
+                    let senderBlsHex = blsPubkey.map { String(format: "%02x", $0) }.joined()
+                    onImageMessage?(groupID, innerText, media, senderBlsHex, event, replyToID)
                 } else if !isMember {
                     SecurityLog.nonMemberMessageRejected(groupID: groupID)
                 }
@@ -215,7 +218,8 @@ final class NostrMessageTransport {
             } else {
                 let isMember = currentMembers.contains { $0.publicKeyCompressed == blsPubkey }
                 if isMember {
-                    onMessage?(groupID, innerText, event, replyToID)
+                    let senderBlsHex = blsPubkey.map { String(format: "%02x", $0) }.joined()
+                    onMessage?(groupID, innerText, senderBlsHex, event, replyToID)
                 } else {
                     SecurityLog.nonMemberMessageRejected(groupID: groupID)
                 }
@@ -294,7 +298,8 @@ final class NostrMessageTransport {
             kind: 44114,
             tags: tags,
             content: content,
-            keyManager: keyManager
+            keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
         )
 
         try await publishToRelays(event)
@@ -345,7 +350,8 @@ final class NostrMessageTransport {
             kind: 44114,
             tags: tags,
             content: content,
-            keyManager: keyManager
+            keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
         )
 
         try await publishToRelays(event)

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -2723,17 +2723,17 @@ final class AppState {
 
     /// Set up the protocol message handler (runs once at init).
     private func setupProtocolHandler() {
-        chatTransport.onProtocolMessage = { [weak self] groupID, json, event, senderBlsPubkeyHex in
+        chatTransport.onProtocolMessage = { [weak self] groupID, json, eventID, senderBlsPubkeyHex in
             guard let self,
                   let data = json.data(using: .utf8) else { return }
 
             Task { @MainActor in
                 // Replay protection (H-7)
-                guard !self.processedProtocolEventIDs.contains(event.id) else { return }
+                guard !self.processedProtocolEventIDs.contains(eventID) else { return }
                 if self.processedProtocolEventIDs.count >= Self.maxDedupSetSize {
                     self.processedProtocolEventIDs.removeFirst()
                 }
-                self.processedProtocolEventIDs.insert(event.id)
+                self.processedProtocolEventIDs.insert(eventID)
 
                 guard self.groups.contains(where: { $0.id == groupID }) else { return }
 

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -1015,7 +1015,8 @@ final class AppState {
                     let content = sealedData.base64EncodedString()
                     let recipientInboxTag = GroupCrypto.hiddenInboxTag(recipientPublicKey: bundle.x25519InboxPubkey)
                     let tags = InvitationTransport.eventTags(recipientInboxTag: recipientInboxTag)
-                    let event = try NostrEvent.build(kind: 34113, tags: tags, content: content, keyManager: km)
+                    let event = try NostrEvent.build(kind: 34113, tags: tags, content: content, keyManager: km,
+                                                     ephemeralSigner: try RustBackedNostrSigner.ephemeral())
                     try await publishEvent(event, relayURLs: urls)
                     sentCount += 1
                     #if DEBUG
@@ -1987,7 +1988,8 @@ final class AppState {
                 let content = sealedData.base64EncodedString()
                 let recipientInboxTag = GroupCrypto.hiddenInboxTag(recipientPublicKey: req.requesterBundle.x25519InboxPubkey)
                 let tags = InvitationTransport.eventTags(recipientInboxTag: recipientInboxTag)
-                let event = try NostrEvent.build(kind: 34113, tags: tags, content: content, keyManager: keyManager)
+                let event = try NostrEvent.build(kind: 34113, tags: tags, content: content, keyManager: keyManager,
+                                                 ephemeralSigner: try RustBackedNostrSigner.ephemeral())
                 try await publishEvent(event, relayURLs: relayURLs)
                 #if DEBUG
                 print("[AppState] Re-sent rekey envelope epoch=\(req.epoch) to requester")
@@ -2046,7 +2048,8 @@ final class AppState {
                     let content = sealedData.base64EncodedString()
                     let recipientInboxTag = GroupCrypto.hiddenInboxTag(recipientPublicKey: bundle.x25519InboxPubkey)
                     let tags = InvitationTransport.eventTags(recipientInboxTag: recipientInboxTag)
-                    let event = try NostrEvent.build(kind: 34113, tags: tags, content: content, keyManager: keyManager)
+                    let event = try NostrEvent.build(kind: 34113, tags: tags, content: content, keyManager: keyManager,
+                                                     ephemeralSigner: try RustBackedNostrSigner.ephemeral())
                     try await publishEvent(event, relayURLs: relayURLs)
                 } catch {
                     #if DEBUG
@@ -2176,7 +2179,7 @@ final class AppState {
 
     /// Set up the chat message handler on the persistent transport (runs once at init).
     private func setupChatHandler() {
-        chatTransport.onMessage = { [weak self] groupID, plaintext, event, replyToID in
+        chatTransport.onMessage = { [weak self] groupID, plaintext, senderBlsHex, event, replyToID in
             guard let self else { return }
             Task { @MainActor in
                 guard self.groups.contains(where: { $0.id == groupID }) else { return }
@@ -2186,13 +2189,14 @@ final class AppState {
 
                 let epochTag = event.tags.first(where: { $0.first == "epoch" }).flatMap { $0.dropFirst().first }
                 let epoch = epochTag.flatMap { UInt64($0) }
+                let myBlsHex = (try? self.keyManager.blsPublicKey).map { $0.map { String(format: "%02x", $0) }.joined() } ?? ""
                 let msg = ChatMessage(
                     id: event.id,
                     groupID: groupID,
-                    senderPubkey: event.pubkey,
+                    senderPubkey: senderBlsHex,
                     text: plaintext,
                     timestamp: Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0),
-                    isMine: event.pubkey == self.keyManager.publicKeyHex,
+                    isMine: senderBlsHex == myBlsHex,
                     epoch: epoch,
                     replyToID: replyToID
                 )
@@ -2200,7 +2204,7 @@ final class AppState {
             }
         }
 
-        chatTransport.onImageMessage = { [weak self] groupID, plaintext, media, event, replyToID in
+        chatTransport.onImageMessage = { [weak self] groupID, plaintext, media, senderBlsHex, event, replyToID in
             guard let self else { return }
             Task { @MainActor in
                 guard self.groups.contains(where: { $0.id == groupID }) else { return }
@@ -2210,13 +2214,14 @@ final class AppState {
 
                 let epochTag = event.tags.first(where: { $0.first == "epoch" }).flatMap { $0.dropFirst().first }
                 let epoch = epochTag.flatMap { UInt64($0) }
+                let myBlsHex = (try? self.keyManager.blsPublicKey).map { $0.map { String(format: "%02x", $0) }.joined() } ?? ""
                 let msg = ChatMessage(
                     id: event.id,
                     groupID: groupID,
-                    senderPubkey: event.pubkey,
+                    senderPubkey: senderBlsHex,
                     text: plaintext,
                     timestamp: Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0),
-                    isMine: event.pubkey == self.keyManager.publicKeyHex,
+                    isMine: senderBlsHex == myBlsHex,
                     mediaAttachment: media,
                     epoch: epoch,
                     replyToID: replyToID
@@ -2273,14 +2278,15 @@ final class AppState {
         let envelopeData = try JSONEncoder().encode(envelope)
         let content = envelopeData.base64EncodedString()
         let event = try NostrEvent.build(
-            kind: 44114, tags: [["t", sendTopic], ["epoch", "\(sendEpoch)"]], content: content, keyManager: keyManager
+            kind: 44114, tags: [["t", sendTopic], ["epoch", "\(sendEpoch)"]], content: content, keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
         )
 
         // Optimistic UI: show the message locally BEFORE waiting for relay publish.
         let msg = ChatMessage(
             id: event.id,
             groupID: groupID,
-            senderPubkey: keyManager.publicKeyHex,
+            senderPubkey: blsPubkey.map { String(format: "%02x", $0) }.joined(),
             text: trimmed,
             timestamp: Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0),
             isMine: true,
@@ -2339,7 +2345,8 @@ final class AppState {
                 let envelopeData = try JSONEncoder().encode(envelope)
                 let content = envelopeData.base64EncodedString()
                 let event = try NostrEvent.build(
-                    kind: 44114, tags: [["t", sendTopic], ["epoch", "\(sendEpoch)"]], content: content, keyManager: keyManager
+                    kind: 44114, tags: [["t", sendTopic], ["epoch", "\(sendEpoch)"]], content: content, keyManager: keyManager,
+                    ephemeralSigner: try RustBackedNostrSigner.ephemeral()
                 )
                 try await chatTransport.publishToRelays(event)
                 await MainActor.run {
@@ -2436,14 +2443,15 @@ final class AppState {
         let envelopeData = try JSONEncoder().encode(envelope)
         let content = envelopeData.base64EncodedString()
         let event = try NostrEvent.build(
-            kind: 44114, tags: [["t", sendTopic], ["epoch", "\(sendEpoch)"]], content: content, keyManager: keyManager
+            kind: 44114, tags: [["t", sendTopic], ["epoch", "\(sendEpoch)"]], content: content, keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
         )
 
         // Optimistic UI: show locally before relay publish
         let msg = ChatMessage(
             id: event.id,
             groupID: groupID,
-            senderPubkey: keyManager.publicKeyHex,
+            senderPubkey: blsPubkey.map { String(format: "%02x", $0) }.joined(),
             text: "Sent an image",
             timestamp: Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0),
             isMine: true,
@@ -2548,14 +2556,15 @@ final class AppState {
         let envelopeData = try JSONEncoder().encode(envelope)
         let content = envelopeData.base64EncodedString()
         let event = try NostrEvent.build(
-            kind: 44114, tags: [["t", sendTopic], ["epoch", "\(sendEpoch)"]], content: content, keyManager: keyManager
+            kind: 44114, tags: [["t", sendTopic], ["epoch", "\(sendEpoch)"]], content: content, keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
         )
 
         // Optimistic UI: show locally before relay publish
         let msg = ChatMessage(
             id: event.id,
             groupID: groupID,
-            senderPubkey: keyManager.publicKeyHex,
+            senderPubkey: blsPubkey.map { String(format: "%02x", $0) }.joined(),
             text: "Sent a video",
             timestamp: Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0),
             isMine: true,
@@ -2641,14 +2650,15 @@ final class AppState {
         let envelopeData = try JSONEncoder().encode(envelope)
         let content = envelopeData.base64EncodedString()
         let event = try NostrEvent.build(
-            kind: 44114, tags: [["t", group.topicTag]], content: content, keyManager: keyManager
+            kind: 44114, tags: [["t", group.topicTag]], content: content, keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
         )
 
         // Optimistic UI
         let msg = ChatMessage(
             id: event.id,
             groupID: groupID,
-            senderPubkey: keyManager.publicKeyHex,
+            senderPubkey: blsPubkey.map { String(format: "%02x", $0) }.joined(),
             text: "Sent a voice message",
             timestamp: Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0),
             isMine: true,
@@ -2770,7 +2780,7 @@ final class AppState {
                             #endif
                             break
                         }
-                        let rateKey = "\(event.pubkey):\(request.epoch)"
+                        let rateKey = "\(senderBlsPubkeyHex ?? ""):\(request.epoch)"
                         guard !self.saltRequestsResponded.contains(rateKey) else { break }
                         self.saltRequestsResponded.insert(rateKey)
                         if let group = self.groups.first(where: { $0.id == groupID }),
@@ -2814,7 +2824,8 @@ final class AppState {
                                 #endif
                                 self.chatTransport.currentMembers = self.groups.flatMap(\.members)
                             }
-                            let removerName = self.contactAliasStore?.displayName(for: event.pubkey) ?? (String(event.pubkey.prefix(8)) + "...")
+                            let removerHex = senderBlsPubkeyHex ?? ""
+                            let removerName = self.contactAliasStore?.displayName(for: removerHex) ?? (String(removerHex.prefix(8)) + "...")
                             self.insertSystemMessage(groupID: groupID, text: "You were removed from this group by \(removerName)", event: "self-removed", epoch: notice.epoch)
                             #if DEBUG
                             print("[AppState] Self-removed from group=\(groupID.prefix(8)) epoch=\(notice.epoch)")

--- a/clients/ios/StellarChat/StellarChatTests/NostrEventTests.swift
+++ b/clients/ios/StellarChat/StellarChatTests/NostrEventTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import SwiftMLS
 
 @testable import StellarChat
 
@@ -114,5 +115,31 @@ struct NostrEventTests {
         )
         // displayMilliseconds should return the ms tag value
         #expect(event.displayMilliseconds > 0)
+    }
+
+    @Test("Ephemeral-signed events have distinct pubkeys and IDs for identical content")
+    func ephemeralSignerUniqueness() throws {
+        let keyManager = try KeyManager()
+        let e1 = try NostrEvent.build(
+            kind: 44114,
+            tags: [["t", "topic"]],
+            content: "same",
+            keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
+        )
+        let e2 = try NostrEvent.build(
+            kind: 44114,
+            tags: [["t", "topic"]],
+            content: "same",
+            keyManager: keyManager,
+            ephemeralSigner: try RustBackedNostrSigner.ephemeral()
+        )
+        #expect(e1.pubkey != e2.pubkey, "Ephemeral outer pubkeys must differ per event")
+        #expect(e1.id != e2.id, "Event IDs must differ because pubkey is part of the ID preimage")
+        #expect(e1.verifyEventID() == true)
+        #expect(e2.verifyEventID() == true)
+        // Ephemeral pubkey must not match the device's long-term Nostr identity key.
+        #expect(e1.pubkey != keyManager.publicKeyHex)
+        #expect(e2.pubkey != keyManager.publicKeyHex)
     }
 }

--- a/docs/nip-private-group-transport.md
+++ b/docs/nip-private-group-transport.md
@@ -389,12 +389,22 @@ Implementations SHOULD consider:
 - batching
 - optional dummy traffic where stronger traffic-analysis resistance is required
 
+## Outer Event Identity
+
+For group-broadcast (kind `44114`) and per-recipient inbox (kind `34113`) events, senders MUST generate a fresh 32-byte secp256k1 secret per event, derive its x-only public key, and sign the NIP-01 event ID with it. The secret MUST NOT be persisted or reused across events. This prevents relays from clustering events by a stable outer author pubkey and reconstructing co-membership or sender activity graphs from ciphertext metadata.
+
+Inner authenticity is proven by a BLS12-381 `senderBlsPubkey` field inside the encrypted wrapper, which recipients MUST verify against the MLS group roster for the event's epoch. This inner check — not the outer Nostr pubkey — is the real sender authentication for kinds `44114` and `34113`.
+
+For Blossom upload authorization (kind `24242`), the device's long-term Nostr key MAY be used so servers can enforce stable per-uploader quotas. Blossom events do not belong to a group and do not participate in the co-membership concern above.
+
+Receivers MUST NOT use the outer event `pubkey` as a sender identity for display, rate-limiting, ACL, or replay bookkeeping on kinds `44114` / `34113`; they MUST derive sender identity from the decrypted BLS pubkey.
+
 ## Security Considerations
 
 - Clients MUST verify invitation and message context against Stellar SEP state where applicable
 - Hidden routing tags are transport hints only and MUST NOT be treated as authority signals
 - Rotating hidden group topics on epoch or secret changes is important to reduce ex-member observability
-- Stable Nostr device keys improve usability but increase sender linkability
+- Outer event keys for kinds `44114` and `34113` MUST be ephemeral per-event; inner authenticity is proven by the BLS `senderBlsPubkey` against the MLS roster. Only kind `24242` (Blossom) retains a stable device-level Nostr key, and only for upload authorization (no co-membership exposure)
 - Device-seed compromise can correlate transport and membership layers if both are derived from the same root
 
 ## Compatibility

--- a/docs/postmortem-co-membership-leak.md
+++ b/docs/postmortem-co-membership-leak.md
@@ -1,0 +1,117 @@
+# Postmortem: Co-Membership Leak via Stable Outer Nostr Keys
+
+**Date:** 2026-04-16
+**Severity:** HIGH (privacy)
+**Duration of vulnerability:** From initial group chat implementation through 2026-04-16
+**Platforms affected:** iOS and Android
+**Status:** Resolved — commit `0d6d041` on `rinat/ephemerial`
+
+---
+
+## Summary
+
+Every encrypted group message (kind `44114`) and every per-recipient invitation/rekey (kind `34113`) was signed with the sender's **long-term** secp256k1 Nostr identity key. Because these kinds also carry a **stable hidden topic tag** (per group) or **stable inbox tag** (per recipient), any relay — or any observer with a relay's event log — could trivially reconstruct the co-membership graph:
+
+> "These N pubkeys all published to hidden-topic `T` → these N devices are in the same group."
+
+This contradicted the explicit SEP privacy goal: *an observer cannot determine who is in the same group*. The leak had been "known" — the NIP spec called it out as a *trade-off* ("stable device keys improve usability but increase sender linkability") — but it was never escalated to a privacy violation and never fixed.
+
+The incident was not a production outage. It was a **framing failure in the spec**: a hard-to-invert cryptographic property was documented as a usability preference.
+
+---
+
+## Timeline
+
+| When | What |
+|------|------|
+| Pre-2026-04-16 | Both clients use `KeyManager.publicKeyHex` (long-term identity) to sign every `44114` / `34113` event. NIP §Security Considerations lists sender linkability as a trade-off. |
+| 2026-04-16 | User reads `NostrEventBuilder.kt` and asks: *"I'm passing a Nostr pubkey for group messages. Does it mean the group privacy is broken? According to SEP there should not be a possibility to determine who is in the same group."* |
+| 2026-04-16 | Audit confirms: yes, co-membership is derivable from any relay that retained events. The "trade-off" framing was wrong — this was a straightforward violation of a load-bearing privacy property. |
+| 2026-04-16 | Plan: ephemeral per-event secp256k1 keys for `44114` + `34113`; keep long-term key for `24242` (Blossom upload quotas). Rust FFI already accepts arbitrary 32-byte secrets — no Rust changes needed. |
+| 2026-04-16 | Implemented on both platforms: `RustBackedNostrSigner.ephemeral()` factory, `ephemeralSigner` parameter threaded through every send callsite. Receive side switched from `event.pubkey` to BLS pubkey hex for sender identity. NIP §Outer Event Identity added as a normative section. |
+
+---
+
+## What went wrong
+
+### 1. A privacy invariant was documented as a usability trade-off
+
+The NIP had a single bullet in Security Considerations:
+
+> *"Stable Nostr device keys improve usability but increase sender linkability."*
+
+That sentence is technically true and **strategically misleading**. "Sender linkability" sounds like a profile-building concern affecting an individual. The actual consequence was **group linkability**: partitioning the user base into co-membership clusters from public relay data alone. The SEP design explicitly promises the second is not possible. The NIP quietly said otherwise.
+
+No one cross-checked the NIP's "trade-off" language against SEP's "you cannot determine who is in the same group" guarantee. The two documents contradicted each other for the entire lifetime of the transport layer.
+
+### 2. The fix was cheap, and no one tried
+
+`sep_nostr_derive_public_key` and `sep_nostr_sign_event_id` in `src/jni_ffi.rs` / `src/ffi.rs` already accepted arbitrary 32-byte secrets. A 5-line factory on each platform and a default-nil `ephemeralSigner` parameter was all that stood between "stable device-linked group graph" and "per-event ephemeral author." The cost of doing it right was roughly the cost of writing the trade-off bullet that justified not doing it.
+
+### 3. The receive side made an implicit assumption that broke silently
+
+Both clients used `event.pubkey` as the sender identity for:
+
+- `isMine` display logic (comparing against `keyManager.publicKeyHex`)
+- Salt-request rate-limit keys (`"${senderPubkey}:${epoch}"`)
+- Removal-notice display name lookup (`contactAliasStore.displayName(senderPubkey)`)
+- `ChatMessage.senderPubkey` persistence
+
+With ephemeral outer keys, `event.pubkey` becomes random-per-event. Every one of these breaks:
+
+- `isMine` always false → user sees their own messages as if from a stranger
+- Rate limiting never coalesces → salt-request DoS amplification
+- Alias lookup always misses → names disappear from removal notices
+- `senderPubkey` column becomes uncorrelated noise
+
+**This was not in the original plan.** It was caught by reading the receive path during the debug-log audit step, only because the plan included an explicit "audit logs that reference sender pubkey" task. Had the plan only specified the send-side change, the feature would have shipped broken and looked correct in every unit test.
+
+Inner BLS authentication was always the real sender check — the BLS pubkey lives inside the encrypted wrapper and is verified against the MLS roster. The outer Nostr pubkey was **never** security-critical; it was being used as a convenient stable identifier because it happened to be stable. The ephemeral change forced us to notice that the convenience had no principled backing.
+
+---
+
+## Root cause
+
+Two coupled misalignments:
+
+1. **Spec drift.** Two normative documents (SEP + NIP) made contradictory claims about what an observer can learn. The NIP's framing ("trade-off") obscured the contradiction instead of surfacing it.
+2. **Identity coupling.** The outer transport key was used both as a signature key *and* as a sender identity. Once those two roles are separated — signature comes from an ephemeral key, identity comes from the inner BLS pubkey — the privacy fix is mechanical. Keeping them coupled made the fix look scarier than it was.
+
+---
+
+## The fix
+
+See commit `0d6d041`. In short:
+
+- `RustBackedNostrSigner.ephemeral()` (Kotlin + Swift): CSPRNG-backed 32-byte secret, single-use.
+- `NostrEventBuilder.build` / `NostrEvent.build` grew an optional `ephemeralSigner` parameter; when provided it replaces the `KeyManager` identity for pubkey + signature.
+- Every `44114` / `34113` callsite on both clients now passes `ephemeralSigner = RustBackedNostrSigner.ephemeral()`. Kind `24242` (Blossom) explicitly keeps the long-term key for upload-quota enforcement.
+- Transport callbacks reshaped to pass **BLS pubkey hex** as the sender identity. `isMine`, contact aliases, salt-request rate limits, and removal-notice displayName all migrated to BLS hex.
+- NIP §Outer Event Identity added as a normative section; §Security Considerations rewritten to require ephemeral outer keys for `44114` / `34113` and to state explicitly that receivers MUST NOT use the outer pubkey for identity.
+
+---
+
+## What prevents recurrence
+
+1. **The NIP is now internally consistent with SEP.** A future reader cannot come away thinking stable outer keys are acceptable on `44114` / `34113`.
+2. **A unit test asserts pubkey uniqueness per event.** `NostrEventTests.ephemeralSignerUniqueness` and `SwiftMLSTests.ephemeralNostrSignersAreUniqueAndProduceValidKeys` fail if anyone re-plumbs a stable key through the ephemeral path.
+3. **`event.pubkey` is no longer threaded through receive callbacks.** The callback signatures now carry BLS hex, forcing new consumers to use the identity the spec endorses.
+
+---
+
+## What did not prevent this
+
+- **Internal security audits (v1–v4).** Every audit examined the *encryption* story — MLS, BLS, rekey, removal — and none examined the *transport metadata* story. A relay operator's view of the event log was not part of any audit's threat model.
+- **The NIP itself.** The document that should have flagged this *did* flag it, then immediately downgraded it to a trade-off without justification.
+- **Code review.** The same person wrote the NIP and the implementation; the "trade-off" framing traveled between documents without ever meeting an adversarial reader.
+
+The issue was caught by a single user question that took the SEP guarantee at face value.
+
+---
+
+## Lessons
+
+1. **"Trade-off" is a red flag in a security spec.** If a stated property is weakened in a Security Considerations section, the weakening must cite either an adversary model or an unfixable constraint. "Improves usability" is neither.
+2. **Cross-check privacy claims across layers.** SEP and the NIP were developed in parallel and diverged on a load-bearing guarantee for months. A one-page "claims matrix" — *what does SEP promise, what does the transport deliver* — would have caught the gap.
+3. **Separate the signing key from the identity claim.** Any protocol that uses a transport-layer signature key as a stable sender identity has coupled two roles that should move independently. The coupling is what made this look expensive to fix.
+4. **When ripping out an implicit identity, grep the receive side too.** The send-side change was the obvious part of the plan; the receive-side cleanup was where the feature would have shipped broken. Plans that only describe the write path are half-plans.

--- a/docs/postmortem-co-membership-leak.md
+++ b/docs/postmortem-co-membership-leak.md
@@ -4,7 +4,7 @@
 **Severity:** HIGH (privacy)
 **Duration of vulnerability:** From initial group chat implementation through 2026-04-16
 **Platforms affected:** iOS and Android
-**Status:** Resolved — commit `0d6d041` on `rinat/ephemerial`
+**Status:** Resolved — commit `b36c9dd` on `rinat/ephemerial`
 
 ---
 
@@ -81,7 +81,7 @@ Two coupled misalignments:
 
 ## The fix
 
-See commit `0d6d041`. In short:
+See commit `b36c9dd`. In short:
 
 - `RustBackedNostrSigner.ephemeral()` (Kotlin + Swift): CSPRNG-backed 32-byte secret, single-use.
 - `NostrEventBuilder.build` / `NostrEvent.build` grew an optional `ephemeralSigner` parameter; when provided it replaces the `KeyManager` identity for pubkey + signature.

--- a/kotlin-mls/src/main/java/com/stellarmls/mls/RustBackedNostrSigner.kt
+++ b/kotlin-mls/src/main/java/com/stellarmls/mls/RustBackedNostrSigner.kt
@@ -17,4 +17,13 @@ class RustBackedNostrSigner(private val secretKey: ByteArray) {
         require(eventId.size == 32) { "event ID must be 32 bytes" }
         return RustBridge.nostrSignEventId(secretKey, eventId)
     }
+
+    companion object {
+        /** Fresh per-event signer backed by a random 32-byte secp256k1 scalar from the JCE CSPRNG. */
+        fun ephemeral(): RustBackedNostrSigner {
+            val secret = ByteArray(32)
+            java.security.SecureRandom().nextBytes(secret)
+            return RustBackedNostrSigner(secret)
+        }
+    }
 }

--- a/swift-mls/Sources/SwiftMLS/NostrCrypto.swift
+++ b/swift-mls/Sources/SwiftMLS/NostrCrypto.swift
@@ -20,4 +20,14 @@ public struct RustBackedNostrSigner: SEPNostrEventSigner, Sendable {
         }
         return try RustBridge.signNostrEventID(secretKey: secretKey, eventID: eventID)
     }
+
+    /// Fresh per-event signer backed by a random 32-byte secp256k1 scalar from the OS CSPRNG.
+    public static func ephemeral() throws -> RustBackedNostrSigner {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, 32, &bytes)
+        guard status == errSecSuccess else {
+            throw SEPError.ffiFailure("SecRandomCopyBytes failed: OSStatus \(status)")
+        }
+        return try RustBackedNostrSigner(secretKey: Data(bytes))
+    }
 }

--- a/swift-mls/Tests/SwiftMLSTests/SwiftMLSTests.swift
+++ b/swift-mls/Tests/SwiftMLSTests/SwiftMLSTests.swift
@@ -194,6 +194,19 @@ struct SwiftMLSTests {
         #expect(signature.count == 64)
     }
 
+    @Test
+    func ephemeralNostrSignersAreUniqueAndProduceValidKeys() throws {
+        let a = try RustBackedNostrSigner.ephemeral()
+        let b = try RustBackedNostrSigner.ephemeral()
+
+        let pubA = try a.publicKey()
+        let pubB = try b.publicKey()
+
+        #expect(pubA.count == 32)
+        #expect(pubB.count == 32)
+        #expect(pubA != pubB, "Two ephemeral signers must not produce the same pubkey")
+    }
+
     private func fieldBytes(_ value: UInt64) -> Data {
         var bytes = Data(repeating: 0, count: 32)
         var bigEndian = value.bigEndian


### PR DESCRIPTION
Group-broadcast (44114) and inbox (34113) events were signed with the device's long-term secp256k1 identity. Because the hidden topic/inbox tags on these kinds are stable per group / recipient, a relay could cluster co-signing authors into a co-membership graph even though the group_id and sender stayed encrypted. This broke the SEP guarantee that co-membership is not derivable from transport metadata.

Switch both clients to generate a fresh 32-byte secp256k1 secret per 44114/34113 event, derive its x-only pubkey, and sign the NIP-01 event ID with it. The secret is never persisted. Inner authenticity is still proven by the BLS12-381 `senderBlsPubkey` inside the encrypted wrapper, checked against the MLS roster. Kind 24242 (Blossom uploads) keeps the long-term key because the Blossom server needs a stable authorized identity for quota enforcement.

Implementation

  * Add RustBackedNostrSigner.ephemeral() to kotlin-mls and swift-mls (CSPRNG-backed 32-byte secret wrappers; Rust FFI already accepted arbitrary secrets, no Rust changes needed).
  * Extend NostrEventBuilder.build / NostrEvent.build with an optional `ephemeralSigner` parameter. When provided, its pubkey + signature replace the KeyManager identity. Otherwise behavior is unchanged.
  * Thread the new parameter through every 44114/34113 callsite in NostrMessageTransport, InvitationTransport, GroupListViewModel (Android), and StellarChatApp (iOS).

Receive-side fix (not in the original design, caught during audit)

  Ephemeral outer keys make event.pubkey meaningless as a sender
  identity. Callers that compared event.pubkey to the local Nostr
  pubkey would compute isMine = false for every message, and contact
  alias / rate-limit lookups keyed on event.pubkey would miss.

  * Reshape transport callbacks to pass the BLS pubkey hex (stable identity from the decrypted wrapper) as the sender identity. Dropped the redundant senderBlsPubkeyHex parameter from onProtocolMessage now that senderPubkey carries the same value.
  * Update ChatMessage.senderPubkey producers (both receive-side and optimistic-UI send paths) to store BLS hex. Update isMine checks, salt-request rate-limit keys, and removal-notice displayName lookups accordingly.
  * GroupInfoScreen was already keying aliases by BLS hex; ContactsScreen builds its contact list from msg.senderPubkey, so switching the message field to BLS hex aligns both code paths on the same key.

Spec

  docs/nip-private-group-transport.md gains an "Outer Event Identity"
  normative section requiring ephemeral outer keys for 44114/34113 and
  documenting the 24242 carve-out. The "stable device keys increase
  sender linkability" bullet in Security Considerations is replaced
  with the stronger requirement and a note that receivers MUST NOT use
  the outer pubkey for identity, display, rate-limiting, or replay.

Tests

  * swift-mls: ephemeralNostrSignersAreUniqueAndProduceValidKeys verifies two ephemeral signers produce distinct 32-byte pubkeys.
  * iOS NostrEventTests.ephemeralSignerUniqueness verifies two events built with RustBackedNostrSigner.ephemeral() have distinct pubkeys and IDs for identical content, verifyEventID() still passes, and neither pubkey matches the device's long-term identity key.

Risks

  * Relay rate-limiting by pubkey: a fresh pubkey per event may look like many distinct users to a relay and trip per-author throttles. Needs a smoke test against the production relay set; fallback would be per-session ephemeral (not per-event) for 44114. Kind 34113 volume is too low to matter.
  * Migration: existing persisted ChatMessage.senderPubkey rows keep the old long-term Nostr hex. isMine on those rows is already persisted so display stays correct; contact aliases set before the upgrade remain reachable only until the sender posts a new message and the map entry migrates naturally to BLS hex.



docs: postmortem for co-membership leak via stable outer Nostr keys

Captures the incident that motivated commit 0d6d041: the NIP framed stable outer keys on kinds 44114/34113 as a usability trade-off, but combined with the stable hidden topic/inbox tags on those same kinds the result was a direct violation of SEP's "cannot determine who is in the same group" guarantee. Documents the framing failure, the fix, and the receive-side identity coupling that would have shipped broken if the plan had only covered the send path.