### PR TITLE
Make on-chain state authoritative for all epoch transitions

### DIFF
--- a/clients/android/StellarChat/app/build.gradle.kts
+++ b/clients/android/StellarChat/app/build.gradle.kts
@@ -193,6 +193,7 @@ dependencies {
 
     // JVM unit tests
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 
     // Android instrumented tests
     androidTestImplementation("androidx.test:runner:1.6.2")

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/onchain/ChainStateRetry.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/onchain/ChainStateRetry.kt
@@ -1,0 +1,43 @@
+package chat.onym.android.onchain
+
+import kotlinx.coroutines.delay
+
+/**
+ * Bounded retry for on-chain state reads when the RPC node is expected to
+ * trail the network briefly. Used on the receive path: when a peer
+ * broadcasts an update for epoch N, our RPC may not yet have indexed the
+ * ledger close that committed epoch N to the contract. Polling once and
+ * rejecting on mismatch would silently drop a legitimate update; polling
+ * forever risks blocking on a genuinely-missing commitment.
+ *
+ * Returns the most recent entry seen — even when its epoch still trails
+ * [expectedEpoch] after exhausting [maxAttempts] — so the caller can still
+ * compare the stale entry and make a chain-authority decision. Re-throws
+ * the last error only if every fetch attempt threw.
+ */
+suspend fun fetchOnChainStateAwaitingEpoch(
+    fetch: suspend () -> SEPCommitmentEntry,
+    expectedEpoch: Long,
+    maxAttempts: Int = 4,
+    initialDelayMs: Long = 250L
+): SEPCommitmentEntry {
+    require(maxAttempts >= 1) { "maxAttempts must be >= 1" }
+    var delayMs = initialDelayMs
+    var lastEntry: SEPCommitmentEntry? = null
+    var lastError: Exception? = null
+    for (attempt in 0 until maxAttempts) {
+        try {
+            val entry = fetch()
+            lastEntry = entry
+            if (entry.epoch >= expectedEpoch) return entry
+        } catch (e: Exception) {
+            lastError = e
+        }
+        if (attempt < maxAttempts - 1) {
+            delay(delayMs)
+            delayMs *= 2
+        }
+    }
+    return lastEntry ?: throw (lastError
+        ?: java.io.IOException("fetchOnChainState failed after $maxAttempts attempts"))
+}

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -603,6 +603,27 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         startRekeyResendTimer()
     }
 
+    /**
+     * Fetch on-chain state with a bounded retry for RPC lag. Delegates to the
+     * top-level [chat.onym.android.onchain.fetchOnChainStateAwaitingEpoch]
+     * helper (extracted so the retry logic can be unit-tested without
+     * instantiating the full ViewModel).
+     */
+    private suspend fun fetchOnChainStateAwaitingEpoch(
+        service: OnChainService,
+        groupIDData: ByteArray,
+        expectedEpoch: Long,
+        maxAttempts: Int = 4,
+        initialDelayMs: Long = 250L
+    ): chat.onym.android.onchain.SEPCommitmentEntry {
+        return chat.onym.android.onchain.fetchOnChainStateAwaitingEpoch(
+            fetch = { withContext(Dispatchers.IO) { service.fetchOnChainState(groupIDData) } },
+            expectedEpoch = expectedEpoch,
+            maxAttempts = maxAttempts,
+            initialDelayMs = initialDelayMs
+        )
+    }
+
     /** Apply a secure rekey envelope received via inbox. Installs fresh groupSecret/salt and migrates topic. */
     private fun applyRekeyEnvelope(obj: JSONObject) {
         val groupIDBytes = android.util.Base64.decode(obj.getString("groupID"), android.util.Base64.NO_WRAP)
@@ -645,13 +666,16 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         val oldTopicTag = group.topicTag
 
         // Compute candidate state from the envelope WITHOUT mutating `groups[index]` yet.
-        val candidate = group.copy(
+        // `cloneGroup` deep-copies `members`, `groupSecret`, `salt`, `commitment`
+        // so `candidate.members.removeAll { ... }` below cannot leak back into
+        // the stored group if we end up rejecting at chain verification.
+        val candidate = cloneGroup(group).copy(
             groupSecret = android.util.Base64.decode(obj.getString("groupSecret"), android.util.Base64.NO_WRAP),
             salt = android.util.Base64.decode(obj.getString("salt"), android.util.Base64.NO_WRAP),
             epoch = epoch,
             commitment = obj.optString("commitment", "").takeIf { it.isNotEmpty() }?.let {
                 android.util.Base64.decode(it, android.util.Base64.NO_WRAP)
-            } ?: group.commitment
+            } ?: group.commitment?.copyOf()
         )
 
         // Apply member changes to candidate
@@ -678,9 +702,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             }
             viewModelScope.launch {
                 val chainMatches: Boolean = try {
-                    val entry = withContext(Dispatchers.IO) {
-                        service.fetchOnChainState(groupIDBytes)
-                    }
+                    val entry = fetchOnChainStateAwaitingEpoch(service, groupIDBytes, expectedEpoch = epoch)
                     val localCommitment = candidate.commitment
                     localCommitment != null
                         && entry.active
@@ -1637,7 +1659,15 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         }
         captureEpochSnapshot(currentGroup, changeDesc)
 
-        groups[index] = candidate
+        // Re-locate the group by ID — `index` captured above may be stale after
+        // the suspend points on chain publish (groups list can be mutated during
+        // the await). If the group disappeared entirely, abort without persisting.
+        val liveIndex = groups.indexOfFirst { it.id == groupID }
+        if (liveIndex < 0) {
+            if (BuildConfig.DEBUG) Log.w("GroupListVM", "Group $groupID disappeared during chain publish; dropping transition")
+            return EpochTransitionResult.CHAIN_REJECTED
+        }
+        groups[liveIndex] = candidate
         try { store.saveGroup(candidate) } catch (_: Exception) { }
         storeSalt(groupID, candidate.epoch, candidate.salt)
 
@@ -2180,9 +2210,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                 if (service != null) {
                     viewModelScope.launch {
                         val chainMatches: Boolean = try {
-                            val entry = withContext(Dispatchers.IO) {
-                                service.fetchOnChainState(group.groupIDData)
-                            }
+                            val entry = fetchOnChainStateAwaitingEpoch(service, group.groupIDData, expectedEpoch = update.epoch)
                             val localCommitment = candidate.commitment
                             localCommitment != null
                                 && entry.active

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -644,11 +644,8 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
 
         val oldTopicTag = group.topicTag
 
-        // Capture epoch snapshot BEFORE mutation for epoch branching
-        captureEpochSnapshot(group, "Secure rekey (member removed)")
-
-        // Install new secrets
-        group = group.copy(
+        // Compute candidate state from the envelope WITHOUT mutating `groups[index]` yet.
+        val candidate = group.copy(
             groupSecret = android.util.Base64.decode(obj.getString("groupSecret"), android.util.Base64.NO_WRAP),
             salt = android.util.Base64.decode(obj.getString("salt"), android.util.Base64.NO_WRAP),
             epoch = epoch,
@@ -657,13 +654,96 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             } ?: group.commitment
         )
 
-        // Apply member changes
+        // Apply member changes to candidate
         val removedArr = obj.optJSONArray("removedMemberKeys") ?: JSONArray()
         for (i in 0 until removedArr.length()) {
             val removedKey = android.util.Base64.decode(removedArr.getString(i), android.util.Base64.NO_WRAP)
-            group.members.removeAll { it.publicKeyCompressed.contentEquals(removedKey) }
+            candidate.members.removeAll { it.publicKeyCompressed.contentEquals(removedKey) }
         }
-        sortMembers(group)
+        sortMembers(candidate)
+        // Recompute commitment locally from the final member set so we can
+        // cross-check against the chain's stored commitment.
+        candidate.recomputeCommitment()
+
+        // --- Chain-first verification (async for published groups). If the chain
+        // disagrees (sender hasn't published, proof rejected, or RPC lagging),
+        // refuse to install fresh secrets — otherwise we'd rotate away from a
+        // key the rest of the group still uses. For unpublished groups, apply
+        // directly.
+        if (candidate.isPublishedOnChain) {
+            val service = onChainService
+            if (service == null) {
+                if (BuildConfig.DEBUG) Log.w("Rekey", "DROPPED: onChainService unavailable for published group=${groupIDHex.take(8)}")
+                return
+            }
+            viewModelScope.launch {
+                val chainMatches: Boolean = try {
+                    val entry = withContext(Dispatchers.IO) {
+                        service.fetchOnChainState(groupIDBytes)
+                    }
+                    val localCommitment = candidate.commitment
+                    localCommitment != null
+                        && entry.active
+                        && entry.epoch == epoch
+                        && entry.commitment.contentEquals(localCommitment)
+                } catch (e: Exception) {
+                    if (BuildConfig.DEBUG) Log.w("Rekey", "DROPPED: chain fetch failed: ${e.message} group=${groupIDHex.take(8)}")
+                    false
+                }
+                if (!chainMatches) {
+                    if (BuildConfig.DEBUG) Log.w("Rekey", "REJECTED: chain disagrees at epoch=$epoch group=${groupIDHex.take(8)}")
+                    return@launch
+                }
+                commitRemoteRekey(
+                    groupIDHex = groupIDHex,
+                    groupIDBytes = groupIDBytes,
+                    candidate = candidate,
+                    senderBundle = senderBundle,
+                    obj = obj,
+                    oldTopicTag = oldTopicTag,
+                    epoch = epoch,
+                    removedArr = removedArr
+                )
+            }
+            return
+        }
+
+        // Unpublished draft — no chain authority, commit directly.
+        commitRemoteRekey(
+            groupIDHex = groupIDHex,
+            groupIDBytes = groupIDBytes,
+            candidate = candidate,
+            senderBundle = senderBundle,
+            obj = obj,
+            oldTopicTag = oldTopicTag,
+            epoch = epoch,
+            removedArr = removedArr
+        )
+    }
+
+    /**
+     * Install a chain-verified candidate from an incoming rekey envelope. Called
+     * from [applyRekeyEnvelope] after on-chain verification succeeds.
+     */
+    private fun commitRemoteRekey(
+        groupIDHex: String,
+        groupIDBytes: ByteArray,
+        candidate: ChatGroup,
+        senderBundle: com.stellarmls.mls.SEPMemberTransportBundle,
+        obj: JSONObject,
+        oldTopicTag: String,
+        epoch: Long,
+        removedArr: JSONArray
+    ) {
+        val idx = groups.indexOfFirst { it.id == groupIDHex }
+        if (idx < 0) return
+        val stored = groups[idx]
+        // Re-check staleness: something could have advanced while we were
+        // awaiting chain confirmation.
+        if (epoch <= stored.epoch) return
+
+        // Capture epoch snapshot of the pre-rekey state now that we're committing.
+        captureEpochSnapshot(stored, "Secure rekey (member removed)")
 
         // Update transport bundles
         val bundlesArr = obj.optJSONArray("memberBundles") ?: JSONArray()
@@ -675,15 +755,22 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         }
         processTransportBundle(senderBundle, groupIDHex)
 
-        groups[index] = group
-        storeSalt(groupIDHex, epoch, group.salt)
+        // Refresh chain baseline to match the now-confirmed state.
+        if (candidate.isPublishedOnChain) {
+            chainBaseline[groupIDHex] = ChainBaseline(
+                candidate.members.toList(), candidate.epoch, candidate.salt.copyOf()
+            )
+        }
+
+        groups[idx] = candidate
+        storeSalt(groupIDHex, epoch, candidate.salt)
 
         // Migrate topic
         if (!BuildConfig.DEBUG) transport.unsubscribe(oldTopicTag)
-        syncTransportAndSubscribe(group)
+        syncTransportAndSubscribe(candidate)
 
         viewModelScope.launch {
-            try { store.saveGroup(group) } catch (_: Exception) { }
+            try { store.saveGroup(candidate) } catch (_: Exception) { }
         }
 
         // System messages
@@ -693,7 +780,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             insertSystemMessage(groupIDHex, "$name was removed from the group", "member-remove", epoch)
         }
 
-        if (BuildConfig.DEBUG) Log.d("Rekey", "INSTALLED groupID=${groupIDHex.take(8)} epoch=$epoch newTopic=${group.topicTag.take(8)}")
+        if (BuildConfig.DEBUG) Log.d("Rekey", "INSTALLED groupID=${groupIDHex.take(8)} epoch=$epoch newTopic=${candidate.topicTag.take(8)}")
 
         // Send ack on the NEW topic
         val myBls = keyManager.blsPublicKey()
@@ -703,7 +790,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             put("epoch", epoch)
             put("senderBlsPubkey", android.util.Base64.encodeToString(myBls, android.util.Base64.NO_WRAP))
         }.toString()
-        transport.sendProtocolMessage(group, ackJson)
+        transport.sendProtocolMessage(candidate, ackJson)
     }
 
     /** Handle a resend request: look up stored envelope, verify requester is authorized, and re-send. */
