### PR TITLE
ci: pin cross-compile targets in rust-toolchain.toml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android
 
       - name: Cache Rust build
         uses: actions/cache@v4
@@ -79,8 +77,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios
 
       - name: Cache Rust build
         uses: actions/cache@v4

--- a/.github/workflows/release-ceremony-tool.yml
+++ b/.github/workflows/release-ceremony-tool.yml
@@ -70,21 +70,15 @@ jobs:
           EPOCH=$(git log -1 --pretty=%ct)
           echo "SOURCE_DATE_EPOCH=$EPOCH" >> "$GITHUB_ENV"
 
-      - name: Install rust-toolchain.toml components
-        uses: dtolnay/rust-toolchain@master
-        with:
-          # The pinned channel is read from rust-toolchain.toml at checkout.
-          # dtolnay/rust-toolchain honors it when set to "stable" here.
-          toolchain: stable
-          targets: ${{ matrix.target }}
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Ensure pinned toolchain has the matrix target
         shell: bash
         run: |
-          # dtolnay/rust-toolchain installed `stable` + the target, but
-          # rust-toolchain.toml pins a specific channel (e.g. 1.88.0) that
-          # auto-installs on first cargo invocation without the target.
-          # Force-install the target against the pinned channel here.
+          # rust-toolchain.toml lists the standard mobile/musl targets, but
+          # the matrix here may add others (e.g. aarch64-unknown-linux-musl)
+          # that aren't pinned there. Add on demand.
           rustup target add ${{ matrix.target }}
 
       - name: Install musl cross tools (Linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,aarch64-apple-darwin
 
       - name: Cache Rust build
         uses: actions/cache@v4
@@ -256,8 +254,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios
 
       - name: Cache Rust build
         uses: actions/cache@v4

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,11 @@
 [toolchain]
 channel = "1.88.0"
 components = ["rustfmt", "clippy"]
+targets = [
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "aarch64-apple-darwin",
+]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Fixes the `Build Android` PR check failing across all open PRs with:

```
error[E0463]: can't find crate for `core`
  | = note: the `aarch64-linux-android` target may not be installed
```

## Root cause

`rust-toolchain.toml` pinned channel `1.88.0` but listed no `targets`. CI installed targets via `dtolnay/rust-toolchain@stable` with `targets: aarch64-linux-android` — but those targets attached to the *stable* toolchain. When `cargo build --target aarch64-linux-android` ran in-repo, rustup auto-synced `1.88.0` per `rust-toolchain.toml` *without* the Android target, and the compile broke. The CI log shows this clearly: `info: syncing channel updates for 1.88.0-x86_64-unknown-linux-gnu` immediately before the missing-`core` error.

The same latent bug affects the iOS jobs (their `targets:` input was attached to the wrong toolchain too); it just hadn't surfaced as a failure thanks to caching.

`release-ceremony-tool.yml` already documents this exact bug and works around it manually (`rustup target add` after dtolnay).

## Fix

- Add `targets = [...]` to `rust-toolchain.toml` so rustup installs them against the pinned channel on first cargo invocation. Canonical Rust solution; works for CI and local devs alike.
- Drop now-redundant `targets:` inputs from `dtolnay/rust-toolchain` in `pr.yml` and `release.yml`.
- In `release-ceremony-tool.yml`, keep the per-matrix `rustup target add` (the matrix includes musl/windows/x86_64-darwin targets that aren't pinned in toolchain.toml) and update the explanatory comment.

## Test plan

- [ ] PR Build → Build Android (arm64-v8a) succeeds on this PR
- [ ] PR Build → Build iOS still passes
- [ ] After merge, re-run failing checks on PRs #67–#73 to confirm propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)