### PR TITLE
Show member aliases/pubkey prefixes instead of "N members" in chat list

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
@@ -217,6 +217,7 @@ fun StellarChatNavHost(
                     chatMessages = groupListViewModel.chatMessages,
                     unreadCounts = groupListViewModel.unreadCounts,
                     isRelayConnected = groupListViewModel.isRelayConnected,
+                    contactAliasStore = groupListViewModel.contactAliasStore,
                     onGroupClick = { group ->
                         navController.navigate("chat/${group.id}")
                     },

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupListScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupListScreen.kt
@@ -60,6 +60,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import chat.onym.android.model.ChatGroup
 import chat.onym.android.model.ChatMessage
+import chat.onym.android.model.toHex
+import chat.onym.android.persistence.ContactAliasStore
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.Calendar
@@ -73,6 +75,7 @@ fun GroupListScreen(
     chatMessages: Map<String, List<ChatMessage>> = emptyMap(),
     unreadCounts: Map<String, Int> = emptyMap(),
     isRelayConnected: Boolean = true,
+    contactAliasStore: ContactAliasStore? = null,
     onGroupClick: (ChatGroup) -> Unit,
     onInviteMember: (ChatGroup) -> Unit = {},
     onCreateGroup: () -> Unit,
@@ -285,11 +288,16 @@ fun GroupListScreen(
                                         }
                                         Spacer(modifier = Modifier.height(2.dp))
                                         Row(verticalAlignment = Alignment.CenterVertically) {
-                                            Text(
-                                                "${group.members.size} members",
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
+                                            val subtitle = memberSubtitle(group, contactAliasStore)
+                                            if (subtitle.isNotEmpty()) {
+                                                Text(
+                                                    subtitle,
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis
+                                                )
+                                            }
                                             if (lastMessage != null) {
                                                 Text(
                                                     text = " · ${lastMessage.text}",
@@ -516,6 +524,14 @@ private fun DiffRow(icon: String, iconColor: Color, text: String, detail: String
             Text(text, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
             Text(detail, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
+    }
+}
+
+private fun memberSubtitle(group: ChatGroup, aliases: ContactAliasStore?): String {
+    if (group.members.isEmpty()) return ""
+    return group.members.joinToString(", ") { member ->
+        val hex = member.publicKeyCompressed.toHex()
+        aliases?.displayName(hex) ?: hex.take(8)
     }
 }
 

--- a/clients/ios/StellarChat/StellarChat/Views/GroupListView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupListView.swift
@@ -76,7 +76,8 @@ struct GroupListView: View {
                             group: group,
                             lastMessage: appState.chatMessages[group.id]?.last,
                             unreadCount: appState.unreadCounts[group.id] ?? 0,
-                            isContractConfigured: appState.isContractConfigured
+                            isContractConfigured: appState.isContractConfigured,
+                            contactAliasStore: appState.contactAliasStore
                         )
                     }
                     .swipeActions(edge: .trailing) {
@@ -205,6 +206,7 @@ struct GroupRow: View {
     let lastMessage: ChatMessage?
     let unreadCount: Int
     let isContractConfigured: Bool
+    let contactAliasStore: ContactAliasStore?
 
     var body: some View {
         HStack {
@@ -220,9 +222,12 @@ struct GroupRow: View {
                     }
                 }
                 HStack {
-                    Text("\(group.members.count) members")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if !group.members.isEmpty {
+                        Text(memberSubtitle(for: group, aliases: contactAliasStore))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
 
                     if let lastMsg = lastMessage {
                         Text("· \(lastMsg.text)")
@@ -273,6 +278,15 @@ struct GroupRow: View {
         formatter.dateFormat = "MMM d"
         return formatter.string(from: date)
     }
+}
+
+// MARK: - Member Subtitle
+
+private func memberSubtitle(for group: ChatGroup, aliases: ContactAliasStore?) -> String {
+    group.members.map { member in
+        let hex = member.publicKeyCompressed.map { String(format: "%02x", $0) }.joined()
+        return aliases?.displayName(for: hex) ?? String(hex.prefix(8))
+    }.joined(separator: ", ")
 }
 
 // MARK: - Chat View Container

--- a/clients/ios/StellarChat/StellarChat/Views/GroupListView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupListView.swift
@@ -282,7 +282,7 @@ struct GroupRow: View {
 
 // MARK: - Member Subtitle
 
-private func memberSubtitle(for group: ChatGroup, aliases: ContactAliasStore?) -> String {
+@MainActor private func memberSubtitle(for group: ChatGroup, aliases: ContactAliasStore?) -> String {
     group.members.map { member in
         let hex = member.publicKeyCompressed.map { String(format: "%02x", $0) }.joined()
         return aliases?.displayName(for: hex) ?? String(hex.prefix(8))


### PR DESCRIPTION
Replace the uninformative "N members" subtitle on the Chats list screen
with comma-separated member display names. For each member, show their
contact alias if set, otherwise the first 8 hex characters of their BLS
pubkey. This matches the alias-or-prefix pattern already used on the
Group Info screen.

Fixes #62

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
