### PR TITLE
fix: reproducible F-Droid builds via fat LTO (v1.10.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ jni = ["dep:jni"]
 [profile.release]
 strip = "symbols"
 opt-level = "z"
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 
 [profile.release-ceremony]

--- a/clients/android/StellarChat/app/build.gradle.kts
+++ b/clients/android/StellarChat/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "chat.onym.android"
         minSdk = 26
         targetSdk = 35
-        versionCode = 45
-        versionName = "1.10.0"
+        versionCode = 46
+        versionName = "1.10.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
 

--- a/clients/ios/StellarChat/project.yml
+++ b/clients/ios/StellarChat/project.yml
@@ -23,8 +23,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios
         INFOPLIST_KEY_CFBundleDisplayName: Onym
-        MARKETING_VERSION: "1.10.0"
-        CURRENT_PROJECT_VERSION: 45
+        MARKETING_VERSION: "1.10.1"
+        CURRENT_PROJECT_VERSION: 46
         SWIFT_VERSION: "5.0"
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
@@ -123,8 +123,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios.NotificationService
-        MARKETING_VERSION: "1.10.0"
-        CURRENT_PROJECT_VERSION: 45
+        MARKETING_VERSION: "1.10.1"
+        CURRENT_PROJECT_VERSION: 46
         SWIFT_VERSION: "5.0"
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: StellarChatNotificationService/Info.plist

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -66,7 +66,8 @@ LIB_NAME="libsep_xxxx_circuits.so"
 # - build-id=none: no build-id in .so (differs across machines)
 # - hash-style=gnu: consistent hash style across platforms
 # - remap-path-prefix: strip build paths from binaries
-export RUSTFLAGS="${RUSTFLAGS:-} -C codegen-units=1 -C link-arg=-Wl,--build-id=none -C link-arg=-Wl,--hash-style=gnu --remap-path-prefix=$REPO_ROOT=/build --remap-path-prefix=$HOME/.cargo/registry=/cargo-registry --remap-path-prefix=$HOME/.rustup/toolchains=/rustup-toolchains"
+# - thinlto-jobs=1: force single-threaded ThinLTO in case any residual ThinLTO runs (e.g. on Rust std bitcode)
+export RUSTFLAGS="${RUSTFLAGS:-} -C codegen-units=1 -C link-arg=-Wl,--build-id=none -C link-arg=-Wl,--hash-style=gnu -C link-arg=-Wl,--thinlto-jobs=1 --remap-path-prefix=$REPO_ROOT=/build --remap-path-prefix=$HOME/.cargo/registry=/cargo-registry --remap-path-prefix=$HOME/.rustup/toolchains=/rustup-toolchains"
 export SOURCE_DATE_EPOCH=0
 export CARGO_TARGET_DIR="$REPO_ROOT/target"
 


### PR DESCRIPTION
## Summary

- Switch Rust release profile from `lto = "thin"` to `lto = "fat"` — fixes F-Droid reproducible-build verification failure for v1.10.0
- Add `-Wl,--thinlto-jobs=1` to RUSTFLAGS as belt-and-suspenders for any residual ThinLTO on Rust std bitcode
- Bump to v1.10.1 / versionCode 46

## Background

F-Droid's reproducible-build check for v1.10.0 failed with `libsep_xxxx_circuits.so` differing ~22 KB between the published release APK and F-Droid's rebuild from commit `4faaa94`. Byte-level analysis (readelf / nm):

- `.text` differed by 6 KB, `.rela.dyn` by 9 KB, `.data.rel.ro` by 7.7 KB
- `RELACOUNT` differed by 383 (2022 vs 1639)
- Release binary imported `gettid@LIBC`, rebuild did not — despite both binaries recording identical `.note.android.ident` (API 26, NDK r27c)

Both builds used identical rustc 1.94.1 + NDK r27c + API 26 sysroot, so the divergence originated in the compiler pipeline, not the toolchain config. ThinLTO's parallel cross-module importer is a known non-determinism source: inliner decisions and dead-code elimination vary with thread count and scheduling, which differs between GitHub hosted runners, F-Droid's build VM, and any local docker host.

## Validation

Rebuilt locally with the fix via `scripts/build-fdroid-release.sh` (F-Droid's buildserver container) and compared the resulting `.so` to both prior builds:

| Binary | Size | `.text` Δ vs release |
|---|---|---|
| F-Droid rebuild (thin LTO, F-Droid VM) | 1,215,584 | +6,044 |
| Original release (thin LTO, GitHub CI) | 1,193,184 | 0 (baseline) |
| **This PR's build (fat LTO, local docker)** | **1,192,880** | **-228** |

Only 4 sections drift now, all by small amounts (`.text` 228B, `.eh_frame` 60B, `.eh_frame_hdr` 16B, `.gcc_except_table` 4B). All other sections byte-identical. **Imports diff is empty** — the spurious `gettid@LIBC` is gone. Total drift collapsed from ~22 KB to 304 B (74× reduction), and the residual is almost certainly host-architecture noise (my build ran linux/amd64 emulated on Apple Silicon; release CI runs native x86_64). When F-Droid's x86_64 VM rebuilds v1.10.1 from x86_64-built release CI output, those bytes should match.

## Test plan

- [ ] CI passes on this branch (unit tests + both Android and iOS builds)
- [ ] After merge, dispatch Release workflow with `tag=v1.10.1`
- [ ] Submit to F-Droid; confirm reproducible-build verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)