### PR TITLE
governance: chat-screen UI + actions (Phase 5)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
@@ -423,6 +423,9 @@ fun StellarChatNavHost(
                             notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                         }
                     },
+                    onProposeRemovalVote = { targetHex ->
+                        groupListViewModel.proposeRemovalVote(groupId, targetHex)
+                    },
                     contactAliasStore = groupListViewModel.contactAliasStore,
                     dao = groupListViewModel.store.dao,
                     onBack = { navController.popBackStack() }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/model/ChatGroup.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/model/ChatGroup.kt
@@ -34,6 +34,10 @@ data class ChatGroup(
     /** Governance type selected at creation. Existing persisted groups
      *  default to [SEPGroupType.ANARCHY] (the historical behavior). */
     var groupType: SEPGroupType = SEPGroupType.ANARCHY,
+    /** Hex-encoded BLS pubkeys (lowercase) of members with admin privileges.
+     *  Only meaningful for [SEPGroupType.OLIGARCHY] groups; seeded with the creator
+     *  at group creation. Existing persisted groups decode this as empty. */
+    var adminPubkeys: MutableSet<String> = mutableSetOf(),
     var isPublishedOnChain: Boolean = false,
     /** Unix timestamp of the last received event, used for offline catch-up. */
     var lastEventTimestamp: Long = 0,

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/PersistedModels.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/PersistedModels.kt
@@ -28,7 +28,10 @@ data class PersistedGroup(
     /** Governance type id (0 = Anarchy, 1 = 1v1, 2 = Democracy, 3 = Oligarchy).
      *  Existing groups migrate in as 0 (Anarchy), preserving historical behavior. */
     @ColumnInfo(defaultValue = "0")
-    val groupTypeRawValue: Int = 0
+    val groupTypeRawValue: Int = 0,
+    /** Encrypted JSON-encoded list of admin BLS pubkey hex strings (lowercase).
+     *  Only populated for Oligarchy groups; existing groups migrate in as null. */
+    val encryptedAdminPubkeys: ByteArray? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/PersistenceStore.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/PersistenceStore.kt
@@ -148,6 +148,13 @@ class PersistenceStore(context: Context) {
 
     private fun encryptGroup(group: ChatGroup): PersistedGroup {
         val membersJson = serializeMembers(group.members)
+        val encAdmins = if (group.adminPubkeys.isEmpty()) {
+            null
+        } else {
+            val arr = JSONArray()
+            for (hex in group.adminPubkeys.sorted()) arr.put(hex)
+            StorageEncryption.encrypt(arr.toString().toByteArray())
+        }
         return PersistedGroup(
             id = group.id,
             encryptedName = StorageEncryption.encrypt(group.name),
@@ -166,7 +173,8 @@ class PersistenceStore(context: Context) {
             forkedAtEpoch = group.forkedAtEpoch?.toInt(),
             removedByPubkeyHex = group.removedByPubkeyHex,
             pushNotificationsEnabled = group.pushNotificationsEnabled,
-            lastMessageAt = group.lastMessageAt
+            lastMessageAt = group.lastMessageAt,
+            encryptedAdminPubkeys = encAdmins
         )
     }
 
@@ -187,6 +195,13 @@ class PersistenceStore(context: Context) {
             SEPGroupType.ANARCHY
         }
 
+        val adminPubkeys: MutableSet<String> = persisted.encryptedAdminPubkeys?.let { enc ->
+            try {
+                val arr = JSONArray(String(StorageEncryption.decrypt(enc)))
+                (0 until arr.length()).map { arr.getString(it) }.toMutableSet()
+            } catch (_: Exception) { mutableSetOf() }
+        } ?: mutableSetOf()
+
         return ChatGroup(
             id = persisted.id,
             name = name,
@@ -199,6 +214,7 @@ class PersistenceStore(context: Context) {
             commitment = commitment,
             tier = tier,
             groupType = groupType,
+            adminPubkeys = adminPubkeys,
             isPublishedOnChain = persisted.isPublishedOnChain,
             pinnedEpoch = persisted.pinnedEpoch?.toLong(),
             forkedFromGroupID = persisted.forkedFromGroupID,

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/StellarChatDatabase.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/StellarChatDatabase.kt
@@ -20,7 +20,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PersistedTransportBundle::class, PersistedPendingRekey::class,
         PersistedEpochSnapshot::class
     ],
-    version = 13
+    version = 14
 )
 abstract class StellarChatDatabase : RoomDatabase() {
     abstract fun dao(): StellarChatDao
@@ -129,13 +129,21 @@ abstract class StellarChatDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Oligarchy admin set: encrypted JSON list of BLS pubkey hex strings.
+                // Null for non-oligarchy groups and pre-existing rows.
+                db.execSQL("ALTER TABLE groups ADD COLUMN encryptedAdminPubkeys BLOB")
+            }
+        }
+
         fun getInstance(context: Context): StellarChatDatabase {
             return instance ?: synchronized(this) {
                 instance ?: Room.databaseBuilder(
                     context.applicationContext,
                     StellarChatDatabase::class.java,
                     "stellar_chat.db"
-                ).addMigrations(MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
+                ).addMigrations(MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
                 .fallbackToDestructiveMigration()
                 .build().also { instance = it }
             }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ChatScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ChatScreen.kt
@@ -96,6 +96,11 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.filled.HowToVote
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Warning
+import com.stellarmls.mls.SEPGroupType
 import chat.onym.android.blossom.BlossomClient
 import chat.onym.android.blossom.ImageCache
 import chat.onym.android.blossom.VideoCache
@@ -190,6 +195,31 @@ fun ChatScreen(
                 .padding(padding)
                 .imePadding()
         ) {
+            // Governance type banner — highlights the rules for this group.
+            // Anarchy is surfaced as a warning (any member can kick/invite);
+            // 1v1 / Democracy / Oligarchy get an informational notice.
+            val governancePrefs = remember { context.getSharedPreferences("stellar_chat", Context.MODE_PRIVATE) }
+            val groupIdForBanner = viewModel.group?.id
+            val governanceDismissKey = remember(groupIdForBanner) { "governance_banner_dismissed_${groupIdForBanner ?: ""}" }
+            var governanceBannerDismissed by remember(groupIdForBanner) {
+                mutableStateOf(
+                    groupIdForBanner != null &&
+                    governancePrefs.getBoolean(governanceDismissKey, false)
+                )
+            }
+            val governanceType = viewModel.group?.groupType
+            if (governanceType != null && !governanceBannerDismissed) {
+                GovernanceBanner(
+                    groupType = governanceType,
+                    onDismiss = {
+                        governanceBannerDismissed = true
+                        if (groupIdForBanner != null) {
+                            governancePrefs.edit().putBoolean(governanceDismissKey, true).apply()
+                        }
+                    }
+                )
+            }
+
             // Epoch pin banner
             val pinnedEpoch = viewModel.group?.pinnedEpoch
             val group = viewModel.group
@@ -405,7 +435,15 @@ fun ChatScreen(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
-                                    SystemMessage(message.text)
+                                    if (message.text.startsWith("VOTE_PROPOSAL::")) {
+                                        VoteProposalCard(
+                                            rawPayload = message.text,
+                                            senderAlias = contactAliasStore?.displayName(message.senderPubkey),
+                                            targetAliasResolver = { hex -> contactAliasStore?.displayName(hex) }
+                                        )
+                                    } else {
+                                        SystemMessage(message.text)
+                                    }
                                     if (message.text.contains("joined the group") &&
                                         (viewModel.group?.members?.size ?: 0) == 2) {
                                         Text(
@@ -1600,6 +1638,131 @@ fun QuotedReplyView(parent: ChatMessage, isMine: Boolean, onClick: () -> Unit) {
                 overflow = TextOverflow.Ellipsis
             )
         }
+    }
+}
+
+@Composable
+fun GovernanceBanner(groupType: SEPGroupType, onDismiss: () -> Unit = {}) {
+    val (title, subtitle, icon, tint) = when (groupType) {
+        SEPGroupType.ANARCHY -> GovernanceBannerSpec(
+            "Anarchy group",
+            "Any member can kick or invite anyone, unilaterally. Choose members carefully.",
+            Icons.Filled.Warning,
+            Color(0xFFE65100)
+        )
+        SEPGroupType.ONE_ON_ONE -> GovernanceBannerSpec(
+            "1-on-1 chat",
+            "Membership is frozen \u2014 no one else can be added. Leaving ends the chat.",
+            Icons.Filled.People,
+            Color(0xFF1565C0)
+        )
+        SEPGroupType.DEMOCRACY -> GovernanceBannerSpec(
+            "Democracy group",
+            "Kicks and invites require a majority vote from current members.",
+            Icons.Filled.HowToVote,
+            Color(0xFF6A1B9A)
+        )
+        SEPGroupType.OLIGARCHY -> GovernanceBannerSpec(
+            "Oligarchy group",
+            "Only admins can kick members or approve new invites.",
+            Icons.Filled.Star,
+            Color(0xFFF9A825)
+        )
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(tint.copy(alpha = 0.12f))
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(20.dp))
+        Spacer(Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.SemiBold)
+            Text(subtitle, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        IconButton(onClick = onDismiss, modifier = Modifier.size(28.dp)) {
+            Icon(Icons.Default.Close, contentDescription = "Dismiss", modifier = Modifier.size(14.dp))
+        }
+    }
+}
+
+private data class GovernanceBannerSpec(
+    val title: String,
+    val subtitle: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val tint: Color
+)
+
+/** Inline ballot card for a `VOTE_PROPOSAL::v1::...` system message. Yes/No
+ *  buttons are stubs — on-chain submission is gated on the Democracy circuit
+ *  VK ceremony. The card surfaces who proposed what so members see it. */
+@Composable
+fun VoteProposalCard(
+    rawPayload: String,
+    senderAlias: String?,
+    targetAliasResolver: (String) -> String?
+) {
+    val parts = rawPayload.split("::")
+    val valid = parts.size >= 5 && parts[0] == "VOTE_PROPOSAL" && parts[1] == "v1" && parts[2] == "remove"
+    if (!valid) {
+        SystemMessage("Ballot (unrecognized)")
+        return
+    }
+    val targetHex = parts[3]
+    val ballotID = parts[4]
+    val targetLabel = targetAliasResolver(targetHex)
+        ?: (targetHex.take(12) + "\u2026" + targetHex.takeLast(6))
+    var choice by remember(ballotID) { mutableStateOf<Boolean?>(null) }
+    val tint = Color(0xFF6A1B9A)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(tint.copy(alpha = 0.08f))
+            .padding(10.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Filled.HowToVote,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(16.dp)
+            )
+            Spacer(Modifier.width(6.dp))
+            Text("Ballot", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.weight(1f))
+            Text("#$ballotID", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "${senderAlias ?: "A member"} proposed to remove:",
+            style = MaterialTheme.typography.labelSmall
+        )
+        Text(targetLabel, style = MaterialTheme.typography.bodySmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Spacer(Modifier.height(6.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            OutlinedButton(
+                onClick = { choice = true },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(if (choice == true) "\u2713 Yes" else "Yes", style = MaterialTheme.typography.labelSmall)
+            }
+            OutlinedButton(
+                onClick = { choice = false },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(if (choice == false) "\u2715 No" else "No", style = MaterialTheme.typography.labelSmall)
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "On-chain voting activates once the Democracy circuit is deployed.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupInfoScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupInfoScreen.kt
@@ -24,7 +24,9 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.HowToVote
 import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -78,6 +80,7 @@ fun GroupInfoScreen(
     onSendInvitation: ((recipientKeyHex: String, onResult: (Result<Unit>) -> Unit) -> Unit)? = null,
     inviteLink: String? = null,
     onTogglePushNotifications: ((Boolean) -> Unit)? = null,
+    onProposeRemovalVote: ((targetPubkeyHex: String) -> Unit)? = null,
     contactAliasStore: ContactAliasStore? = null,
     dao: StellarChatDao? = null,
     onBack: () -> Unit
@@ -195,6 +198,8 @@ fun GroupInfoScreen(
                         val isMe = member.publicKeyCompressed.contentEquals(myBlsPubkey)
                         val hex = member.publicKeyCompressed.toHex()
                         val alias = contactAliasStore?.displayName(hex)
+                        val isAdmin = group.groupType == com.stellarmls.mls.SEPGroupType.OLIGARCHY &&
+                                      group.adminPubkeys.contains(hex)
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -218,15 +223,53 @@ fun GroupInfoScreen(
                                     color = if (alias != null) MaterialTheme.colorScheme.onSurfaceVariant
                                         else MaterialTheme.colorScheme.onSurface
                                 )
-                                if (isMe) {
-                                    Text(
-                                        "You",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.primary
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    if (isMe) {
+                                        Text(
+                                            "You",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
+                                    if (isAdmin) {
+                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                            Icon(
+                                                Icons.Filled.Star,
+                                                contentDescription = null,
+                                                tint = Color(0xFFF9A825),
+                                                modifier = Modifier.size(12.dp)
+                                            )
+                                            Spacer(Modifier.width(2.dp))
+                                            Text(
+                                                "Admin",
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = Color(0xFFF9A825)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                            // Democracy: ballot proposal replaces direct kick.
+                            if (!isMe && isMember &&
+                                group.groupType == com.stellarmls.mls.SEPGroupType.DEMOCRACY &&
+                                onProposeRemovalVote != null) {
+                                IconButton(onClick = { onProposeRemovalVote(hex) }) {
+                                    Icon(
+                                        Icons.Filled.HowToVote,
+                                        contentDescription = "Propose vote to remove",
+                                        tint = Color(0xFF6A1B9A)
                                     )
                                 }
                             }
-                            if (!isMe && isMember) {
+                            // Kick hidden for 1v1 (frozen membership) and Democracy (uses ballots).
+                            // Oligarchy still renders it, but the ceremony-gated contract rejects
+                            // its update_commitment calls until VKs are published.
+                            if (!isMe && isMember &&
+                                group.groupType != com.stellarmls.mls.SEPGroupType.ONE_ON_ONE &&
+                                group.groupType != com.stellarmls.mls.SEPGroupType.DEMOCRACY) {
                                 IconButton(
                                     onClick = { memberToRemove = member },
                                     enabled = !isRemovingMember
@@ -244,8 +287,9 @@ fun GroupInfoScreen(
                 }
             }
 
-            // Invite Member section
-            if (isMember && onSendInvitation != null) {
+            // Invite Member section — hidden for 1v1 groups (frozen membership).
+            if (isMember && onSendInvitation != null &&
+                group.groupType != com.stellarmls.mls.SEPGroupType.ONE_ON_ONE) {
                 Spacer(modifier = Modifier.height(16.dp))
                 Card(modifier = Modifier.fillMaxWidth()) {
                     Column(modifier = Modifier.padding(16.dp)) {
@@ -313,8 +357,9 @@ fun GroupInfoScreen(
                 }
             }
 
-            // Copy Invite Link section
-            if (isMember && inviteLink != null) {
+            // Copy Invite Link section — hidden for 1v1 groups (frozen membership).
+            if (isMember && inviteLink != null &&
+                group.groupType != com.stellarmls.mls.SEPGroupType.ONE_ON_ONE) {
                 Spacer(modifier = Modifier.height(16.dp))
                 Card(modifier = Modifier.fillMaxWidth()) {
                     Column(modifier = Modifier.padding(16.dp)) {

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/InviteMemberScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/InviteMemberScreen.kt
@@ -10,8 +10,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.People
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.style.TextAlign
+import com.stellarmls.mls.SEPGroupType
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -65,6 +71,51 @@ fun InviteMemberScreen(
                     recipientKey = trimmed
                 }
                 showScanner = false
+            }
+        }
+        return
+    }
+
+    // 1v1 chats have frozen membership — render a blocker instead of the invite form.
+    if (group.groupType == SEPGroupType.ONE_ON_ONE) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Invite Member") },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    }
+                )
+            }
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(32.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    androidx.compose.material.icons.Icons.Filled.People,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(44.dp)
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    "1-on-1 chats are sealed",
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "This conversation was created as a 1-on-1 chat. Membership is frozen \u2014 no one else can be added.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
             }
         }
         return

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/CreateGroupViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/CreateGroupViewModel.kt
@@ -89,6 +89,11 @@ class CreateGroupViewModel : ViewModel() {
                 tier = effectiveTier,
                 groupType = groupType
             )
+            // Oligarchy creator is seeded as the initial admin. Demoting this
+            // member (via future on-chain flows) requires another admin's consent.
+            if (groupType == SEPGroupType.OLIGARCHY) {
+                group.adminPubkeys.add(myLeaf.publicKeyCompressed.toHex())
+            }
             group.recomputeCommitment()
 
             val invite = InviteCode(

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -1524,6 +1524,31 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         return contactAliasStore.displayName(hex) ?: (hex.take(8) + "...")
     }
 
+    /** Propose a Democracy-group vote to remove a member. Inserts a locally visible
+     *  ballot system message. On-chain vote submission is gated on the Democracy
+     *  circuit VK ceremony; this method only surfaces the proposal in chat.
+     *
+     *  Text format (parsed by `ChatScreen`): `VOTE_PROPOSAL::v1::remove::<targetHex>::<ballotID>` */
+    fun proposeRemovalVote(groupID: String, targetPubkeyHex: String) {
+        val group = groups.firstOrNull { it.id == groupID } ?: return
+        if (group.groupType != com.stellarmls.mls.SEPGroupType.DEMOCRACY) return
+        val ballotID = java.util.UUID.randomUUID().toString().take(8)
+        val text = "VOTE_PROPOSAL::v1::remove::$targetPubkeyHex::$ballotID"
+        val msg = ChatMessage(
+            id = "vote-${groupID.take(8)}-$ballotID",
+            groupID = groupID,
+            senderPubkey = keyManager.publicKeyHex,
+            text = text,
+            timestamp = java.util.Date(),
+            isMine = true,
+            isSystemMessage = true,
+            epoch = group.epoch
+        )
+        chatMessages[groupID] = (chatMessages[groupID] ?: emptyList()) + msg
+        bumpGroupLastMessage(groupID, msg.timestamp.time)
+        viewModelScope.launch { try { store.saveMessage(msg) } catch (_: Exception) { } }
+    }
+
     /** Insert a system message into chatMessages (and persist). Uses deterministic IDs for dedup. */
     private fun insertSystemMessage(groupID: String, text: String, event: String, epoch: Long) {
         val id = "sys-$event-${groupID.take(8)}-$epoch"

--- a/clients/ios/StellarChat/StellarChat/Models/ChatGroup.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/ChatGroup.swift
@@ -18,6 +18,10 @@ struct ChatGroup: Identifiable, Codable {
     /// Governance type selected at creation. Existing persisted groups
     /// decode this as `.anarchy` (the historical default).
     var groupType: SEPGroupType = .anarchy
+    /// Hex-encoded BLS pubkeys (lowercase) of members with admin privileges.
+    /// Only meaningful for `.oligarchy` groups; seeded with the creator at
+    /// group creation. Existing persisted groups decode this as empty.
+    var adminPubkeys: Set<String> = []
     var isPublishedOnChain: Bool = false
     /// Unix timestamp of the last received event, used for offline catch-up.
     var lastEventTimestamp: Int64 = 0

--- a/clients/ios/StellarChat/StellarChat/Models/PersistedModels.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/PersistedModels.swift
@@ -27,6 +27,9 @@ final class PersistedGroup {
     /// as `nil`, which we treat as `.anarchy` when projecting back to
     /// `ChatGroup` (see `PersistenceStore.decryptGroup`).
     var groupTypeRawValue: Int?
+    /// Encrypted JSON-encoded `[String]` of admin BLS pubkey hex. Optional so
+    /// existing SwiftData stores migrate in as `nil` (empty set).
+    var encryptedAdminPubkeys: Data?
 
     init(
         id: String,
@@ -46,7 +49,8 @@ final class PersistedGroup {
         removedByPubkeyHex: String? = nil,
         pushNotificationsEnabled: Bool = false,
         lastMessageAt: Date? = nil,
-        groupTypeRawValue: Int? = nil
+        groupTypeRawValue: Int? = nil,
+        encryptedAdminPubkeys: Data? = nil
     ) {
         self.id = id
         self.encryptedName = encryptedName
@@ -66,6 +70,7 @@ final class PersistedGroup {
         self.pushNotificationsEnabled = pushNotificationsEnabled
         self.lastMessageAt = lastMessageAt
         self.groupTypeRawValue = groupTypeRawValue
+        self.encryptedAdminPubkeys = encryptedAdminPubkeys
     }
 }
 

--- a/clients/ios/StellarChat/StellarChat/Models/PersistenceStore.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/PersistenceStore.swift
@@ -514,6 +514,19 @@ final class PersistenceStore {
         let relayStrings = group.relayHints.map(\.absoluteString)
         let relayJSON = (try? JSONEncoder().encode(relayStrings)) ?? Data()
 
+        let encAdmins: Data?
+        if group.adminPubkeys.isEmpty {
+            encAdmins = nil
+        } else {
+            let sorted = Array(group.adminPubkeys).sorted()
+            if let adminJSON = try? JSONEncoder().encode(sorted),
+               let encrypted = try? StorageEncryption.encrypt(adminJSON) {
+                encAdmins = encrypted
+            } else {
+                encAdmins = nil
+            }
+        }
+
         return PersistedGroup(
             id: group.id,
             encryptedName: encName,
@@ -532,7 +545,8 @@ final class PersistenceStore {
             removedByPubkeyHex: group.removedByPubkeyHex,
             pushNotificationsEnabled: group.pushNotificationsEnabled,
             lastMessageAt: group.lastMessageAt,
-            groupTypeRawValue: Int(group.groupType.rawValue)
+            groupTypeRawValue: Int(group.groupType.rawValue),
+            encryptedAdminPubkeys: encAdmins
         )
     }
 
@@ -576,6 +590,11 @@ final class PersistenceStore {
         group.lastMessageAt = persisted.lastMessageAt
         if let raw = persisted.groupTypeRawValue, let parsed = SEPGroupType(rawValue: UInt32(raw)) {
             group.groupType = parsed
+        }
+        if let encAdmins = persisted.encryptedAdminPubkeys,
+           let adminJSON = try? StorageEncryption.decrypt(encAdmins),
+           let admins = try? JSONDecoder().decode([String].self, from: adminJSON) {
+            group.adminPubkeys = Set(admins)
         }
         return group
     }

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -595,6 +595,13 @@ final class AppState {
             tier: tier
         )
         group.groupType = groupType
+        // Oligarchy creator is seeded as the initial admin. Demoting this
+        // member (via future on-chain flows) requires another admin's consent.
+        if groupType == .oligarchy {
+            let creatorHex = myLeaf.publicKeyCompressed
+                .map { String(format: "%02x", $0) }.joined()
+            group.adminPubkeys = [creatorHex]
+        }
         try group.recomputeCommitment()
         addGroup(group)
         captureEpochSnapshot(group: group, changeDescription: "Group created")
@@ -1130,6 +1137,34 @@ final class AppState {
         }
         let hex = blsPubkey.map { String(format: "%02x", $0) }.joined()
         return contactAliasStore?.displayName(for: hex) ?? (String(hex.prefix(8)) + "...")
+    }
+
+    /// Propose a Democracy-group vote to remove a member. Inserts a locally
+    /// visible ballot system message. The actual on-chain vote flow is gated
+    /// on the Democracy circuit VK ceremony; this method only surfaces the
+    /// proposal in chat so members can see it.
+    ///
+    /// Text format (parsed by `ChatView`): `VOTE_PROPOSAL::v1::remove::<targetHex>`
+    func proposeRemovalVote(groupID: String, targetPubkeyHex: String) {
+        guard let group = groups.first(where: { $0.id == groupID }),
+              group.groupType == .democracy else { return }
+        let ballotID = UUID().uuidString.prefix(8)
+        let text = "VOTE_PROPOSAL::v1::remove::\(targetPubkeyHex)::\(ballotID)"
+        let msg = ChatMessage(
+            id: "vote-\(String(groupID.prefix(8)))-\(ballotID)",
+            groupID: groupID,
+            senderPubkey: keyManager.publicKeyHex,
+            text: text,
+            timestamp: Date(),
+            isMine: true,
+            isSystemMessage: true,
+            epoch: group.epoch
+        )
+        var messages = chatMessages[groupID, default: []]
+        messages.append(msg)
+        chatMessages[groupID] = messages
+        bumpGroupLastMessage(groupID: groupID, timestamp: msg.timestamp)
+        store.saveMessageAsync(msg)
     }
 
     /// Insert a system message into chatMessages (and persist). Uses deterministic IDs for dedup.

--- a/clients/ios/StellarChat/StellarChat/Views/ChatView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ChatView.swift
@@ -1,5 +1,6 @@
 import AVKit
 import PhotosUI
+import SwiftMLS
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -20,10 +21,22 @@ struct ChatView: View {
     @State private var showCallScreen = false
     @State private var showForkSheet = false
     @State private var pushBannerDismissed = false
+    @State private var governanceBannerDismissed: [String: Bool] = [:]
     @AppStorage("hasSeenFirstGroupWelcome") private var hasSeenFirstGroupWelcome = false
 
     var body: some View {
         VStack(spacing: 0) {
+            // Governance type banner — highlights the rules for this group.
+            // Anarchy is surfaced as a warning (any member can kick/invite);
+            // 1v1 / Democracy / Oligarchy get an informational notice.
+            if let group = viewModel.group,
+               governanceBannerDismissed[group.id] != true {
+                GovernanceBanner(
+                    groupType: group.groupType,
+                    onDismiss: { governanceBannerDismissed[group.id] = true }
+                )
+            }
+
             // Welcome banner for first group
             if !hasSeenFirstGroupWelcome, appState.groups.count == 1 {
                 HStack(spacing: 8) {
@@ -151,7 +164,15 @@ struct ChatView: View {
 
                                     if message.isSystemMessage {
                                         VStack(spacing: 4) {
-                                            SystemMessageView(text: message.text)
+                                            if message.text.hasPrefix("VOTE_PROPOSAL::") {
+                                                VoteProposalCard(
+                                                    rawPayload: message.text,
+                                                    senderAlias: appState.contactAliasStore.displayName(for: message.senderPubkey),
+                                                    targetAlias: { hex in appState.contactAliasStore.displayName(for: hex) }
+                                                )
+                                            } else {
+                                                SystemMessageView(text: message.text)
+                                            }
                                             if message.text.contains("joined the group"),
                                                appState.groups.count == 1,
                                                let group = viewModel.group,
@@ -529,6 +550,177 @@ struct SystemMessageView: View {
             .padding(.vertical, 4)
             .padding(.horizontal, 12)
             .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Governance Banner
+
+struct GovernanceBanner: View {
+    let groupType: SEPGroupType
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(tint.opacity(0.12))
+    }
+
+    private var icon: String {
+        switch groupType {
+        case .anarchy: return "exclamationmark.triangle"
+        case .oneOnOne: return "person.2.fill"
+        case .democracy: return "hand.raised.fill"
+        case .oligarchy: return "star.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch groupType {
+        case .anarchy: return .orange
+        case .oneOnOne: return .blue
+        case .democracy: return .purple
+        case .oligarchy: return .yellow
+        }
+    }
+
+    private var title: String {
+        switch groupType {
+        case .anarchy: return "Anarchy group"
+        case .oneOnOne: return "1-on-1 chat"
+        case .democracy: return "Democracy group"
+        case .oligarchy: return "Oligarchy group"
+        }
+    }
+
+    private var subtitle: String {
+        switch groupType {
+        case .anarchy:
+            return "Any member can kick or invite anyone, unilaterally. Choose members carefully."
+        case .oneOnOne:
+            return "Membership is frozen — no one else can be added. Leaving ends the chat."
+        case .democracy:
+            return "Kicks and invites require a majority vote from current members."
+        case .oligarchy:
+            return "Only admins can kick members or approve new invites."
+        }
+    }
+}
+
+// MARK: - Democracy Vote Proposal Card
+
+/// Renders an inline ballot card for a `VOTE_PROPOSAL::v1::...` system message.
+/// Yes / No buttons are stubs — actual vote submission is gated on the
+/// Democracy circuit VK ceremony. The card surfaces who proposed what so
+/// members can see the ballot exists.
+struct VoteProposalCard: View {
+    let rawPayload: String
+    let senderAlias: String?
+    let targetAlias: (String) -> String?
+
+    @State private var myChoice: Bool?
+
+    private var parsed: VoteProposalPayload? {
+        VoteProposalPayload.parse(rawPayload)
+    }
+
+    var body: some View {
+        if let parsed {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Image(systemName: "hand.raised.fill")
+                        .foregroundStyle(.purple)
+                    Text("Ballot")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                    Spacer()
+                    Text("#\(parsed.ballotID)")
+                        .font(.caption2)
+                        .monospaced()
+                        .foregroundStyle(.secondary)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(senderAlias ?? "A member") proposed to remove:")
+                        .font(.caption)
+                    Text(displayTarget(parsed.targetPubkeyHex))
+                        .font(.caption)
+                        .monospaced()
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                HStack(spacing: 8) {
+                    Button {
+                        myChoice = true
+                    } label: {
+                        Label("Yes", systemImage: myChoice == true ? "checkmark.circle.fill" : "checkmark.circle")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.green)
+
+                    Button {
+                        myChoice = false
+                    } label: {
+                        Label("No", systemImage: myChoice == false ? "xmark.circle.fill" : "xmark.circle")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.red)
+                    Spacer()
+                }
+                Text("On-chain voting activates once the Democracy circuit is deployed.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(10)
+            .background(Color.purple.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            SystemMessageView(text: "Ballot (unrecognized)")
+        }
+    }
+
+    private func displayTarget(_ hex: String) -> String {
+        if let alias = targetAlias(hex) { return alias }
+        return hex.prefix(12) + "…" + hex.suffix(6)
+    }
+}
+
+struct VoteProposalPayload {
+    let targetPubkeyHex: String
+    let ballotID: String
+
+    static func parse(_ raw: String) -> VoteProposalPayload? {
+        // `VOTE_PROPOSAL::v1::remove::<targetHex>::<ballotID>`
+        let parts = raw.components(separatedBy: "::")
+        guard parts.count >= 5,
+              parts[0] == "VOTE_PROPOSAL",
+              parts[1] == "v1",
+              parts[2] == "remove" else { return nil }
+        return VoteProposalPayload(
+            targetPubkeyHex: parts[3],
+            ballotID: parts[4]
+        )
     }
 }
 

--- a/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
@@ -82,7 +82,8 @@ struct GroupInfoView: View {
                     ))
                 }
 
-                if appState.isMember(of: group) {
+                // 1v1 groups have frozen membership — no invites after creation.
+                if appState.isMember(of: group) && group.groupType != .oneOnOne {
                     // MARK: - Invite Member
                     Section {
                         TextField("X25519 public key (hex)", text: $recipientInboxKey)
@@ -138,53 +139,7 @@ struct GroupInfoView: View {
 
                 Section("Members") {
                     ForEach(group.members, id: \.publicKeyCompressed) { member in
-                        let pubkeyHex = member.publicKeyCompressed.map { String(format: "%02x", $0) }.joined()
-                        let alias = appState.contactAliasStore.displayName(for: pubkeyHex)
-                        HStack {
-                            VStack(alignment: .leading) {
-                                if let alias {
-                                    Text(alias)
-                                        .font(.caption)
-                                }
-                                Text(pubkeyHex.prefix(16) + "...")
-                                    .font(.caption2)
-                                    .monospaced()
-                                    .foregroundStyle(alias != nil ? .secondary : .primary)
-
-                                if isMyKey(member) {
-                                    Text("You")
-                                        .font(.caption2)
-                                        .foregroundStyle(.blue)
-                                }
-                            }
-
-                            Spacer()
-
-                            if !isMyKey(member) {
-                                Button(role: .destructive) {
-                                    memberToRemove = member
-                                    showRemoveConfirmation = true
-                                } label: {
-                                    Image(systemName: "person.badge.minus")
-                                }
-                                .disabled(isRemovingMember)
-                            }
-                        }
-                        .contextMenu {
-                            Button {
-                                aliasText = alias ?? ""
-                                aliasTarget = pubkeyHex
-                            } label: {
-                                Label("Set Name", systemImage: "pencil")
-                            }
-                            if alias != nil {
-                                Button(role: .destructive) {
-                                    appState.contactAliasStore.removeAlias(pubkey: pubkeyHex)
-                                } label: {
-                                    Label("Remove Name", systemImage: "trash")
-                                }
-                            }
-                        }
+                        memberRow(for: member)
                     }
                 }
 
@@ -398,6 +353,75 @@ struct GroupInfoView: View {
     private func isMyKey(_ member: SEPGroupMemberLeaf) -> Bool {
         guard let myLeaf = try? appState.keyManager.memberLeaf else { return false }
         return member.publicKeyCompressed == myLeaf.publicKeyCompressed
+    }
+
+    @ViewBuilder
+    private func memberRow(for member: SEPGroupMemberLeaf) -> some View {
+        let pubkeyHex = member.publicKeyCompressed.map { String(format: "%02x", $0) }.joined()
+        let alias = appState.contactAliasStore.displayName(for: pubkeyHex)
+        let isAdmin = group.groupType == .oligarchy && group.adminPubkeys.contains(pubkeyHex)
+        let isSelf = isMyKey(member)
+        let showVoteButton = !isSelf && group.groupType == .democracy
+        let showKickButton = !isSelf && group.groupType != .oneOnOne && group.groupType != .democracy
+
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                if let alias {
+                    Text(alias).font(.caption)
+                }
+                Text(pubkeyHex.prefix(16) + "...")
+                    .font(.caption2)
+                    .monospaced()
+                    .foregroundStyle(alias != nil ? .secondary : .primary)
+
+                HStack(spacing: 6) {
+                    if isSelf {
+                        Text("You").font(.caption2).foregroundStyle(.blue)
+                    }
+                    if isAdmin {
+                        Label("Admin", systemImage: "star.fill")
+                            .labelStyle(.titleAndIcon)
+                            .font(.caption2)
+                            .foregroundStyle(.yellow)
+                    }
+                }
+            }
+
+            Spacer()
+
+            if showVoteButton {
+                Button {
+                    appState.proposeRemovalVote(groupID: group.id, targetPubkeyHex: pubkeyHex)
+                } label: {
+                    Image(systemName: "hand.raised")
+                }
+                .help("Propose vote to remove")
+            }
+            if showKickButton {
+                Button(role: .destructive) {
+                    memberToRemove = member
+                    showRemoveConfirmation = true
+                } label: {
+                    Image(systemName: "person.badge.minus")
+                }
+                .disabled(isRemovingMember)
+            }
+        }
+        .contextMenu {
+            Button {
+                aliasText = alias ?? ""
+                aliasTarget = pubkeyHex
+            } label: {
+                Label("Set Name", systemImage: "pencil")
+            }
+            if alias != nil {
+                Button(role: .destructive) {
+                    appState.contactAliasStore.removeAlias(pubkey: pubkeyHex)
+                } label: {
+                    Label("Remove Name", systemImage: "trash")
+                }
+            }
+        }
     }
 
     private func removeMember(_ member: SEPGroupMemberLeaf) {

--- a/clients/ios/StellarChat/StellarChat/Views/InviteMemberView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/InviteMemberView.swift
@@ -1,3 +1,4 @@
+import SwiftMLS
 import SwiftUI
 
 struct InviteMemberView: View {
@@ -10,6 +11,40 @@ struct InviteMemberView: View {
 
     var body: some View {
         NavigationStack {
+            if group.groupType == .oneOnOne {
+                oneOnOneBlocker
+            } else {
+                inviteForm
+            }
+        }
+    }
+
+    private var oneOnOneBlocker: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "person.2.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(.blue)
+            Text("1-on-1 chats are sealed")
+                .font(.headline)
+            Text("This conversation was created as a 1-on-1 chat. Membership is frozen — no one else can be added.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+            Spacer()
+        }
+        .navigationTitle("Invite via Nostr")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Close") { dismiss() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var inviteForm: some View {
             Form {
                 Section("Group") {
                     LabeledContent("Name") { Text(group.name) }
@@ -72,7 +107,6 @@ struct InviteMemberView: View {
                     showScanner = false
                 }
             }
-        }
     }
 
     private func sendInvitation() {


### PR DESCRIPTION
## Summary

Adds user-visible governance UX on top of the SDK plumbing from Phase 4. Each of the four governance types now has a visible behavior and the actionable controls that match it.

- **Anarchy (0)** — dismissible warning banner at the top of the chat: _any member can change membership_.
- **1v1 (1)** — banner explaining sealed membership. Invite-member and copy-invite-link sections hidden in Group Info. A dedicated blocker scaffold replaces the invite form if the sheet is reached anyway. Kick button hidden.
- **Democracy (2)** — banner explaining ballot requirement. Kick replaced with a vote proposal action; proposals render as a `VoteProposalCard` in the chat with local-preview Yes/No buttons, using existing `isSystemMessage` plus a `VOTE_PROPOSAL::v1::remove::<hex>::<ballotID>` text prefix — no new schema.
- **Oligarchy (3)** — banner noting admin-gated changes. Group creator is seeded as the sole admin at create time. Members list shows an Admin star badge. `adminPubkeys: Set<String>` persists as a field-encrypted blob (SwiftData optional field on iOS; Android Room migration 13 → 14 with `ALTER TABLE groups ADD COLUMN encryptedAdminPubkeys BLOB`).

On-chain vote / admin-rotation submission remains gated on the Democracy and Oligarchy ceremony VK being deployed — consistent with Phases 1–4.

## Test plan

- [ ] Anarchy group: banner visible and dismissible; dismiss persists across launches.
- [ ] 1v1 group: Invite Member section absent; entering the invite sheet shows the sealed-chat blocker; kick button hidden in Group Info.
- [ ] Democracy group: kick replaced with vote/hand-raise action; tapping it posts a system message that renders as a ballot card; Yes/No buttons toggle locally.
- [ ] Oligarchy group: creator shows Admin star badge in Group Info; admin set survives app restart (SwiftData) and database migration (Room 13 → 14).
- [ ] Existing Anarchy groups continue to read with empty adminPubkeys after migration.
- [ ] iOS build succeeds for iPhone 17 Pro simulator.
- [ ] Android build succeeds in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)