@@ -1392,16 +1479,8 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         val currentGroup = cloneGroup(groups[index])
 
         // Note: we no longer block transitions when a chain publish is pending.
-        // Local transitions proceed immediately; chain publishes are cancelled and
-        // restarted with the latest state (coalesced).
-
-        // Capture epoch snapshot BEFORE mutation
-        val changeDesc = when (kind) {
-            is EpochTransitionKind.MemberAdd -> "Member added"
-            is EpochTransitionKind.MemberRemove -> "Member removed"
-            is EpochTransitionKind.KeyRotation -> "Key rotated"
-        }
-        captureEpochSnapshot(currentGroup, changeDesc)
+        // Chain publishes are awaited synchronously before mutating local state
+        // (see chain-first block below), so concurrent transitions queue naturally.
 
         // Compute candidate next state
         var candidate = cloneGroup(currentGroup)
@@ -1463,6 +1542,15 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             Log.d("GroupListVM", "Removal flow: useSecureRekey=$useSecureRekey isRemoval=$isRemoval bundles=$bundleKeys members=$memberKeys")
         }
 
+        // Removals REQUIRE inbox delivery (secure rekey). If bundles are missing,
+        // bail before advancing chain state — otherwise chain epoch advances
+        // while peers can't follow. Caller must rotate the key first to
+        // distribute bundles.
+        if (isRemoval && !useSecureRekey) {
+            if (BuildConfig.DEBUG) Log.w("GroupListVM", "Removal blocked pre-chain: not all remaining members have transport bundles. Rotate key first.")
+            return EpochTransitionResult.BUNDLES_MISSING
+        }
+
         // If secure rekey, apply fresh groupSecret + salt now so the chain publish
         // uses the final commitment (one publish instead of two).
         val preRekeyCandidate = cloneGroup(candidate)
@@ -1474,26 +1562,35 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             candidate.recomputeCommitment()
         }
 
