### PR TITLE
ota: auto-generate OTA install manifests for iOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,3 +384,49 @@ jobs:
         with:
           tag_name: ${{ inputs.tag }}
           files: StellarChat-${{ steps.version.outputs.version }}.ipa
+
+  publish-ota-manifest:
+    runs-on: ubuntu-latest
+    needs: ios-build
+    concurrency:
+      group: ota-manifest-main
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse version from tag
+        id: version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate OTA manifest + install page
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash scripts/generate-ota-manifest.sh "${{ steps.version.outputs.version }}"
+
+      - name: Commit and push to main
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add deploy/website/ota/
+          if git diff --cached --quiet; then
+            echo "OTA manifest for v${VERSION} already up to date."
+            exit 0
+          fi
+          git commit -m "ota: publish manifest for v${VERSION}"
+          # CI also pushes altstore updates on the same branch; rebase before retrying on contention.
+          for attempt in 1 2 3; do
+            if git push origin main; then
+              exit 0
+            fi
+            echo "push attempt ${attempt} failed, rebasing..."
+            git pull --rebase origin main
+          done
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,7 +407,8 @@ jobs:
       - name: Generate OTA manifest + install page
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: bash scripts/generate-ota-manifest.sh "${{ steps.version.outputs.version }}"
+          VERSION: ${{ steps.version.outputs.version }}
+        run: bash scripts/generate-ota-manifest.sh "$VERSION"
 
       - name: Commit and push to main
         env:
@@ -421,30 +422,46 @@ jobs:
             exit 0
           fi
           git commit -m "ota: publish manifest for v${VERSION}"
-          # CI also pushes altstore updates on the same branch; rebase before retrying on contention.
+          # CI also pushes altstore updates on the same branch. On push
+          # contention, re-run the generator against fresh main so the root
+          # index.html listing stays complete with any version dirs that were
+          # added concurrently.
           for attempt in 1 2 3; do
             if git push origin main; then
               exit 0
             fi
-            echo "push attempt ${attempt} failed, rebasing..."
-            git pull --rebase origin main
+            echo "push attempt ${attempt} failed; resetting to origin/main and regenerating..."
+            git fetch origin main
+            git reset --hard origin/main
+            bash scripts/generate-ota-manifest.sh "$VERSION"
+            git add deploy/website/ota/
+            if git diff --cached --quiet; then
+              echo "After reset, no OTA changes left to publish for v${VERSION}."
+              exit 0
+            fi
+            git commit -m "ota: publish manifest for v${VERSION}"
           done
-          git push origin main
+          echo "failed to push OTA manifest for v${VERSION} after 3 attempts" >&2
+          exit 1
 
   redeploy-ota:
     runs-on: ubuntu-latest
     needs: publish-ota-manifest
+    concurrency:
+      group: ota-redeploy-main
+      cancel-in-progress: false
     steps:
       - name: Check redeploy secrets
         id: check
         env:
           HAS_KEY: ${{ secrets.DROPLET_SSH_KEY != '' }}
           HAS_IP: ${{ secrets.DROPLET_IP != '' }}
+          HAS_HOST_KEY: ${{ secrets.DROPLET_HOST_KEY != '' }}
         run: |