-        // --- Persist locally FIRST (optimistic), then sync chain in background ---
-        candidate.isPublishedOnChain = currentGroup.isPublishedOnChain
-        groups[index] = candidate
-        storeSalt(groupID, candidate.epoch, candidate.salt)
-
-        // --- Async chain sync (non-blocking, coalesced) ---
-        // Launch BEFORE the Nostr broadcast so the chain publish isn't gated
-        // by relay round-trips.
-        if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain sync check: isPublishedOnChain=${currentGroup.isPublishedOnChain} onChainService=${onChainService != null} group=${groupID.take(8)} newEpoch=${candidate.epoch} oneOnOneFinalize=$isOneOnOneFinalize")
-        if (isOneOnOneFinalize && onChainService != null) {
+        // --- Chain-first: confirm on-chain BEFORE mutating local state ---
+        // Any group whose state is tracked on-chain MUST have its next-epoch
+        // commitment accepted by the contract before we persist, subscribe,
+        // or broadcast. If the contract rejects (e.g. Oligarchy non-admin
+        // removal, proof mismatch, stale baseline), we return without
+        // touching local state so sender and peers stay consistent with
+        // chain authority.
+        if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain-first check: isPublishedOnChain=${currentGroup.isPublishedOnChain} isOneOnOneFinalize=$isOneOnOneFinalize onChainService=${onChainService != null} group=${groupID.take(8)} newEpoch=${candidate.epoch}")
+        if (isOneOnOneFinalize) {
+            if (onChainService == null) return EpochTransitionResult.CHAIN_UNAVAILABLE
             chainPublishJobs[groupID]?.cancel()
-            val chainCandidate = cloneGroup(candidate)
-            publishGroupOnChain(chainCandidate) { result ->
-                if (BuildConfig.DEBUG) {
-                    if (result.isSuccess) Log.d("GroupListVM", "1v1 finalize SUCCEEDED group=${groupID.take(8)}")
-                    else Log.e("GroupListVM", "1v1 finalize FAILED group=${groupID.take(8)} error=${result.exceptionOrNull()?.message}")
-                }
+            chainPublishJobs.remove(groupID)
+            val deferred = kotlinx.coroutines.CompletableDeferred<Result<Unit>>()
+            publishGroupOnChain(cloneGroup(candidate)) { deferred.complete(it) }
+            val result = deferred.await()
+            if (result.isFailure) {
+                if (BuildConfig.DEBUG) Log.e("GroupListVM", "1v1 finalize chain publish FAILED group=${groupID.take(8)} error=${result.exceptionOrNull()?.message}")
+                return EpochTransitionResult.CHAIN_REJECTED
             }
-        } else if (currentGroup.isPublishedOnChain && onChainService != null) {
+            // publishGroupOnChain flips isPublishedOnChain=true on the stored
+            // group via updateGroup(...). Re-read the live group so subsequent
+            // local mutations build on that flag.
+            groups.find { it.id == groupID }?.let {
+                candidate.isPublishedOnChain = it.isPublishedOnChain
+            }
+        } else if (currentGroup.isPublishedOnChain) {
+            if (onChainService == null) return EpochTransitionResult.CHAIN_UNAVAILABLE
             chainPublishJobs[groupID]?.cancel()
+            chainPublishJobs.remove(groupID)
             val targetEpoch = candidate.epoch
             pendingTransitions[groupID] = PendingTransitionState.AwaitingChainConfirmation(targetEpoch)
             val baseline = chainBaseline[groupID]
@@ -1507,35 +1604,42 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             } else {
                 cloneGroup(currentGroup)
             }
-            val chainCandidate = cloneGroup(candidate)
-            if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain sync STARTING: baselineEpoch=${baselineGroup.epoch} targetEpoch=$targetEpoch baselineMembers=${baselineGroup.members.size} candidateMembers=${chainCandidate.members.size} hasStoredBaseline=${baseline != null}")
-            chainPublishJobs[groupID] = viewModelScope.launch {
-                if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain sync Task EXECUTING for epoch=$targetEpoch group=${groupID.take(8)}")
-                try {
-                    val result = publishMembershipUpdateIfNeeded(baselineGroup, chainCandidate)
-                    if (result.isSuccess) {
-                        chainBaseline[groupID] = ChainBaseline(
-                            chainCandidate.members.toList(), chainCandidate.epoch, chainCandidate.salt.copyOf()
-                        )
-                        if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain sync SUCCEEDED epoch=${chainCandidate.epoch} group=${groupID.take(8)}")
-                    } else {
-                        if (BuildConfig.DEBUG) Log.e("GroupListVM", "Chain sync FAILED epoch=${chainCandidate.epoch} baselineEpoch=${baselineGroup.epoch} group=${groupID.take(8)} error=${result.exceptionOrNull()?.message}")
-                    }
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain sync CANCELLED (superseded) epoch=${chainCandidate.epoch} group=${groupID.take(8)}")
-                } catch (e: Exception) {
-                    if (BuildConfig.DEBUG) Log.e("GroupListVM", "Chain sync FAILED epoch=${chainCandidate.epoch} baselineEpoch=${baselineGroup.epoch} group=${groupID.take(8)} error=${e.message}", e)
-                } finally {
-                    val current = pendingTransitions[groupID]
-                    if (current is PendingTransitionState.AwaitingChainConfirmation && current.targetEpoch == targetEpoch) {
-                        pendingTransitions[groupID] = PendingTransitionState.Idle
-                    }
-                    chainPublishJobs.remove(groupID)
-                }
+            if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain publish STARTING: baselineEpoch=${baselineGroup.epoch} targetEpoch=$targetEpoch baselineMembers=${baselineGroup.members.size} candidateMembers=${candidate.members.size} hasStoredBaseline=${baseline != null}")
+            val result = try {
+                publishMembershipUpdateIfNeeded(baselineGroup, candidate)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
             }
+            pendingTransitions[groupID] = PendingTransitionState.Idle
+            if (result.isFailure) {
+                if (BuildConfig.DEBUG) Log.e("GroupListVM", "Chain publish REJECTED epoch=${candidate.epoch} baselineEpoch=${baselineGroup.epoch} group=${groupID.take(8)} error=${result.exceptionOrNull()?.message}")
+                return EpochTransitionResult.CHAIN_REJECTED
+            }
+            chainBaseline[groupID] = ChainBaseline(
+                candidate.members.toList(), candidate.epoch, candidate.salt.copyOf()
+            )
+            candidate.isPublishedOnChain = currentGroup.isPublishedOnChain
+            if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain publish SUCCEEDED epoch=${candidate.epoch} group=${groupID.take(8)}")
         } else {
-            if (BuildConfig.DEBUG) Log.d("GroupListVM", "Chain sync SKIPPED: isPublishedOnChain=${currentGroup.isPublishedOnChain} onChainService=${onChainService != null} group=${groupID.take(8)}")
+            // Unpublished draft group (e.g. 1v1 creator waiting for peer).
+            // No chain authority yet — safe to mutate locally.
+            candidate.isPublishedOnChain = currentGroup.isPublishedOnChain
         }
+
+        // Chain confirmed (or not required). Capture snapshot of the pre-transition
+        // state for history/fork resolution, then persist the candidate locally.
+        val changeDesc = when (kind) {
+            is EpochTransitionKind.MemberAdd -> "Member added"
+            is EpochTransitionKind.MemberRemove -> "Member removed"
+            is EpochTransitionKind.KeyRotation -> "Key rotated"
+        }
+        captureEpochSnapshot(currentGroup, changeDesc)
+
+        groups[index] = candidate
+        try { store.saveGroup(candidate) } catch (_: Exception) { }
+        storeSalt(groupID, candidate.epoch, candidate.salt)
 
         // Sync transport and ensure subscription uses the latest key.
         // This must happen BEFORE the secure rekey / legacy blocks so A can
@@ -1628,33 +1732,20 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
             }
             if (BuildConfig.DEBUG) Log.d("Rekey", "COMPLETE groupID=${groupID.take(8)} epoch=${candidate.epoch} sent=$sentCount/${candidate.members.size}")
 
-            // Persist new group state SYNCHRONOUSLY before subscribing/publishing,
-            // so a crash can't leave us on a stale groupSecret while recipients
-            // have already installed the new one from the rekey envelope.
+            // Group state was persisted synchronously above (chain-first block).
+            // Persist the pending rekey so retry can re-deliver envelopes if a
+            // recipient is offline.
             val unackedKeys = candidate.members
                 .filter { !it.publicKeyCompressed.contentEquals(myLeaf.publicKeyCompressed) }
                 .map { it.publicKeyCompressed.toHex() }
-            kotlinx.coroutines.runBlocking {
-                try {
-                    store.saveGroup(candidate)
-                    store.savePendingRekey(groupID, candidate.epoch.toInt(), envelopeJson, unackedKeys, isRemovalEpoch = true)
-                } catch (_: Exception) { }
-            }
+            try {
+                store.savePendingRekey(groupID, candidate.epoch.toInt(), envelopeJson, unackedKeys, isRemovalEpoch = true)
+            } catch (_: Exception) { }
 
-        } else if (isRemoval) {
-            // Removals REQUIRE inbox delivery (secure rekey). If bundles are missing,
-            // the remover must first do a key rotation to distribute bundles.
-            if (BuildConfig.DEBUG) Log.w("GroupListVM", "Removal blocked: not all remaining members have transport bundles. Rotate key first.")
-            // Revert the optimistic local state
-            groups[index] = currentGroup
-            return EpochTransitionResult.BUNDLES_MISSING
         } else {
             // --- LEGACY FLOW: non-removal operations only (add member, key rotation) ---
             val update = buildStateUpdate(candidate, addedMembers, removedMemberKeys)
             broadcastStateUpdate(candidate, update, overrideKey = previousKey)
-            viewModelScope.launch {
-                try { store.saveGroup(candidate) } catch (_: Exception) { }
-            }
         }
 
         // Insert system message for the transition
@@ -2067,40 +2158,106 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                 try { store.saveGroup(group) } catch (_: Exception) { }
             }
         } else {
-            // Check if WE were removed before applying
+            // Normal case: update.epoch > group.epoch
             val selfRemoved = isSelfRemoved(update)
 
-            // Apply optimistically — sender already verified with chain.
-            // Verify in background for integrity, but don't block the update.
-            applyMemberDelta(update, group)
-            group.epoch = update.epoch
-            group.salt = update.salt
-            if (update.commitment != null) group.commitment = update.commitment
+            // Compute candidate state from the update without mutating `group` yet.
+            val candidate = cloneGroup(group)
+            applyMemberDelta(update, candidate)
+            candidate.epoch = update.epoch
+            candidate.salt = update.salt
+            if (update.commitment != null) candidate.commitment = update.commitment
+            else candidate.recomputeCommitment()
 
-            // Discard any superseded pending transition
-            val pt = pendingTransitions[groupID]
-            if (pt is PendingTransitionState.AwaitingChainConfirmation && update.epoch >= pt.targetEpoch) {
-                pendingTransitions[groupID] = PendingTransitionState.Idle
-            }
-
-            groups[index] = group
-            storeSalt(groupID, update.epoch, update.salt)
-
-            if (selfRemoved) {
-                if (!BuildConfig.DEBUG) transport.unsubscribe(group.topicTag)
-                val removerBlsHex = update.senderAttestation?.blsPubkey?.toHex()
-                val removerName = removerBlsHex?.let { memberDisplayName(update.senderAttestation!!.blsPubkey) } ?: "unknown"
-                group.removedByPubkeyHex = removerBlsHex
-                groups[index] = group
-                viewModelScope.launch { try { store.saveGroup(group) } catch (_: Exception) { } }
-                insertSystemMessage(groupID, "You were removed from this group by $removerName", "self-removed", update.epoch)
-            } else {
-                syncTransportAndSubscribe(group)
-                viewModelScope.launch {
-                    try { store.saveGroup(group) } catch (_: Exception) { }
+            // --- Chain-first verification: for on-chain groups, the contract is
+            // authoritative. Accept the update only if the chain's stored
+            // commitment at this epoch matches what we computed from the
+            // update. Reject otherwise — sender forged the update, raced
+            // ahead of chain confirmation, or our RPC hasn't caught up. The
+            // sender's retry will eventually reconcile.
+            if (candidate.isPublishedOnChain) {
+                val service = onChainService
+                if (service != null) {
+                    viewModelScope.launch {
+                        val chainMatches: Boolean = try {
+                            val entry = withContext(Dispatchers.IO) {
+                                service.fetchOnChainState(group.groupIDData)
+                            }
+                            val localCommitment = candidate.commitment
+                            localCommitment != null
+                                && entry.active
+                                && entry.epoch == update.epoch
+                                && entry.commitment.contentEquals(localCommitment)
+                        } catch (e: Exception) {
+                            if (BuildConfig.DEBUG) Log.w("GroupListVM", "Remote update DROPPED: chain fetch failed: ${e.message} group=${groupID.take(8)}")
+                            false
+                        }
+                        if (!chainMatches) {
+                            if (BuildConfig.DEBUG) Log.w("GroupListVM", "Remote update REJECTED: chain disagrees at epoch=${update.epoch} group=${groupID.take(8)}")
+                            return@launch
+                        }
+                        commitRemoteStateUpdate(groupID, candidate, update, selfRemoved)
+                    }
+                    return
                 }
-                insertSystemMessagesForStateUpdate(update, groupID)
+                // No contract service configured but group is published —
+                // refuse to apply unverified updates.
+                if (BuildConfig.DEBUG) Log.w("GroupListVM", "Remote update DROPPED: onChainService unavailable for published group=${groupID.take(8)}")
+                return
             }
+
+            // Unpublished draft group — no chain authority, commit directly.
+            commitRemoteStateUpdate(groupID, candidate, update, selfRemoved)
+        }
+    }
+
+    /**
+     * Install a chain-verified candidate state from an incoming SEPGroupStateUpdate.
+     * Called from [applyStateUpdate] after on-chain verification succeeds (or for
+     * unpublished groups that have no chain authority).
+     */
+    private fun commitRemoteStateUpdate(
+        groupID: String,
+        candidate: ChatGroup,
+        update: SEPGroupStateUpdate,
+        selfRemoved: Boolean
+    ) {
+        val idx = groups.indexOfFirst { it.id == groupID }
+        if (idx < 0) return
+        val stored = groups[idx]
+        // Re-check staleness: something could have advanced while awaiting chain.
+        if (update.epoch <= stored.epoch) return
+
+        // Discard any superseded pending transition
+        val pt = pendingTransitions[groupID]
+        if (pt is PendingTransitionState.AwaitingChainConfirmation && update.epoch >= pt.targetEpoch) {
+            pendingTransitions[groupID] = PendingTransitionState.Idle
+        }
+
+        // Refresh chain baseline to match the now-confirmed state.
+        if (candidate.isPublishedOnChain) {
+            chainBaseline[groupID] = ChainBaseline(
+                candidate.members.toList(), candidate.epoch, candidate.salt.copyOf()
+            )
+        }
+
+        groups[idx] = candidate
+        storeSalt(groupID, update.epoch, update.salt)
+
+        if (selfRemoved) {
+            if (!BuildConfig.DEBUG) transport.unsubscribe(candidate.topicTag)
+            val removerBlsHex = update.senderAttestation?.blsPubkey?.toHex()
+            val removerName = removerBlsHex?.let { memberDisplayName(update.senderAttestation!!.blsPubkey) } ?: "unknown"
+            candidate.removedByPubkeyHex = removerBlsHex
+            groups[idx] = candidate
+            viewModelScope.launch { try { store.saveGroup(candidate) } catch (_: Exception) { } }
+            insertSystemMessage(groupID, "You were removed from this group by $removerName", "self-removed", update.epoch)
+        } else {
+            syncTransportAndSubscribe(candidate)
+            viewModelScope.launch {
+                try { store.saveGroup(candidate) } catch (_: Exception) { }
+            }
+            insertSystemMessagesForStateUpdate(update, groupID)
         }
     }
 

--- a/clients/android/StellarChat/app/src/test/java/chat/onym/android/ChainStateRetryTest.kt
+++ b/clients/android/StellarChat/app/src/test/java/chat/onym/android/ChainStateRetryTest.kt
@@ -1,0 +1,128 @@
+package chat.onym.android
+
+import chat.onym.android.onchain.SEPCommitmentEntry
+import chat.onym.android.onchain.fetchOnChainStateAwaitingEpoch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Regression tests for the chain-first receive-path retry helper. The
+ * receive path rejects an update when the on-chain commitment at the
+ * update's epoch disagrees with what the envelope claims. Without bounded
+ * retry, an RPC node that trails the network by one ledger close would
+ * cause a legitimate update to be silently dropped. These tests lock in
+ * the retry semantics so a future refactor can't regress to single-shot
+ * polling.
+ */
+class ChainStateRetryTest {
+
+    private fun entry(epoch: Long, active: Boolean = true): SEPCommitmentEntry =
+        SEPCommitmentEntry(
+            commitment = ByteArray(32) { it.toByte() },
+            epoch = epoch,
+            timestamp = 0L,
+            tier = 0,
+            active = active
+        )
+
+    @Test
+    fun returnsImmediately_whenChainAlreadyAtExpectedEpoch() = runTest {
+        var calls = 0
+        val result = fetchOnChainStateAwaitingEpoch(
+            fetch = { calls++; entry(epoch = 5) },
+            expectedEpoch = 5,
+            maxAttempts = 4,
+            initialDelayMs = 0L
+        )
+        assertEquals(5L, result.epoch)
+        assertEquals("must not retry when first fetch already satisfies expected epoch", 1, calls)
+    }
+
+    @Test
+    fun retriesUntilEpochAdvances_simulatingRpcLag() = runTest {
+        val epochsSeen = mutableListOf<Long>()
+        val epochsToReturn = listOf(3L, 3L, 5L)
+        var attempt = 0
+        val result = fetchOnChainStateAwaitingEpoch(
+            fetch = {
+                val e = epochsToReturn[attempt++]
+                epochsSeen.add(e)
+                entry(epoch = e)
+            },
+            expectedEpoch = 5,
+            maxAttempts = 4,
+            initialDelayMs = 0L
+        )
+        assertEquals(5L, result.epoch)
+        assertEquals(listOf(3L, 3L, 5L), epochsSeen)
+    }
+
+    @Test
+    fun returnsLastStaleEntry_whenChainNeverAdvancesWithinBudget() = runTest {
+        var calls = 0
+        val result = fetchOnChainStateAwaitingEpoch(
+            fetch = { calls++; entry(epoch = 3) },
+            expectedEpoch = 5,
+            maxAttempts = 3,
+            initialDelayMs = 0L
+        )
+        // Helper returns the last seen entry so the caller can still decide
+        // based on commitment match — but the trailing epoch will cause the
+        // caller's chain-match check to fail, dropping the update.
+        assertEquals(3L, result.epoch)
+        assertEquals(3, calls)
+    }
+
+    @Test
+    fun rethrowsWhenEveryAttemptFails() = runTest {
+        var calls = 0
+        try {
+            fetchOnChainStateAwaitingEpoch(
+                fetch = { calls++; throw IOException("rpc down") },
+                expectedEpoch = 5,
+                maxAttempts = 3,
+                initialDelayMs = 0L
+            )
+            fail("expected IOException after all attempts fail")
+        } catch (e: IOException) {
+            assertEquals("rpc down", e.message)
+        }
+        assertEquals(3, calls)
+    }
+
+    @Test
+    fun returnsSuccessfulEntry_evenAfterTransientErrors() = runTest {
+        var attempt = 0
+        val result = fetchOnChainStateAwaitingEpoch(
+            fetch = {
+                attempt++
+                if (attempt == 1) throw IOException("transient")
+                entry(epoch = 7)
+            },
+            expectedEpoch = 7,
+            maxAttempts = 4,
+            initialDelayMs = 0L
+        )
+        assertEquals(7L, result.epoch)
+        assertEquals(2, attempt)
+    }
+
+    @Test
+    fun rejectsInvalidMaxAttempts() = runTest {
+        try {
+            fetchOnChainStateAwaitingEpoch(
+                fetch = { entry(epoch = 5) },
+                expectedEpoch = 5,
+                maxAttempts = 0,
+                initialDelayMs = 0L
+            )
+            fail("expected IllegalArgumentException for maxAttempts=0")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("maxAttempts"))
+        }
+    }
+}

--- a/clients/android/StellarChat/app/src/test/java/chat/onym/android/ChainStateRetryTest.kt
+++ b/clients/android/StellarChat/app/src/test/java/chat/onym/android/ChainStateRetryTest.kt
@@ -125,4 +125,34 @@ class ChainStateRetryTest {
             assertTrue(e.message!!.contains("maxAttempts"))
         }
     }
+
+    /**
+     * Production default is 4 attempts with initialDelayMs=250, so the
+     * expected sleep schedule between attempts is 250→500→1000 ms. Under
+     * [runTest] the `delay` calls advance virtual time deterministically,
+     * so we can assert the total elapsed virtual time without wall-clocking
+     * 1.75 s. Locks in exponential backoff in case someone tweaks the
+     * multiplier.
+     */
+    @Test
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    fun appliesExponentialBackoff_betweenAttempts() = runTest {
+        var attempt = 0
+        val startVirtual = testScheduler.currentTime
+        fetchOnChainStateAwaitingEpoch(
+            // Force three retries: return stale epoch on attempts 1..3, then
+            // the expected epoch on attempt 4 so we exercise all three sleeps.
+            fetch = {
+                attempt++
+                entry(epoch = if (attempt == 4) 5L else 3L)
+            },
+            expectedEpoch = 5,
+            maxAttempts = 4,
+            initialDelayMs = 250L
+        )
+        val elapsed = testScheduler.currentTime - startVirtual
+        // 250 + 500 + 1000 = 1750 ms of virtual time spent sleeping.
+        assertEquals(1750L, elapsed)
+        assertEquals(4, attempt)
+    }
 }