-          if [ "$HAS_KEY" = "true" ] && [ "$HAS_IP" = "true" ]; then
+          if [ "$HAS_KEY" = "true" ] && [ "$HAS_IP" = "true" ] && [ "$HAS_HOST_KEY" = "true" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
-            echo "DROPLET_SSH_KEY or DROPLET_IP not set; skipping redeploy."
+            echo "DROPLET_SSH_KEY / DROPLET_IP / DROPLET_HOST_KEY not all set; skipping redeploy."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -457,12 +474,18 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         env:
           DROPLET_SSH_KEY: ${{ secrets.DROPLET_SSH_KEY }}
-          DROPLET_IP: ${{ secrets.DROPLET_IP }}
+          DROPLET_HOST_KEY: ${{ secrets.DROPLET_HOST_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "$DROPLET_SSH_KEY" > ~/.ssh/droplet
+          chmod 700 ~/.ssh
+          # Pin the expected droplet host key (ed25519 / rsa line from
+          # `ssh-keyscan -H <droplet-ip>` captured once by the operator and
+          # stored as secret). This replaces runtime TOFU with an explicit
+          # trust anchor.
+          printf '%s\n' "$DROPLET_HOST_KEY" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+          printf '%s\n' "$DROPLET_SSH_KEY" > ~/.ssh/droplet
           chmod 600 ~/.ssh/droplet
-          ssh-keyscan -H "$DROPLET_IP" >> ~/.ssh/known_hosts
 
       - name: Rsync OTA files to droplet
         if: steps.check.outputs.enabled == 'true'
@@ -479,19 +502,38 @@ jobs:
         env:
           DROPLET_IP: ${{ secrets.DROPLET_IP }}
         run: |
+          set -euo pipefail
           # Nginx conf rarely changes per release, but keep it in sync.
           # Static-file changes don't need a reload (bind mount); conf changes do.
           local_sha=$(sha256sum deploy/nginx/conf.d/onym.chat.conf | awk '{print $1}')
           remote_sha=$(ssh -i ~/.ssh/droplet "root@${DROPLET_IP}" \
             "sha256sum /opt/onym-chat/deploy/nginx/conf.d/onym.chat.conf 2>/dev/null | awk '{print \$1}'" \
             || echo "")
-          if [ "$local_sha" != "$remote_sha" ]; then
-            echo "nginx conf changed, uploading + reloading..."
-            rsync -az -e "ssh -i ~/.ssh/droplet" \
-              deploy/nginx/conf.d/onym.chat.conf \
-              "root@${DROPLET_IP}:/opt/onym-chat/deploy/nginx/conf.d/onym.chat.conf"
-            ssh -i ~/.ssh/droplet "root@${DROPLET_IP}" \
-              'cd /opt/onym-chat && docker compose exec -T nginx nginx -t && docker compose exec -T nginx nginx -s reload'
-          else
+          if [ "$local_sha" = "$remote_sha" ]; then
             echo "nginx conf unchanged; no reload."
+            exit 0
           fi
+          echo "nginx conf changed; staging + validating + atomically swapping..."
+          # 1. Upload to a staging filename alongside the live one. Nginx
+          #    only reads files matching *.conf in /etc/nginx/conf.d/, so
+          #    a *.conf.new filename is a harmless staging slot.
+          rsync -az -e "ssh -i ~/.ssh/droplet" \
+            deploy/nginx/conf.d/onym.chat.conf \
+            "root@${DROPLET_IP}:/opt/onym-chat/deploy/nginx/conf.d/onym.chat.conf.new"
+          # 2. Atomically swap + validate on the droplet. If the new conf
+          #    fails `nginx -t`, restore the backup before any reload.
+          ssh -i ~/.ssh/droplet "root@${DROPLET_IP}" bash -s <<'REMOTE'
+          set -euo pipefail
+          cd /opt/onym-chat
+          cp deploy/nginx/conf.d/onym.chat.conf deploy/nginx/conf.d/onym.chat.conf.bak
+          mv deploy/nginx/conf.d/onym.chat.conf.new deploy/nginx/conf.d/onym.chat.conf
+          if docker compose exec -T nginx nginx -t; then
+            docker compose exec -T nginx nginx -s reload
+            rm -f deploy/nginx/conf.d/onym.chat.conf.bak
+            echo "nginx reloaded with new config"
+          else
+            echo "ERROR: new nginx config failed validation, rolling back" >&2
+            mv deploy/nginx/conf.d/onym.chat.conf.bak deploy/nginx/conf.d/onym.chat.conf
+            exit 1
+          fi
+          REMOTE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,3 +430,68 @@ jobs:
             git pull --rebase origin main
           done
           git push origin main
+
+  redeploy-ota:
+    runs-on: ubuntu-latest
+    needs: publish-ota-manifest
+    steps:
+      - name: Check redeploy secrets
+        id: check
+        env:
+          HAS_KEY: ${{ secrets.DROPLET_SSH_KEY != '' }}
+          HAS_IP: ${{ secrets.DROPLET_IP != '' }}
+        run: |
+          if [ "$HAS_KEY" = "true" ] && [ "$HAS_IP" = "true" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "DROPLET_SSH_KEY or DROPLET_IP not set; skipping redeploy."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.enabled == 'true'
+        with:
+          ref: main
+
+      - name: Configure SSH
+        if: steps.check.outputs.enabled == 'true'
+        env:
+          DROPLET_SSH_KEY: ${{ secrets.DROPLET_SSH_KEY }}
+          DROPLET_IP: ${{ secrets.DROPLET_IP }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DROPLET_SSH_KEY" > ~/.ssh/droplet
+          chmod 600 ~/.ssh/droplet
+          ssh-keyscan -H "$DROPLET_IP" >> ~/.ssh/known_hosts
+
+      - name: Rsync OTA files to droplet
+        if: steps.check.outputs.enabled == 'true'
+        env:
+          DROPLET_IP: ${{ secrets.DROPLET_IP }}
+        run: |
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/droplet -o StrictHostKeyChecking=yes" \
+            deploy/website/ota/ \
+            "root@${DROPLET_IP}:/opt/onym-chat/deploy/website/ota/"
+
+      - name: Upload nginx conf + reload if changed
+        if: steps.check.outputs.enabled == 'true'
+        env:
+          DROPLET_IP: ${{ secrets.DROPLET_IP }}
+        run: |
+          # Nginx conf rarely changes per release, but keep it in sync.
+          # Static-file changes don't need a reload (bind mount); conf changes do.
+          local_sha=$(sha256sum deploy/nginx/conf.d/onym.chat.conf | awk '{print $1}')
+          remote_sha=$(ssh -i ~/.ssh/droplet "root@${DROPLET_IP}" \
+            "sha256sum /opt/onym-chat/deploy/nginx/conf.d/onym.chat.conf 2>/dev/null | awk '{print \$1}'" \
+            || echo "")
+          if [ "$local_sha" != "$remote_sha" ]; then
+            echo "nginx conf changed, uploading + reloading..."
+            rsync -az -e "ssh -i ~/.ssh/droplet" \
+              deploy/nginx/conf.d/onym.chat.conf \
+              "root@${DROPLET_IP}:/opt/onym-chat/deploy/nginx/conf.d/onym.chat.conf"
+            ssh -i ~/.ssh/droplet "root@${DROPLET_IP}" \
+              'cd /opt/onym-chat && docker compose exec -T nginx nginx -t && docker compose exec -T nginx nginx -s reload'
+          else
+            echo "nginx conf unchanged; no reload."
+          fi

--- a/deploy/nginx/conf.d/onym.chat.conf
+++ b/deploy/nginx/conf.d/onym.chat.conf
@@ -23,7 +23,7 @@ server {
         add_header Cache-Control "no-cache, must-revalidate";
     }
 
-    location ~ \.plist$ {
+    location ~ ^/ota/.*\.plist$ {
         default_type application/xml;
         add_header Cache-Control "no-cache, must-revalidate";
     }

--- a/deploy/nginx/conf.d/onym.chat.conf
+++ b/deploy/nginx/conf.d/onym.chat.conf
@@ -23,6 +23,11 @@ server {
         add_header Cache-Control "no-cache, must-revalidate";
     }
 
+    location ~ \.plist$ {
+        default_type application/xml;
+        add_header Cache-Control "no-cache, must-revalidate";
+    }
+
     location / {
         try_files $uri $uri.html $uri/ /index.html;
     }

--- a/deploy/website/ota/1.10.2/index.html
+++ b/deploy/website/ota/1.10.2/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Install Onym 1.10.2</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            max-width: 420px;
+            margin: 0 auto;
+            padding: 48px 24px;
+            color: #1c1c1e;
+            background: #f2f2f7;
+            text-align: center;
+        }
+        img.icon {
+            width: 96px;
+            height: 96px;
+            border-radius: 22px;
+            box-shadow: 0 4px 14px rgba(0,0,0,0.12);
+        }
+        h1 { font-size: 24px; margin: 16px 0 4px; }
+        .version { color: #6e6e73; font-size: 15px; margin-bottom: 32px; }
+        a.install {
+            display: inline-block;
+            background: #6c5ce7;
+            color: #fff;
+            text-decoration: none;
+            padding: 14px 32px;
+            border-radius: 22px;
+            font-size: 17px;
+            font-weight: 600;
+        }
+        a.install:active { opacity: 0.85; }
+        .note {
+            margin-top: 32px;
+            padding: 16px;
+            background: #fff;
+            border-radius: 12px;
+            font-size: 14px;
+            color: #3c3c43;
+            text-align: left;
+            line-height: 1.5;
+        }
+        .note strong { color: #1c1c1e; }
+        code {
+            background: #e5e5ea;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 13px;
+        }
+    </style>
+</head>
+<body>
+    <img class="icon" src="/icon.png" alt="Onym">
+    <h1>Onym</h1>
+    <div class="version">Version 1.10.2 &middot; ad-hoc build</div>
+
+    <a class="install"
+       href="itms-services://?action=download-manifest&url=https://onym.chat/ota/1.10.2/manifest.plist">
+        Install on iPhone
+    </a>
+
+    <div class="note">
+        <strong>Requirements:</strong> Open this page in Safari on iOS. Your device UDID must be registered in the ad-hoc provisioning profile used to sign <code>v1.10.2</code>. If the install fails with "Unable to Install", the UDID was not included in that build.
+    </div>
+</body>
+</html>

--- a/deploy/website/ota/1.10.2/manifest.plist
+++ b/deploy/website/ota/1.10.2/manifest.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>items</key>
+    <array>
+        <dict>
+            <key>assets</key>
+            <array>
+                <dict>
+                    <key>kind</key>
+                    <string>software-package</string>
+                    <key>url</key>
+                    <string>https://github.com/rinat-enikeev/stellar-mls/releases/download/v1.10.2/StellarChat-1.10.2.ipa</string>
+                </dict>
+                <dict>
+                    <key>kind</key>
+                    <string>display-image</string>
+                    <key>url</key>
+                    <string>https://onym.chat/icon.png</string>
+                </dict>
+                <dict>
+                    <key>kind</key>
+                    <string>full-size-image</string>
+                    <key>url</key>
+                    <string>https://onym.chat/icon.png</string>
+                </dict>
+            </array>
+            <key>metadata</key>
+            <dict>
+                <key>bundle-identifier</key>
+                <string>chat.onym.ios</string>
+                <key>bundle-version</key>
+                <string>1.10.2</string>
+                <key>kind</key>
+                <string>software</string>
+                <key>title</key>
+                <string>Onym</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/deploy/website/ota/index.html
+++ b/deploy/website/ota/index.html
@@ -2,10 +2,65 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=/ota/1.10.2/">
-    <title>Onym OTA — latest</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Onym OTA — releases</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            max-width: 520px;
+            margin: 0 auto;
+            padding: 48px 24px;
+            color: #1c1c1e;
+            background: #f2f2f7;
+        }
+        h1 { font-size: 24px; margin: 0 0 4px; text-align: center; }
+        p.sub { color: #6e6e73; font-size: 15px; text-align: center; margin: 0 0 32px; }
+        ul { list-style: none; padding: 0; margin: 0; }
+        li { margin: 0 0 8px; }
+        li a {
+            display: block;
+            background: #fff;
+            color: #1c1c1e;
+            text-decoration: none;
+            padding: 14px 18px;
+            border-radius: 12px;
+            font-size: 16px;
+            font-weight: 500;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        }
+        li a:active { background: #eceef3; }
+        .badge {
+            display: inline-block;
+            background: #6c5ce7;
+            color: #fff;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 2px 8px;
+            border-radius: 8px;
+            margin-left: 8px;
+            vertical-align: middle;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+        .note {
+            margin-top: 24px;
+            padding: 16px;
+            background: #fff;
+            border-radius: 12px;
+            font-size: 14px;
+            color: #3c3c43;
+            line-height: 1.5;
+        }
+    </style>
 </head>
 <body>
-    <p>Redirecting to <a href="/ota/1.10.2/">Onym 1.10.2</a>&hellip;</p>
+    <h1>Onym</h1>
+    <p class="sub">Ad-hoc iOS releases</p>
+    <ul>
+        <li><a href="/ota/1.10.2/">Version 1.10.2 <span class="badge">latest</span></a></li>
+    </ul>
+    <div class="note">
+        Open this page in <strong>Safari on iOS</strong>. Installation requires the device UDID to be in the ad-hoc provisioning profile used to sign the chosen build.
+    </div>
 </body>
 </html>

--- a/deploy/website/ota/index.html
+++ b/deploy/website/ota/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=/ota/1.10.2/">
+    <title>Onym OTA — latest</title>
+</head>
+<body>
+    <p>Redirecting to <a href="/ota/1.10.2/">Onym 1.10.2</a>&hellip;</p>
+</body>
+</html>

--- a/scripts/generate-ota-manifest.sh
+++ b/scripts/generate-ota-manifest.sh
@@ -148,20 +148,94 @@ cat > "${version_dir}/index.html" <<HTML
 </html>
 HTML
 
+# Collect all versions with a manifest.plist, sort descending by semver.
+sorted_versions=$(
+    find "$ota_root" -mindepth 2 -maxdepth 2 -name manifest.plist -type f \
+        -exec sh -c 'basename "$(dirname "$1")"' _ {} \; \
+    | sort -rV
+)
+
+latest=$(printf '%s\n' "$sorted_versions" | head -n1)
+
+rows=""
+while IFS= read -r v; do
+    [ -z "$v" ] && continue
+    if [ "$v" = "$latest" ]; then
+        badge=' <span class="badge">latest</span>'
+    else
+        badge=''
+    fi
+    rows+="        <li><a href=\"/ota/${v}/\">Version ${v}${badge}</a></li>"$'\n'
+done <<< "$sorted_versions"
+
 cat > "${ota_root}/index.html" <<ROOT
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=/ota/${VERSION}/">
-    <title>${TITLE} OTA — latest</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${TITLE} OTA — releases</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            max-width: 520px;
+            margin: 0 auto;
+            padding: 48px 24px;
+            color: #1c1c1e;
+            background: #f2f2f7;
+        }
+        h1 { font-size: 24px; margin: 0 0 4px; text-align: center; }
+        p.sub { color: #6e6e73; font-size: 15px; text-align: center; margin: 0 0 32px; }
+        ul { list-style: none; padding: 0; margin: 0; }
+        li { margin: 0 0 8px; }
+        li a {
+            display: block;
+            background: #fff;
+            color: #1c1c1e;
+            text-decoration: none;
+            padding: 14px 18px;
+            border-radius: 12px;
+            font-size: 16px;
+            font-weight: 500;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        }
+        li a:active { background: #eceef3; }
+        .badge {
+            display: inline-block;
+            background: #6c5ce7;
+            color: #fff;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 2px 8px;
+            border-radius: 8px;
+            margin-left: 8px;
+            vertical-align: middle;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+        .note {
+            margin-top: 24px;
+            padding: 16px;
+            background: #fff;
+            border-radius: 12px;
+            font-size: 14px;
+            color: #3c3c43;
+            line-height: 1.5;
+        }
+    </style>
 </head>
 <body>
-    <p>Redirecting to <a href="/ota/${VERSION}/">${TITLE} ${VERSION}</a>&hellip;</p>
+    <h1>${TITLE}</h1>
+    <p class="sub">Ad-hoc iOS releases</p>
+    <ul>
+${rows}    </ul>
+    <div class="note">
+        Open this page in <strong>Safari on iOS</strong>. Installation requires the device UDID to be in the ad-hoc provisioning profile used to sign the chosen build.
+    </div>
 </body>
 </html>
 ROOT
 
 echo "Wrote ${version_dir}/manifest.plist"
 echo "Wrote ${version_dir}/index.html"
-echo "Updated ${ota_root}/index.html -> /ota/${VERSION}/"
+echo "Updated ${ota_root}/index.html — listing $(echo "$sorted_versions" | wc -l | tr -d ' ') version(s), latest ${latest}"

--- a/scripts/generate-ota-manifest.sh
+++ b/scripts/generate-ota-manifest.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Generates the OTA manifest.plist + install page for an iOS ad-hoc release.
+#
+# Usage: scripts/generate-ota-manifest.sh <version>
+#   e.g. scripts/generate-ota-manifest.sh 1.10.2
+#
+# Env overrides (normally unset):
+#   GITHUB_REPOSITORY  — owner/repo for the IPA URL (default rinat-enikeev/stellar-mls)
+#   BUNDLE_ID          — iOS bundle identifier (default chat.onym.ios)
+#   TITLE              — app title shown in the iOS install prompt (default Onym)
+#   DOMAIN             — domain the manifest is served from (default onym.chat)
+#
+# Writes:
+#   deploy/website/ota/<version>/manifest.plist
+#   deploy/website/ota/<version>/index.html
+#   deploy/website/ota/index.html  (redirect to latest version)
+
+set -euo pipefail
+
+VERSION="${1:?version required (without leading v), e.g. 1.10.2}"
+REPO="${GITHUB_REPOSITORY:-rinat-enikeev/stellar-mls}"
+BUNDLE_ID="${BUNDLE_ID:-chat.onym.ios}"
+TITLE="${TITLE:-Onym}"
+DOMAIN="${DOMAIN:-onym.chat}"
+
+IPA_URL="https://github.com/${REPO}/releases/download/v${VERSION}/StellarChat-${VERSION}.ipa"
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+ota_root="${repo_root}/deploy/website/ota"
+version_dir="${ota_root}/${VERSION}"
+mkdir -p "$version_dir"
+
+cat > "${version_dir}/manifest.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>items</key>
+    <array>
+        <dict>
+            <key>assets</key>
+            <array>
+                <dict>
+                    <key>kind</key>
+                    <string>software-package</string>
+                    <key>url</key>
+                    <string>${IPA_URL}</string>
+                </dict>
+                <dict>
+                    <key>kind</key>
+                    <string>display-image</string>
+                    <key>url</key>
+                    <string>https://${DOMAIN}/icon.png</string>
+                </dict>
+                <dict>
+                    <key>kind</key>
+                    <string>full-size-image</string>
+                    <key>url</key>
+                    <string>https://${DOMAIN}/icon.png</string>
+                </dict>
+            </array>
+            <key>metadata</key>
+            <dict>
+                <key>bundle-identifier</key>
+                <string>${BUNDLE_ID}</string>
+                <key>bundle-version</key>
+                <string>${VERSION}</string>
+                <key>kind</key>
+                <string>software</string>
+                <key>title</key>
+                <string>${TITLE}</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>
+PLIST
+
+cat > "${version_dir}/index.html" <<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Install ${TITLE} ${VERSION}</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            max-width: 420px;
+            margin: 0 auto;
+            padding: 48px 24px;
+            color: #1c1c1e;
+            background: #f2f2f7;
+            text-align: center;
+        }
+        img.icon {
+            width: 96px;
+            height: 96px;
+            border-radius: 22px;
+            box-shadow: 0 4px 14px rgba(0,0,0,0.12);
+        }
+        h1 { font-size: 24px; margin: 16px 0 4px; }
+        .version { color: #6e6e73; font-size: 15px; margin-bottom: 32px; }
+        a.install {
+            display: inline-block;
+            background: #6c5ce7;
+            color: #fff;
+            text-decoration: none;
+            padding: 14px 32px;
+            border-radius: 22px;
+            font-size: 17px;
+            font-weight: 600;
+        }
+        a.install:active { opacity: 0.85; }
+        .note {
+            margin-top: 32px;
+            padding: 16px;
+            background: #fff;
+            border-radius: 12px;
+            font-size: 14px;
+            color: #3c3c43;
+            text-align: left;
+            line-height: 1.5;
+        }
+        .note strong { color: #1c1c1e; }
+        code {
+            background: #e5e5ea;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 13px;
+        }
+    </style>
+</head>
+<body>
+    <img class="icon" src="/icon.png" alt="${TITLE}">
+    <h1>${TITLE}</h1>
+    <div class="version">Version ${VERSION} &middot; ad-hoc build</div>
+
+    <a class="install"
+       href="itms-services://?action=download-manifest&url=https://${DOMAIN}/ota/${VERSION}/manifest.plist">
+        Install on iPhone
+    </a>
+
+    <div class="note">
+        <strong>Requirements:</strong> Open this page in Safari on iOS. Your device UDID must be registered in the ad-hoc provisioning profile used to sign <code>v${VERSION}</code>. If the install fails with "Unable to Install", the UDID was not included in that build.
+    </div>
+</body>
+</html>
+HTML
+
+cat > "${ota_root}/index.html" <<ROOT
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=/ota/${VERSION}/">
+    <title>${TITLE} OTA — latest</title>
+</head>
+<body>
+    <p>Redirecting to <a href="/ota/${VERSION}/">${TITLE} ${VERSION}</a>&hellip;</p>
+</body>
+</html>
+ROOT
+
+echo "Wrote ${version_dir}/manifest.plist"
+echo "Wrote ${version_dir}/index.html"
+echo "Updated ${ota_root}/index.html -> /ota/${VERSION}/"

--- a/scripts/generate-ota-manifest.test.sh
+++ b/scripts/generate-ota-manifest.test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/generate-ota-manifest.sh.
+#
+# Copies the generator into an isolated fake-repo tree (so it writes to a
+# temp directory rather than the real deploy/website/ota/), then checks:
+#   - First-run single version produces manifest + install page + root listing.
+#   - Multiple versions are listed in descending semver order, with the
+#     highest semver (not lexicographic max) badged "latest".
+#   - Re-running with the same args is idempotent (byte-identical output).
+#   - Env overrides (GITHUB_REPOSITORY, BUNDLE_ID, TITLE, DOMAIN) are honored.
+#
+# Run: bash scripts/generate-ota-manifest.test.sh
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+generator="${script_dir}/generate-ota-manifest.sh"
+
+if [ ! -x "$generator" ] && [ ! -r "$generator" ]; then
+    echo "FAIL: generator not found at ${generator}" >&2
+    exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Stage a fake repo: scripts/<generator>, plus the dirs the generator writes into.
+mkdir -p "${tmpdir}/scripts" "${tmpdir}/deploy/website"
+cp "$generator" "${tmpdir}/scripts/generate-ota-manifest.sh"
+chmod +x "${tmpdir}/scripts/generate-ota-manifest.sh"
+
+fail=0
+pass() { printf '  ok  %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1" >&2; fail=1; }
+
+run_gen() {
+    # Invoke the staged copy so the generator's `pwd` walk picks up the tmp repo.
+    ( cd "$tmpdir" && bash scripts/generate-ota-manifest.sh "$@" ) >/dev/null
+}
+
+ota="${tmpdir}/deploy/website/ota"
+
+# -------- Test 1: first-run with a single version --------
+echo "Test 1: single version first run"
+run_gen 1.10.2
+
+if [ -f "${ota}/1.10.2/manifest.plist" ]; then
+    pass "manifest.plist written"
+else
+    fail "manifest.plist missing"
+fi
+
+if [ -f "${ota}/1.10.2/index.html" ]; then
+    pass "per-version index.html written"
+else
+    fail "per-version index.html missing"
+fi
+
+if [ -f "${ota}/index.html" ]; then
+    pass "root index.html written"
+else
+    fail "root index.html missing"
+fi
+
+if grep -q 'v1.10.2/StellarChat-1.10.2.ipa' "${ota}/1.10.2/manifest.plist"; then
+    pass "manifest references correct IPA URL"
+else
+    fail "manifest IPA URL wrong"
+fi
+
+if grep -q 'chat.onym.ios' "${ota}/1.10.2/manifest.plist"; then
+    pass "default bundle-id present"
+else
+    fail "default bundle-id missing"
+fi
+
+# -------- Test 2: multiple versions → semver descending with badge --------
+echo "Test 2: multiple versions sorted descending"
+run_gen 1.9.0
+run_gen 1.10.10
+run_gen 2.0.0
+run_gen 1.10.2   # re-run to rebuild root listing
+
+root_index="${ota}/index.html"
+# Extract version strings in the order they appear in the listing.
+order=$(grep -oE '/ota/[0-9]+\.[0-9]+\.[0-9]+/' "$root_index" \
+    | sed 's|/ota/||; s|/||')
+expected=$(printf '2.0.0\n1.10.10\n1.10.2\n1.9.0\n')
+if [ "$order" = "$expected" ]; then
+    pass "versions in descending semver order"
+else
+    fail "version order wrong"
+    printf '    got:\n%s\n    expected:\n%s\n' "$order" "$expected" >&2
+fi
+
+# Badge must be on 2.0.0 row only.
+badge_line=$(grep -n 'class="badge"' "$root_index" | head -1 || true)
+if [ -n "$badge_line" ] && printf '%s' "$badge_line" | grep -q '2.0.0'; then
+    pass "latest badge on highest semver"
+else
+    fail "latest badge missing or on wrong version (line: ${badge_line})"
+fi
+
+badge_count=$(grep -c 'class="badge"' "$root_index" || true)
+if [ "$badge_count" = "1" ]; then
+    pass "exactly one latest badge"
+else
+    fail "expected 1 badge, got ${badge_count}"
+fi
+
+# -------- Test 3: idempotency (same args → byte-identical output) --------
+echo "Test 3: idempotency"
+hash_before=$(find "$ota" -type f -exec shasum {} \; | sort | shasum | awk '{print $1}')
+run_gen 2.0.0
+run_gen 1.10.2
+hash_after=$(find "$ota" -type f -exec shasum {} \; | sort | shasum | awk '{print $1}')
+if [ "$hash_before" = "$hash_after" ]; then
+    pass "re-run produces byte-identical tree"
+else
+    fail "re-run changed output (${hash_before} → ${hash_after})"
+fi
+
+# -------- Test 4: env overrides --------
+echo "Test 4: env overrides"
+rm -rf "$ota"
+( cd "$tmpdir" && \
+    GITHUB_REPOSITORY="someone/fork" \
+    BUNDLE_ID="chat.example.ios" \
+    TITLE="Example" \
+    DOMAIN="example.test" \
+    bash scripts/generate-ota-manifest.sh 3.0.0 ) >/dev/null
+
+m="${ota}/3.0.0/manifest.plist"
+if grep -q 'someone/fork/releases/download/v3.0.0/StellarChat-3.0.0.ipa' "$m"; then
+    pass "GITHUB_REPOSITORY override applied"
+else
+    fail "GITHUB_REPOSITORY not applied"
+fi
+if grep -q 'chat.example.ios' "$m"; then
+    pass "BUNDLE_ID override applied"
+else
+    fail "BUNDLE_ID not applied"
+fi
+if grep -q '<string>Example</string>' "$m"; then
+    pass "TITLE override applied"
+else
+    fail "TITLE not applied"
+fi
+if grep -q 'example.test/ota/3.0.0/manifest.plist' "${ota}/3.0.0/index.html"; then
+    pass "DOMAIN override applied in install-page itms-services URL"
+else
+    fail "DOMAIN not applied"
+fi
+
+echo
+if [ "$fail" = "0" ]; then
+    echo "PASS"
+else
+    echo "FAIL" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `/ota/<version>/` endpoints on onym.chat — an install landing page plus an Apple `itms-services://` `manifest.plist` — so ad-hoc IPAs attached to GitHub releases can be installed OTA from iOS Safari onto any device in the provisioning profile.
- `/ota/` renders a semver-sorted listing of every version on disk, latest flagged with a badge.
- Release workflow now auto-generates the manifest for each tag and (optionally) rsyncs it to the droplet.

## Changes
- `scripts/generate-ota-manifest.sh` — writes `manifest.plist`, per-version install page, and the root listing page. Pure bash, no deps.
- `.github/workflows/release.yml`:
  - `publish-ota-manifest` job (after `ios-build`) — runs the script for the new tag, commits `deploy/website/ota/` to `main`, rebase-retries up to 3× (same pattern CI already uses for altstore updates).
  - `redeploy-ota` job (after `publish-ota-manifest`) — rsyncs `deploy/website/ota/` to `/opt/onym-chat/` on the droplet. Only uploads/reloads nginx when `onym.chat.conf` content actually changed; static website files don't need a reload (bind mount). Gated on secrets so merging is safe before they're configured.
- `deploy/nginx/conf.d/onym.chat.conf` — serve `*.plist` as `application/xml` with `no-cache` (Apple's requirement for OTA manifests).
- `deploy/website/ota/1.10.2/` + `deploy/website/ota/index.html` — seed files for the existing v1.10.2 release.

## Required secrets (for the `redeploy-ota` job to run)
Without these, the job logs "skipping redeploy" and exits 0 — everything else still works.
- `DROPLET_SSH_KEY` — private key with root access to `/opt/onym-chat/`. Recommend generating a dedicated CI deploy key rather than reusing a personal key.
- `DROPLET_IP` — the droplet IP.

## Branch-protection note
`publish-ota-manifest` pushes directly to `main` with `GITHUB_TOKEN`. If branch protection blocks unattended pushes (same as the altstore CI flow), swap the `token:` line to a PAT secret.

## Test plan
- [x] `scripts/generate-ota-manifest.sh 1.10.2` produces files byte-identical to the ones currently live on https://onym.chat/ota/1.10.2/
- [x] Semver listing sort verified with dummy versions (1.10.2 > 1.9.1 > 1.5.0)
- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` on the workflow
- [x] `bash -n scripts/generate-ota-manifest.sh`
- [ ] Dispatch Release workflow on a test tag, confirm `/ota/<new>/` + listing update
- [ ] Install v1.10.2 from https://onym.chat/ota/1.10.2/ in Safari on a provisioned device

🤖 Generated with [Claude Code](https://claude.com/claude-code)