--- a/clients/ios/StellarChat/StellarChat/Models/OnChainService.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/OnChainService.swift
@@ -390,6 +390,54 @@ actor OnChainService {
         try await withRetry { try await self.contractClient.getState(groupID: groupIDData) }
     }
 
+    /// Bounded retry for on-chain state reads when the RPC node is expected
+    /// to trail the network briefly. Used on the receive path: when a peer
+    /// broadcasts an update for epoch N, our RPC may not yet have indexed
+    /// the ledger close that committed epoch N to the contract. Polling
+    /// once and rejecting on mismatch would silently drop a legitimate
+    /// update; polling forever risks blocking on a genuinely-missing
+    /// commitment.
+    ///
+    /// Returns the most recent entry seen — even when its epoch still
+    /// trails `expectedEpoch` after exhausting `maxAttempts` — so the
+    /// caller can still compare the stale entry and make a chain-authority
+    /// decision. Re-throws the last error only if every fetch attempt
+    /// threw. Extracted as a static helper (delegating `fetch`) so the
+    /// retry semantics can be unit-tested without a live RPC.
+    static func fetchOnChainStateAwaitingEpoch(
+        fetch: () async throws -> SEPCommitmentEntry,
+        expectedEpoch: UInt64,
+        maxAttempts: Int = 4,
+        initialDelayMs: UInt64 = 250,
+        sleep: (UInt64) async -> Void = { ms in
+            try? await Task.sleep(nanoseconds: ms * 1_000_000)
+        }
+    ) async throws -> SEPCommitmentEntry {
+        precondition(maxAttempts >= 1, "maxAttempts must be >= 1")
+        var delayMs: UInt64 = initialDelayMs
+        var lastEntry: SEPCommitmentEntry?
+        var lastError: Error?
+        for attempt in 0..<maxAttempts {
+            do {
+                let entry = try await fetch()
+                lastEntry = entry
+                if entry.epoch >= expectedEpoch { return entry }
+            } catch {
+                lastError = error
+            }
+            if attempt < maxAttempts - 1 {
+                await sleep(delayMs)
+                delayMs *= 2
+            }
+        }
+        if let entry = lastEntry { return entry }
+        throw lastError ?? NSError(
+            domain: "OnChainService",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "fetchOnChainState failed after \(maxAttempts) attempts"]
+        )
+    }
+
     // MARK: - Democracy (#26)
 
     /// Delta kind for a Democracy update (add/remove/kick), matching the

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -1051,7 +1051,17 @@ final class AppState {
         }
         captureEpochSnapshot(group: currentGroup, changeDescription: snapshotDescription)
 
-        groups[index] = candidate
+        // Re-lookup index: the chain-publish awaits above can suspend long enough
+        // for `groups` to be mutated (a concurrent apply/fork/leave can shift or
+        // remove entries), so the `index` captured before the await may now point
+        // at a different group or be out of bounds.
+        guard let liveIndex = groups.firstIndex(where: { $0.id == groupID }) else {
+            #if DEBUG
+            print("[EpochTransition] Group \(groupID.prefix(8)) disappeared during chain publish; dropping transition")
+            #endif
+            return .chainRejected(reason: "Group removed during chain publish")
+        }
+        groups[liveIndex] = candidate
         store.saveGroup(candidate)
         storeSalt(groupID: groupID, epoch: candidate.epoch, salt: candidate.salt)
 
@@ -1871,7 +1881,16 @@ final class AppState {
                 try? group.recomputeCommitment()
             }
 
-            groups[index] = group
+            // Re-lookup: the fork-resolution await above can suspend long enough
+            // for `groups` to be mutated, so `index` captured before the await
+            // may now point at a different entry or be out of bounds.
+            guard let liveIndex = groups.firstIndex(where: { $0.id == groupID }) else {
+                #if DEBUG
+                print("[AppState] Group \(groupID.prefix(8)) disappeared during fork resolution; dropping update")
+                #endif
+                return
+            }
+            groups[liveIndex] = group
             store.saveGroup(group)
             storeSalt(groupID: groupID, epoch: group.epoch, salt: group.salt)
             subscribeGroup(group)
@@ -1902,7 +1921,17 @@ final class AppState {
             // update, raced ahead of chain confirmation, or we're querying
             // an RPC that hasn't caught up. The sender's ack/retry will
             // eventually reconcile via a fresh broadcast or chain resync.
-            if candidate.isPublishedOnChain, let service = onChainService {
+            if candidate.isPublishedOnChain {
+                guard let service = onChainService else {
+                    // Published group with no contract service configured —
+                    // refuse to apply unverified updates. Mirrors the Android
+                    // guard in GroupListViewModel.applyStateUpdate so a
+                    // transiently-nil service can't become a governance bypass.
+                    #if DEBUG
+                    print("[AppState] Remote update DROPPED: onChainService unavailable for published group=\(groupID.prefix(8))")
+                    #endif
+                    return
+                }
                 do {
                     let entry = try await fetchOnChainStateAwaitingEpoch(
                         service: service,
@@ -1954,7 +1983,17 @@ final class AppState {
                 )
             }
 
-            groups[index] = group
+            // Re-lookup: the chain-state await above can suspend long enough for
+            // `groups` to be mutated (concurrent apply/fork/leave can shift or
+            // remove entries), so the `index` captured before the await may
+            // now point at a different group or be out of bounds.
+            guard let liveIndex = groups.firstIndex(where: { $0.id == groupID }) else {
+                #if DEBUG
+                print("[AppState] Group \(groupID.prefix(8)) disappeared during chain verification; dropping update")
+                #endif
+                return
+            }
+            groups[liveIndex] = group
             store.saveGroup(group)
             storeSalt(groupID: groupID, epoch: update.epoch, salt: update.salt)
 
@@ -2342,7 +2381,13 @@ final class AppState {
         // (sender hasn't published, contract rejected their proof, or we're
         // querying a lagging RPC), refuse to install fresh secrets — otherwise
         // we'd rotate away from a key the rest of the group still uses.
-        if updatedGroup.isPublishedOnChain, let service = onChainService {
+        if updatedGroup.isPublishedOnChain {
+            guard let service = onChainService else {
+                #if DEBUG
+                print("[Rekey] DROPPED: onChainService unavailable for published group=\(groupIDHex.prefix(8))")
+                #endif
+                return
+            }
             do {
                 let entry = try await fetchOnChainStateAwaitingEpoch(
                     service: service,
@@ -2382,7 +2427,16 @@ final class AppState {
         }
         processTransportBundle(envelope.senderBundle, groupID: groupIDHex)
 
-        groups[index] = group
+        // Re-lookup: the chain-state await above can suspend long enough for
+        // `groups` to be mutated, so `index` captured before the await may now
+        // point at a different group or be out of bounds.
+        guard let liveIndex = groups.firstIndex(where: { $0.id == groupIDHex }) else {
+            #if DEBUG
+            print("[Rekey] Group \(groupIDHex.prefix(8)) disappeared during chain verification; dropping envelope")
+            #endif
+            return
+        }
+        groups[liveIndex] = group
         store.saveGroup(group)
         storeSalt(groupID: groupIDHex, epoch: envelope.epoch, salt: envelope.salt)
 

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -922,6 +922,17 @@ final class AppState {
         print("[AppState] Removal flow: useSecureRekey=\(useSecureRekey) isRemoval=\(isRemoval) bundles=\(bundleKeys) members=\(memberKeys)")
         #endif
 
+        // Removals REQUIRE inbox delivery (secure rekey). If bundles are missing,
+        // bail before advancing chain state — otherwise chain epoch advances
+        // while peers can't follow. Caller must rotate the key first to
+        // distribute bundles.
+        if isRemoval && !useSecureRekey {
+            #if DEBUG
+            print("[EpochTransition] Removal blocked pre-chain: not all remaining members have transport bundles. Rotate key first.")
+            #endif
+            return .bundlesMissing
+        }
+
         // If secure rekey, apply fresh groupSecret + salt now so the chain publish
         // uses the final commitment (one publish instead of two).
         // Save pre-rekey candidate for broadcasting on the old channel later.
@@ -952,7 +963,81 @@ final class AppState {
             candidate = rekeyCandidate
         }
 
-        // Capture epoch snapshot BEFORE persisting the new state
+        // --- Chain-first: confirm on-chain BEFORE mutating local state ---
+        // Any group whose state is tracked on-chain MUST have its next-epoch
+        // commitment accepted by the contract before we persist, subscribe,
+        // or broadcast. If the contract rejects (e.g. Oligarchy non-admin
+        // removal, proof mismatch, stale baseline), we return without
+        // touching local state so sender and peers stay consistent with
+        // chain authority.
+        #if DEBUG
+        print("[EpochTransition] Chain-first check: isPublishedOnChain=\(currentGroup.isPublishedOnChain) isOneOnOneFinalize=\(isOneOnOneFinalize) onChainService=\(onChainService != nil) group=\(groupID.prefix(8)) newEpoch=\(candidate.epoch)")
+        #endif
+        if isOneOnOneFinalize {
+            guard onChainService != nil else {
+                return .chainUnavailable
+            }
+            chainPublishTasks[groupID]?.cancel()
+            chainPublishTasks[groupID] = nil
+            do {
+                try await publishGroupOnChain(candidate)
+                // publishGroupOnChain flips isPublishedOnChain=true on the
+                // stored group via updateGroup(...). Re-read the live group
+                // so subsequent local mutations build on that flag.
+                if let refreshed = groups.first(where: { $0.id == groupID }) {
+                    candidate.isPublishedOnChain = refreshed.isPublishedOnChain
+                }
+            } catch {
+                #if DEBUG
+                print("[EpochTransition] 1v1 finalize chain publish FAILED group=\(groupID.prefix(8)) error=\(error)")
+                #endif
+                return .chainRejected(reason: error.localizedDescription)
+            }
+        } else if currentGroup.isPublishedOnChain {
+            guard onChainService != nil else {
+                return .chainUnavailable
+            }
+            chainPublishTasks[groupID]?.cancel()
+            chainPublishTasks[groupID] = nil
+            let targetEpoch = candidate.epoch
+            pendingTransitions[groupID] = .awaitingChainConfirmation(targetEpoch: targetEpoch)
+            let baseline = chainBaseline[groupID]
+                ?? (members: currentGroup.members, epoch: currentGroup.epoch, salt: currentGroup.salt)
+            #if DEBUG
+            print("[EpochTransition] Chain publish STARTING: baselineEpoch=\(baseline.epoch) targetEpoch=\(targetEpoch) baselineMembers=\(baseline.members.count) candidateMembers=\(candidate.members.count) hasStoredBaseline=\(chainBaseline[groupID] != nil)")
+            #endif
+            do {
+                try await publishMemberUpdate(
+                    group: candidate,
+                    oldMembers: baseline.members,
+                    oldEpoch: baseline.epoch,
+                    oldSalt: baseline.salt
+                )
+                chainBaseline[groupID] = (
+                    members: candidate.members,
+                    epoch: candidate.epoch,
+                    salt: candidate.salt
+                )
+                pendingTransitions[groupID] = .idle
+                #if DEBUG
+                print("[EpochTransition] Chain publish SUCCEEDED epoch=\(candidate.epoch) group=\(groupID.prefix(8))")
+                #endif
+            } catch {
+                pendingTransitions[groupID] = .idle
+                #if DEBUG
+                print("[EpochTransition] Chain publish REJECTED epoch=\(candidate.epoch) baselineEpoch=\(baseline.epoch) group=\(groupID.prefix(8)) error=\(error)")
+                #endif
+                return .chainRejected(reason: error.localizedDescription)
+            }
+            candidate.isPublishedOnChain = currentGroup.isPublishedOnChain
+        } else {
+            // Unpublished draft group (e.g. 1v1 creator waiting for peer).
+            // No chain authority yet — safe to mutate locally.
+            candidate.isPublishedOnChain = currentGroup.isPublishedOnChain
+        }
+
+        // Chain confirmed (or not required). Capture snapshot of the pre-transition
+        // state for history/fork resolution, then persist the candidate locally.
         let snapshotDescription: String
         switch kind {
         case .memberAdd(let member):
@@ -966,92 +1051,9 @@ final class AppState {
         }
         captureEpochSnapshot(group: currentGroup, changeDescription: snapshotDescription)
 
-        // --- Persist locally FIRST (optimistic), then sync chain in background ---
-        candidate.isPublishedOnChain = currentGroup.isPublishedOnChain
         groups[index] = candidate
         store.saveGroup(candidate)
         storeSalt(groupID: groupID, epoch: candidate.epoch, salt: candidate.salt)
-
-        // --- Async chain sync (non-blocking, coalesced) ---
-        // Launch BEFORE the Nostr broadcast so the chain publish isn't gated
-        // by relay round-trips. Cancel any in-flight publish and restart with
-        // the latest state.
-        #if DEBUG
-        print("[EpochTransition] Chain sync check: isPublishedOnChain=\(currentGroup.isPublishedOnChain) onChainService=\(onChainService != nil) group=\(groupID.prefix(8)) newEpoch=\(candidate.epoch)")
-        #endif
-        if isOneOnOneFinalize, onChainService != nil {
-            chainPublishTasks[groupID]?.cancel()
-            let chainCandidate = candidate
-            chainPublishTasks[groupID] = Task {
-                defer {
-                    if self.chainPublishTasks[groupID]?.isCancelled != false {
-                        self.chainPublishTasks[groupID] = nil
-                    }
-                }
-                do {
-                    try await self.publishGroupOnChain(chainCandidate)
-                } catch is CancellationError {
-                    #if DEBUG
-                    print("[EpochTransition] 1v1 finalize CANCELLED group=\(groupID.prefix(8))")
-                    #endif
-                } catch {
-                    #if DEBUG
-                    print("[EpochTransition] 1v1 finalize FAILED group=\(groupID.prefix(8)) error=\(error)")
-                    #endif
-                }
-            }
-        } else if currentGroup.isPublishedOnChain, onChainService != nil {
-            chainPublishTasks[groupID]?.cancel()
-            let targetEpoch = candidate.epoch
-            pendingTransitions[groupID] = .awaitingChainConfirmation(targetEpoch: targetEpoch)
-            let chainCandidate = candidate
-            let baseline = chainBaseline[groupID]
-                ?? (members: currentGroup.members, epoch: currentGroup.epoch, salt: currentGroup.salt)
-            #if DEBUG
-            print("[EpochTransition] Chain sync STARTING: baselineEpoch=\(baseline.epoch) targetEpoch=\(targetEpoch) baselineMembers=\(baseline.members.count) candidateMembers=\(chainCandidate.members.count) hasStoredBaseline=\(chainBaseline[groupID] != nil)")
-            #endif
-            chainPublishTasks[groupID] = Task {
-                #if DEBUG
-                print("[EpochTransition] Chain sync Task EXECUTING for epoch=\(targetEpoch) group=\(groupID.prefix(8))")
-                #endif
-                defer {
-                    if case .awaitingChainConfirmation(let t) = self.pendingTransitions[groupID], t == targetEpoch {
-                        self.pendingTransitions[groupID] = .idle
-                    }
-                    if self.chainPublishTasks[groupID]?.isCancelled != false {
-                        self.chainPublishTasks[groupID] = nil
-                    }
-                }
-                do {
-                    try await self.publishMemberUpdate(
-                        group: chainCandidate,
-                        oldMembers: baseline.members,
-                        oldEpoch: baseline.epoch,
-                        oldSalt: baseline.salt
-                    )
-                    self.chainBaseline[groupID] = (
-                        members: chainCandidate.members,
-                        epoch: chainCandidate.epoch,
-                        salt: chainCandidate.salt
-                    )
-                    #if DEBUG
-                    print("[EpochTransition] Chain sync SUCCEEDED epoch=\(chainCandidate.epoch) group=\(groupID.prefix(8))")
-                    #endif
-                } catch is CancellationError {
-                    #if DEBUG
-                    print("[EpochTransition] Chain sync CANCELLED (superseded) epoch=\(chainCandidate.epoch) group=\(groupID.prefix(8))")
-                    #endif
-                } catch {
-                    #if DEBUG
-                    print("[EpochTransition] Chain sync FAILED epoch=\(chainCandidate.epoch) baselineEpoch=\(baseline.epoch) group=\(groupID.prefix(8)) error=\(error)")
-                    #endif
-                }
-            }
-        } else {
-            #if DEBUG
-            print("[EpochTransition] Chain sync SKIPPED: isPublishedOnChain=\(currentGroup.isPublishedOnChain) onChainService=\(onChainService != nil) group=\(groupID.prefix(8))")
-            #endif
-        }
 
         // Sync transport and ensure subscription uses the latest key.
         // This must happen BEFORE the secure rekey / legacy blocks so A can
@@ -1183,16 +1185,6 @@ final class AppState {
                 },
                 isRemovalEpoch: true
             )
-        } else if isRemoval {
-            // Removals REQUIRE inbox delivery (secure rekey). If bundles are missing,
-            // the remover must first do a key rotation to distribute bundles.
-            #if DEBUG
-            print("[EpochTransition] Removal blocked: not all remaining members have transport bundles. Rotate key first.")
-            #endif
-            // Revert the optimistic local state
-            groups[index] = currentGroup
-            store.saveGroup(currentGroup)
-            return .bundlesMissing
         } else {
             // --- LEGACY FLOW: non-removal operations only (add member, key rotation) ---
             let update = buildStateUpdate(
@@ -1870,16 +1862,54 @@ final class AppState {
             #endif
         } else {
             // Normal case: update.epoch > group.epoch
-            // Apply optimistically — sender already verified with chain.
             // Check if WE were removed before applying
             let selfRemoved = isSelfRemoved(in: update)
 
-            applyMemberDelta(update, to: &group)
-            group.epoch = update.epoch
-            group.salt = update.salt
+            // Compute candidate state from the update without mutating `group` yet.
+            var candidate = group
+            applyMemberDelta(update, to: &candidate)
+            candidate.epoch = update.epoch
+            candidate.salt = update.salt
             if let commitment = update.commitment {
-                group.commitment = commitment
+                candidate.commitment = commitment
+            } else {
+                try? candidate.recomputeCommitment()
             }
+
+            // --- Chain-first verification: for on-chain groups, the contract
+            // is authoritative. Accept the update only if the chain's
+            // stored commitment at this epoch matches what we computed from
+            // the update. Reject otherwise — the sender either forged the
+            // update, raced ahead of chain confirmation, or we're querying
+            // an RPC that hasn't caught up. The sender's ack/retry will
+            // eventually reconcile via a fresh broadcast or chain resync.
+            if candidate.isPublishedOnChain, let service = onChainService {
+                do {
+                    let entry = try await service.fetchOnChainState(groupIDData: group.groupIDData)
+                    let chainMatches: Bool
+                    if let candCommitment = candidate.commitment {
+                        chainMatches = entry.active
+                            && entry.epoch == update.epoch
+                            && entry.commitment == candCommitment
+                    } else {
+                        chainMatches = false
+                    }
+                    if !chainMatches {
+                        #if DEBUG
+                        print("[AppState] Remote update REJECTED: chain epoch=\(entry.epoch) active=\(entry.active) updateEpoch=\(update.epoch) group=\(groupID.prefix(8))")
+                        #endif
+                        return
+                    }
+                } catch {
+                    #if DEBUG
+                    print("[AppState] Remote update DROPPED: chain fetch failed: \(error) group=\(groupID.prefix(8))")
+                    #endif
+                    return
+                }
+            }
+
+            // Chain confirmed (or group is unpublished draft). Commit candidate.
+            group = candidate
             if selfRemoved {
                 group.removedByPubkeyHex = update.senderAttestation.map {
                     $0.blsPubkey.map { String(format: "%02x", $0) }.joined()
@@ -1890,6 +1920,15 @@ final class AppState {
             if case .awaitingChainConfirmation(let target) = pendingTransitions[groupID],
                update.epoch >= target {
                 pendingTransitions[groupID] = .idle
+            }
+
+            // Update chain baseline to reflect the chain-confirmed state.
+            if group.isPublishedOnChain {
+                chainBaseline[groupID] = (
+                    members: group.members,
+                    epoch: group.epoch,
+                    salt: group.salt
+                )
             }
 
             groups[index] = group
@@ -2209,7 +2248,7 @@ final class AppState {
     }
 
     /// Apply a secure rekey envelope received via inbox. Installs fresh groupSecret/salt and migrates topic.
-    func applyRekeyEnvelope(_ envelope: SEPRekeyEnvelope) {
+    func applyRekeyEnvelope(_ envelope: SEPRekeyEnvelope) async {
         let groupIDHex = envelope.groupID.map { String(format: "%02x", $0) }.joined()
         guard let index = groups.firstIndex(where: { $0.id == groupIDHex }) else { return }
         var group = groups[index]
@@ -2271,7 +2310,44 @@ final class AppState {
         // survive epoch transitions (member add/remove/key rotation).
         updatedGroup.adminPubkeys = group.adminPubkeys
         updatedGroup.groupType = group.groupType
+        // Recompute commitment locally from final member set + salt so we can
+        // cross-check against what the chain says before installing anything.
+        try? updatedGroup.recomputeCommitment()
+
+        // --- Chain-first verification: on-chain state must match the envelope's
+        // claimed new commitment at the new epoch. If the chain disagrees
+        // (sender hasn't published, contract rejected their proof, or we're
+        // querying a lagging RPC), refuse to install fresh secrets — otherwise
+        // we'd rotate away from a key the rest of the group still uses.
+        if updatedGroup.isPublishedOnChain, let service = onChainService {
+            do {
+                let entry = try await service.fetchOnChainState(groupIDData: envelope.groupID)
+                let chainMatches: Bool = {
+                    guard let local = updatedGroup.commitment else { return false }
+                    return entry.active && entry.epoch == envelope.epoch && entry.commitment == local
+                }()
+                if !chainMatches {
+                    #if DEBUG
+                    print("[Rekey] REJECTED: chain epoch=\(entry.epoch) active=\(entry.active) envelopeEpoch=\(envelope.epoch) group=\(groupIDHex.prefix(8))")
+                    #endif
+                    return
+                }
+            } catch {
+                #if DEBUG
+                print("[Rekey] DROPPED: chain fetch failed: \(error) group=\(groupIDHex.prefix(8))")
+                #endif
+                return
+            }
+        }
+
         group = updatedGroup
+        if group.isPublishedOnChain {
+            chainBaseline[groupIDHex] = (
+                members: group.members,
+                epoch: group.epoch,
+                salt: group.salt
+            )
+        }
 
         // Update transport bundles from envelope
         for bundle in envelope.memberBundles {
@@ -3462,7 +3538,7 @@ final class AppState {
         invitationTransport.onRekeyEnvelope = { [weak self] envelope in
             Task { @MainActor in
                 guard let self else { return }
-                self.applyRekeyEnvelope(envelope)
+                await self.applyRekeyEnvelope(envelope)
             }
         }
 

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -1742,6 +1742,25 @@ final class AppState {
         )
     }
 
+    /// Fetch on-chain state with a bounded retry for RPC lag. Thin wrapper
+    /// around the top-level `fetchOnChainStateAwaitingEpoch` helper
+    /// (extracted so the retry logic can be unit-tested without
+    /// instantiating the full AppState).
+    private func fetchOnChainStateAwaitingEpoch(
+        service: OnChainService,
+        groupIDData: Data,
+        expectedEpoch: UInt64,
+        maxAttempts: Int = 4,
+        initialDelayMs: UInt64 = 250
+    ) async throws -> SEPCommitmentEntry {
+        try await OnChainService.fetchOnChainStateAwaitingEpoch(
+            fetch: { try await service.fetchOnChainState(groupIDData: groupIDData) },
+            expectedEpoch: expectedEpoch,
+            maxAttempts: maxAttempts,
+            initialDelayMs: initialDelayMs
+        )
+    }
+
     /// Apply a received state update to a local group.
     /// Handles three cases:
     /// Apply a received state update. For published groups, chain-confirm-first:
@@ -1885,7 +1904,11 @@ final class AppState {
             // eventually reconcile via a fresh broadcast or chain resync.
             if candidate.isPublishedOnChain, let service = onChainService {
                 do {
-                    let entry = try await service.fetchOnChainState(groupIDData: group.groupIDData)
+                    let entry = try await fetchOnChainStateAwaitingEpoch(
+                        service: service,
+                        groupIDData: group.groupIDData,
+                        expectedEpoch: update.epoch
+                    )
                     let chainMatches: Bool
                     if let candCommitment = candidate.commitment {
                         chainMatches = entry.active
@@ -2321,7 +2344,11 @@ final class AppState {
         // we'd rotate away from a key the rest of the group still uses.
         if updatedGroup.isPublishedOnChain, let service = onChainService {
             do {
-                let entry = try await service.fetchOnChainState(groupIDData: envelope.groupID)
+                let entry = try await fetchOnChainStateAwaitingEpoch(
+                    service: service,
+                    groupIDData: envelope.groupID,
+                    expectedEpoch: envelope.epoch
+                )
                 let chainMatches: Bool = {
                     guard let local = updatedGroup.commitment else { return false }
                     return entry.active && entry.epoch == envelope.epoch && entry.commitment == local

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -1061,6 +1061,15 @@ final class AppState {
             #endif
             return .chainRejected(reason: "Group removed during chain publish")
         }
+        // Re-check staleness: a remote state update or rekey may have advanced
+        // the stored epoch past our candidate while we awaited chain publish.
+        // Overwriting with an older candidate would revert the group.
+        guard candidate.epoch >= groups[liveIndex].epoch else {
+            #if DEBUG
+            print("[EpochTransition] Local transition stale after chain publish: candidateEpoch=\(candidate.epoch) storedEpoch=\(groups[liveIndex].epoch) group=\(groupID.prefix(8))")
+            #endif
+            return .chainRejected(reason: "Concurrent remote update raced local transition")
+        }
         groups[liveIndex] = candidate
         store.saveGroup(candidate)
         storeSalt(groupID: groupID, epoch: candidate.epoch, salt: candidate.salt)
@@ -1890,6 +1899,15 @@ final class AppState {
                 #endif
                 return
             }
+            // Re-check staleness: a subsequent update (or secure rekey) may have
+            // advanced the stored epoch past our fork-resolved epoch while we
+            // awaited the chain. Committing now would revert the group.
+            guard group.epoch >= groups[liveIndex].epoch else {
+                #if DEBUG
+                print("[AppState] Fork resolution stale after await: resolvedEpoch=\(group.epoch) storedEpoch=\(groups[liveIndex].epoch) group=\(groupID.prefix(8))")
+                #endif
+                return
+            }
             groups[liveIndex] = group
             store.saveGroup(group)
             storeSalt(groupID: groupID, epoch: group.epoch, salt: group.salt)
@@ -1990,6 +2008,17 @@ final class AppState {
             guard let liveIndex = groups.firstIndex(where: { $0.id == groupID }) else {
                 #if DEBUG
                 print("[AppState] Group \(groupID.prefix(8)) disappeared during chain verification; dropping update")
+                #endif
+                return
+            }
+            // Re-check staleness against the *current* stored epoch: a second
+            // update for the same group may have landed while we awaited chain
+            // verification, advancing the stored epoch past ours. Committing
+            // now would revert the group to an older state. Mirrors the Android
+            // `commitRemoteStateUpdate` recheck.
+            guard update.epoch > groups[liveIndex].epoch else {
+                #if DEBUG
+                print("[AppState] Remote update stale after await: updateEpoch=\(update.epoch) storedEpoch=\(groups[liveIndex].epoch) group=\(groupID.prefix(8))")
                 #endif
                 return
             }
@@ -2433,6 +2462,16 @@ final class AppState {
         guard let liveIndex = groups.firstIndex(where: { $0.id == groupIDHex }) else {
             #if DEBUG
             print("[Rekey] Group \(groupIDHex.prefix(8)) disappeared during chain verification; dropping envelope")
+            #endif
+            return
+        }
+        // Re-check staleness: a second rekey for the same group may have
+        // arrived and committed while we were awaiting chain confirmation.
+        // Installing older secrets now would revert everyone past the newer
+        // epoch. Mirrors the Android `commitRemoteRekey` recheck.
+        guard envelope.epoch > groups[liveIndex].epoch else {
+            #if DEBUG
+            print("[Rekey] DROPPED stale envelope after await: envelopeEpoch=\(envelope.epoch) storedEpoch=\(groups[liveIndex].epoch) group=\(groupIDHex.prefix(8))")
             #endif
             return
         }

--- a/clients/ios/StellarChat/StellarChatTests/ModelsTests.swift
+++ b/clients/ios/StellarChat/StellarChatTests/ModelsTests.swift
@@ -328,4 +328,24 @@ struct ChainStateRetryTests {
         #expect(result.epoch == 7)
         #expect(attempt == 2)
     }
+
+    @Test("applies exponential backoff between attempts (250→500→1000ms)")
+    func exponentialBackoffTiming() async throws {
+        var sleeps: [UInt64] = []
+        var attempt = 0
+        _ = try await OnChainService.fetchOnChainStateAwaitingEpoch(
+            fetch: {
+                attempt += 1
+                // Force retry: return stale epoch on every attempt until the last.
+                return self.entry(epoch: attempt == 4 ? 5 : 3)
+            },
+            expectedEpoch: 5,
+            maxAttempts: 4,
+            initialDelayMs: 250,
+            sleep: { ms in sleeps.append(ms) }
+        )
+        // Three sleeps between four attempts: 250ms, 500ms, 1000ms.
+        // The sleep closure receives delay in milliseconds.
+        #expect(sleeps == [250, 500, 1000])
+    }
 }

--- a/clients/ios/StellarChat/StellarChatTests/ModelsTests.swift
+++ b/clients/ios/StellarChat/StellarChatTests/ModelsTests.swift
@@ -213,3 +213,119 @@ struct EpochSnapshotTests {
         #expect(snapshot.changeDescription == "Member added")
     }
 }
+
+// MARK: - OnChainService.fetchOnChainStateAwaitingEpoch
+
+/// Regression tests for the chain-first receive-path retry helper. The
+/// receive path rejects an update when the on-chain commitment at the
+/// update's epoch disagrees with what the envelope claims. Without bounded
+/// retry, an RPC node that trails the network by one ledger close would
+/// cause a legitimate update to be silently dropped. These tests lock in
+/// the retry semantics so a future refactor can't regress to single-shot
+/// polling.
+@Suite("OnChainService.fetchOnChainStateAwaitingEpoch")
+struct ChainStateRetryTests {
+
+    private func entry(epoch: UInt64, active: Bool = true) -> SEPCommitmentEntry {
+        SEPCommitmentEntry(
+            commitment: Data(repeating: 0x11, count: 32),
+            epoch: epoch,
+            timestamp: 0,
+            tier: 0,
+            active: active
+        )
+    }
+
+    @Test("returns immediately when chain already at expected epoch")
+    func returnsImmediatelyWhenAtExpectedEpoch() async throws {
+        var calls = 0
+        let result = try await OnChainService.fetchOnChainStateAwaitingEpoch(
+            fetch: {
+                calls += 1
+                return self.entry(epoch: 5)
+            },
+            expectedEpoch: 5,
+            maxAttempts: 4,
+            initialDelayMs: 0,
+            sleep: { _ in }
+        )
+        #expect(result.epoch == 5)
+        #expect(calls == 1)
+    }
+
+    @Test("retries until epoch advances, simulating RPC lag")
+    func retriesUntilEpochAdvances() async throws {
+        let epochsToReturn: [UInt64] = [3, 3, 5]
+        var attempt = 0
+        var epochsSeen: [UInt64] = []
+        let result = try await OnChainService.fetchOnChainStateAwaitingEpoch(
+            fetch: {
+                let e = epochsToReturn[attempt]
+                attempt += 1
+                epochsSeen.append(e)
+                return self.entry(epoch: e)
+            },
+            expectedEpoch: 5,
+            maxAttempts: 4,
+            initialDelayMs: 0,
+            sleep: { _ in }
+        )
+        #expect(result.epoch == 5)
+        #expect(epochsSeen == [3, 3, 5])
+    }
+
+    @Test("returns last stale entry when chain never advances within budget")
+    func returnsLastStaleEntry() async throws {
+        var calls = 0
+        let result = try await OnChainService.fetchOnChainStateAwaitingEpoch(
+            fetch: {
+                calls += 1
+                return self.entry(epoch: 3)
+            },
+            expectedEpoch: 5,
+            maxAttempts: 3,
+            initialDelayMs: 0,
+            sleep: { _ in }
+        )
+        #expect(result.epoch == 3)
+        #expect(calls == 3)
+    }
+
+    @Test("rethrows when every attempt fails")
+    func rethrowsWhenAllAttemptsFail() async throws {
+        struct RPCDown: Error {}
+        var calls = 0
+        await #expect(throws: RPCDown.self) {
+            try await OnChainService.fetchOnChainStateAwaitingEpoch(
+                fetch: {
+                    calls += 1
+                    throw RPCDown()
+                },
+                expectedEpoch: 5,
+                maxAttempts: 3,
+                initialDelayMs: 0,
+                sleep: { _ in }
+            )
+        }
+        #expect(calls == 3)
+    }
+
+    @Test("returns successful entry even after a transient error")
+    func recoversFromTransientError() async throws {
+        struct Transient: Error {}
+        var attempt = 0
+        let result = try await OnChainService.fetchOnChainStateAwaitingEpoch(
+            fetch: {
+                attempt += 1
+                if attempt == 1 { throw Transient() }
+                return self.entry(epoch: 7)
+            },
+            expectedEpoch: 7,
+            maxAttempts: 4,
+            initialDelayMs: 0,
+            sleep: { _ in }
+        )
+        #expect(result.epoch == 7)
+        #expect(attempt == 2)
+    }
+}


### PR DESCRIPTION
## Summary

- Both clients now block on contract confirmation before any local state change, MLS broadcast, or rekey-envelope install — on send and receive paths.
- Send path (`performEpochTransition` on iOS/Android) awaits `publishMemberUpdate` / `publishGroupOnChain` synchronously; chain rejection returns `.chainRejected` / `CHAIN_REJECTED` with no local mutation. Missing-bundle early-out moved ahead of the chain call so we don't advance chain epoch when peers can't follow.
- Receive path (`applyStateUpdate`, `applyRekeyEnvelope`) recomputes the candidate commitment from the incoming payload and refuses to commit it unless `fetchOnChainState` reports the same commitment at the same epoch.

Motivation: a non-admin member of an Oligarchy group could remove the creator locally, rebroadcast the MLS commit over Nostr, and peers applied it optimistically — even though `update_commitment` had rejected the call with `UnknownGroupType`. Making chain confirmation a prerequisite closes that path for every governance type.

## Test plan

- [ ] iOS: in Oligarchy group, non-admin attempts to remove a member → transition returns `.chainRejected`, no local state change, no Nostr broadcast.
- [ ] Android: same scenario, `CHAIN_REJECTED` surfaces to UI and membership unchanged.
- [ ] iOS + Android: admin removes a member in Democracy/Anarchy/1v1 groups (where chain accepts) → chain confirms, local state updates, secure rekey envelopes delivered to survivors.
- [ ] Receiver drops a tampered/forged `SEPGroupStateUpdate` or `SEPRekeyEnvelope` whose claimed commitment does not match `get_state` at the claimed epoch.
- [ ] RPC lag tolerance: sender completes chain publish (ledger closed) before broadcasting, so receivers' `fetchOnChainState` returns the new entry by the time the Nostr message arrives.
- [ ] Key rotation still works for published groups (smoke test on both platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)