### PR TITLE
n8n: workflow 07 — issue-comment @-mention opens a PR

### DIFF
--- a/build/dev-env/README.md
+++ b/build/dev-env/README.md
@@ -68,7 +68,7 @@ build/dev-env/
 │   ├── remote-xcodebuild.sh     # baked to /usr/local/bin/remote-xcodebuild in container
 │   └── remote-jnilibs.sh        # baked to /usr/local/bin/remote-jnilibs
 ├── n8n/
-│   ├── README.md                # workflow specs (6 workflows — see docs/design-n8n-agent-round-trip.md for the round-trip)
+│   ├── README.md                # workflow specs (7 workflows — see docs/design-n8n-agent-round-trip.md for the round-trip)
 │   └── workflows/               # exported JSON (manual import in n8n UI)
 └── host/                        # deployed manually to the Mac mini
     ├── host-build-dispatch.sh
@@ -320,7 +320,7 @@ chmod 600 n8n/secrets/*.json
 
 `n8n-deploy.sh` imports every credential + workflow into
 `stellar-n8n`, rewrites `REPLACE_ME` IDs to real ones, activates the
-six workflows, and prints each webhook URL.
+seven workflows, and prints each webhook URL.
 
 You still need to create the owner account at
 http://127.0.0.1:5678 (UI, one-time) and point a cloudflared tunnel at

--- a/build/dev-env/bin/gh-webhooks-sync.sh
+++ b/build/dev-env/bin/gh-webhooks-sync.sh
@@ -69,6 +69,7 @@ DESIRED+=("pr-review-request         pull_request")
 DESIRED+=("pr-address-comment        issue_comment")
 DESIRED+=("pr-address-review-comment pull_request_review_comment")
 DESIRED+=("pr-merge                  issue_comment")
+DESIRED+=("issue-mention             issue_comment")
 
 echo "==> fetching existing webhooks from $REPO"
 gh api "repos/$REPO/hooks" --paginate > /tmp/gh-hooks.json

--- a/build/dev-env/n8n/README.md
+++ b/build/dev-env/n8n/README.md
@@ -6,7 +6,7 @@ agents over SSH at `qa-agent:22` / `release-agent:22` using a dedicated
 key pair stored in n8n's encrypted credential store — **never** via the
 Docker socket.
 
-Six workflows live under `workflows/`. They're JSON exports of n8n
+Seven workflows live under `workflows/`. They're JSON exports of n8n
 flows, but the specs below describe what each one does in plain terms so
 you (or a future agent) can rebuild them from scratch in the n8n UI.
 
@@ -131,7 +131,7 @@ back-post as the right GitHub identity by consulting env vars set in
 | `N8N_HUMAN_QA_LOGIN` | Receives the smoke-test issue created by workflow 06. |
 | `N8N_BOT_LOGINS` | CSV of logins whose events must never re-trigger the round-trip. Include every agent-bound handle from `N8N_AGENT_MAP` plus `github-actions[bot]`. |
 | `N8N_MERGE_AUTHORIZED_LOGINS` | CSV of logins whose `/merge` comments workflow 06 will honour. |
-| `N8N_COMMAND_USERS` | CSV of logins allowed to address agents in PR comments by `@`-mentioning an implementer (see workflow 05). Can include agent handles — loop-proof because bot-posted comments never match the `@<login> <free text>` pattern. |
+| `N8N_COMMAND_USERS` | CSV of logins allowed to address agents by `@`-mentioning an implementer — used by workflow 05 (PR comments) and workflow 07 (plain-issue comments). Can include agent handles — loop-proof because bot-posted comments never match the `@<login> <free text>` pattern. |
 
 **Adding a new agent**: add a JSON key to `N8N_AGENT_MAP`; create the
 matching n8n SSH + GitHub credentials; add a new branch to the `Switch
@@ -186,6 +186,11 @@ agents by name on any PR.
 ## Workflow 1 — `01-qa-agent-issue`
 
 **Trigger**: GitHub webhook, `issues` event.
+
+> **See also**: workflow 07 handles `issue_comment` events on plain
+> issues when the commenter `@`-mentions an implementer. Both workflows
+> share the same `n8n-agent-issue.sh` script and target the same
+> `agent/issue-<N>` branch, so they're idempotent against each other.
 
 **Filter** (single boolean expression):
 - `action ∈ [opened, reopened, labeled, assigned]`
@@ -458,6 +463,56 @@ smallest change possible. Commit with message `address review comment
 
 The actual `gh pr merge` side-effect fires `pull_request.closed` +
 `merged == true`, which then flows into **workflow 02** to cut a tag.
+
+---
+
+## Workflow 7 — `07-issue-mention`
+
+**Trigger**: GitHub webhook, `issue_comment` event.
+
+**Filter** (all AND):
+- `action == "created"`.
+- Comment is on a **plain issue** (`issue` set, `issue.pull_request` is
+  falsy). PR comments are handled by workflow 05, not here.
+- Sender not a Bot; sender and comment author both ∉ `N8N_BOT_LOGINS`.
+- Commenter ∈ `N8N_COMMAND_USERS`.
+- Comment body does **not** match `/^\/(build|merge|review|fix)\b/i`
+  (those are slash-command workflows).
+- Comment body `@`-mentions at least one `implementer` login from
+  `N8N_AGENT_MAP` (`@<login>(?![a-z0-9-])`, case-insensitive) so prefix
+  collisions like `@gramyzer-helper` don't fire.
+
+**Steps**:
+
+1. **Extract issue fields** (Set): `issueNumber`, `issueTitle`,
+   `issueBody`, `commentBody`, `commentId`, `senderLogin`, `repoOwner`,
+   `repoName`.
+2. **Resolve implementer** (Code): parse the `@<implementer>` mention
+   from the comment → `implementerLogin`; strip the mention from the
+   body to get the free-text `instruction`; look up `host`/`port`/`user`
+   in the map; set `reviewerLogin = N8N_REVIEWER_DEFAULT`.
+3. **Encode prompt** (Code): build a Claude prompt that includes the
+   issue title + body plus the stripped instruction from the commenter,
+   base64-encoded.
+4. **Switch by host** — same branches as workflows 01/04/05/06.
+5. **SSH to the resolved agent**: same wrapper as workflow 01,
+   delegating to `./build/dev-env/bin/n8n-agent-issue.sh <issue#>
+   <promptB64> <reviewer>`. The script is idempotent on
+   `agent/issue-<N>` — if workflow 01 already opened a PR for this
+   issue, workflow 07 prints `SKIPPED=existing-pr` and returns the
+   existing PR URL rather than double-commenting.
+6. **Merge SSH outputs**, **Should comment?** (requires `PR_URL=` on
+   stdout and no `SKIPPED=`), **Comment on issue** posting the new PR
+   URL via the qa-bot credential.
+
+**Loop safety**: `sender.type === 'Bot'` rejects App-posted comments
+(the primary channel for agent comments); the `commandUsers.includes
+(commenter)` gate is the authorisation boundary for human commenters.
+Agents can still cross-delegate (agent A mentions agent B) if both are
+in `N8N_COMMAND_USERS` and A posts as a PAT/`User` type — mirrors
+workflow 05's design. This does not self-loop because agent-authored
+comments are templated (`agent opened …`) and never include free-text
+`@<agent>` mentions.
 
 ---
 

--- a/build/dev-env/n8n/workflows/07-issue-mention.json
+++ b/build/dev-env/n8n/workflows/07-issue-mention.json
@@ -1,0 +1,329 @@
+{
+  "name": "07 Issue mention",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "issue-mention",
+        "responseMode": "onReceived",
+        "responseData": "allEntries",
+        "options": {}
+      },
+      "id": "a7000000-0000-0000-0000-000000000001",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1.1,
+      "position": [240, 300],
+      "webhookId": "issue-mention"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "b7000000-0000-0000-0000-000000000001",
+              "leftValue": "={{ (() => { const body = $json.body; if (body.action !== 'created') return false; if (!body.issue) return false; if (body.issue.pull_request) return false; if (body.sender && body.sender.type === 'Bot') return false; const text = ((body.comment && body.comment.body) || '').trim(); if (/^\\/(build|merge|review|fix)\\b/i.test(text)) return false; const commandUsers = ($env.N8N_COMMAND_USERS || '').split(',').map(s => s.trim()).filter(Boolean); const senderLogin = body.sender && body.sender.login; const commenter = (body.comment && body.comment.user && body.comment.user.login) || senderLogin; if (!commandUsers.includes(commenter)) return false; let map = {}; try { map = JSON.parse($env.N8N_AGENT_MAP || '{}'); } catch (e) { return false; } const implementerLogins = Object.keys(map).filter(k => map[k] && map[k].role === 'implementer'); if (!implementerLogins.length) return false; return new RegExp('@(' + implementerLogins.join('|') + ')(?![a-z0-9-])', 'i').test(text); })() }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "a7000000-0000-0000-0000-000000000002",
+      "name": "Is authorised issue mention?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "c7000000-0000-0000-0000-000000000001",
+              "name": "issueNumber",
+              "value": "={{ $json.body.issue.number }}",
+              "type": "number"
+            },
+            {
+              "id": "c7000000-0000-0000-0000-000000000002",
+              "name": "issueTitle",
+              "value": "={{ $json.body.issue.title }}",
+              "type": "string"
+            },
+            {
+              "id": "c7000000-0000-0000-0000-000000000003",
+              "name": "issueBody",
+              "value": "={{ $json.body.issue.body || '' }}",
+              "type": "string"
+            },
+            {
+              "id": "c7000000-0000-0000-0000-000000000004",
+              "name": "commentBody",
+              "value": "={{ ($json.body.comment && $json.body.comment.body) || '' }}",
+              "type": "string"
+            },
+            {
+              "id": "c7000000-0000-0000-0000-000000000005",
+              "name": "commentId",
+              "value": "={{ ($json.body.comment && $json.body.comment.id) || 0 }}",
+              "type": "number"
+            },
+            {
+              "id": "c7000000-0000-0000-0000-000000000006",
+              "name": "senderLogin",
+              "value": "={{ ($json.body.sender && $json.body.sender.login) || '' }}",
+              "type": "string"
+            },
+            {
+              "id": "c7000000-0000-0000-0000-000000000007",
+              "name": "repoOwner",
+              "value": "={{ $json.body.repository.owner.login }}",
+              "type": "string"
+            },
+            {
+              "id": "c7000000-0000-0000-0000-000000000008",
+              "name": "repoName",
+              "value": "={{ $json.body.repository.name }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a7000000-0000-0000-0000-000000000003",
+      "name": "Extract issue fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [680, 220]
+    },
+    {
+      "parameters": {
+        "jsCode": "const prev = $input.first().json;\nconst map = JSON.parse($env.N8N_AGENT_MAP || '{}');\nconst implementerLogins = Object.keys(map).filter(k => map[k] && map[k].role === 'implementer');\nconst commentBody = (prev.commentBody || '').trim();\nconst re = new RegExp('@(' + implementerLogins.join('|') + ')(?![a-z0-9-])', 'i');\nconst m = commentBody.match(re);\nif (!m) {\n  throw new Error('Workflow 07 reached Resolve with no implementer @-mention — filter regression');\n}\nconst mentionedLogin = implementerLogins.find(l => l.toLowerCase() === m[1].toLowerCase());\nconst entry = map[mentionedLogin];\nif (!entry) {\n  throw new Error(`N8N_AGENT_MAP has no entry for mentioned login \"${mentionedLogin}\"`);\n}\nconst instruction = (commentBody.slice(0, m.index) + commentBody.slice(m.index + m[0].length)).trim();\nconst reviewerLogin = $env.N8N_REVIEWER_DEFAULT || '';\nreturn [{ json: { ...prev, host: entry.host, sshPort: entry.port, sshUser: entry.user, implementerLogin: mentionedLogin, reviewerLogin, instruction } }];\n"
+      },
+      "id": "a7000000-0000-0000-0000-000000000004",
+      "name": "Resolve implementer",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [790, 220]
+    },
+    {
+      "parameters": {
+        "jsCode": "const j = $input.first().json;\nconst prompt = `You are @${j.implementerLogin}, responding to an instruction from @${j.senderLogin} on issue #${j.issueNumber}.\n\nIssue title: ${j.issueTitle}\n\nIssue body:\n---\n${j.issueBody}\n---\n\nInstruction from @${j.senderLogin}:\n---\n${j.instruction}\n---\n\nImplement the change. Keep it minimal and scoped to what was asked. Open a PR with a clear title and body; the workflow will push the branch and open the PR for you.\n`;\nreturn [{ json: { ...j, promptB64: Buffer.from(prompt, 'utf8').toString('base64') } }];\n"
+      },
+      "id": "a7000000-0000-0000-0000-000000000005",
+      "name": "Encode prompt",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 220]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "id": "d7000000-0000-0000-0000-000000000001",
+                    "leftValue": "={{ $json.host }}",
+                    "rightValue": "release-agent",
+                    "operator": { "type": "string", "operation": "equals" }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "release-agent"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "id": "d7000000-0000-0000-0000-000000000002",
+                    "leftValue": "={{ $json.host }}",
+                    "rightValue": "qa-agent",
+                    "operator": { "type": "string", "operation": "equals" }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "qa-agent"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a7000000-0000-0000-0000-000000000006",
+      "name": "Switch by host",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [1020, 220]
+    },
+    {
+      "parameters": {
+        "authentication": "privateKey",
+        "resource": "command",
+        "command": "=set +e\ncd ~/workspace || exit 10\n_URL=$(git remote get-url origin 2>/dev/null)\n_T=\"${_URL#*x-access-token:}\"\nexport GH_TOKEN=\"${_T%%@*}\"\ngit fetch origin main >/dev/null 2>&1\ngit checkout -f -B main origin/main >/dev/null 2>&1\nexec bash ./build/dev-env/bin/n8n-agent-issue.sh \"{{ $json.issueNumber }}\" \"{{ $json.promptB64 }}\" \"{{ $json.reviewerLogin }}\"\n"
+      },
+      "id": "a7000000-0000-0000-0000-000000000007",
+      "name": "Run claude in release-agent",
+      "type": "n8n-nodes-base.ssh",
+      "typeVersion": 1,
+      "position": [1240, 140],
+      "credentials": {
+        "sshPrivateKey": {
+          "id": "REPLACE_ME",
+          "name": "release-agent SSH"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "privateKey",
+        "resource": "command",
+        "command": "=set +e\ncd ~/workspace || exit 10\n_URL=$(git remote get-url origin 2>/dev/null)\n_T=\"${_URL#*x-access-token:}\"\nexport GH_TOKEN=\"${_T%%@*}\"\ngit fetch origin main >/dev/null 2>&1\ngit checkout -f -B main origin/main >/dev/null 2>&1\nexec bash ./build/dev-env/bin/n8n-agent-issue.sh \"{{ $json.issueNumber }}\" \"{{ $json.promptB64 }}\" \"{{ $json.reviewerLogin }}\"\n"
+      },
+      "id": "a7000000-0000-0000-0000-000000000008",
+      "name": "Run claude in qa-agent",
+      "type": "n8n-nodes-base.ssh",
+      "typeVersion": 1,
+      "position": [1240, 300],
+      "credentials": {
+        "sshPrivateKey": {
+          "id": "REPLACE_ME",
+          "name": "qa-agent SSH"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "numberInputs": 2
+      },
+      "id": "a7000000-0000-0000-0000-000000000009",
+      "name": "Merge SSH outputs",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [1460, 220]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "b7000000-0000-0000-0000-000000000002",
+              "leftValue": "={{ (() => { const s = $json.stdout || ''; return /^PR_URL=https:\\/\\//m.test(s) && !/^SKIPPED=/m.test(s); })() }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "a7000000-0000-0000-0000-000000000010",
+      "name": "Should comment?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1570, 220]
+    },
+    {
+      "parameters": {
+        "resource": "issue",
+        "operation": "createComment",
+        "owner": "={{ $('Extract issue fields').item.json.repoOwner }}",
+        "repository": "={{ $('Extract issue fields').item.json.repoName }}",
+        "issueNumber": "={{ $('Extract issue fields').item.json.issueNumber }}",
+        "body": "=agent opened {{ (($json.stdout || '').match(/^PR_URL=(https:\\/\\/\\S+)$/m) || [])[1] || '' }}"
+      },
+      "id": "a7000000-0000-0000-0000-000000000011",
+      "name": "Comment on issue",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [1680, 220],
+      "credentials": {
+        "githubApi": {
+          "id": "REPLACE_ME",
+          "name": "qa-bot GitHub"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Is authorised issue mention?", "type": "main", "index": 0 }]]
+    },
+    "Is authorised issue mention?": {
+      "main": [
+        [{ "node": "Extract issue fields", "type": "main", "index": 0 }],
+        []
+      ]
+    },
+    "Extract issue fields": {
+      "main": [[{ "node": "Resolve implementer", "type": "main", "index": 0 }]]
+    },
+    "Resolve implementer": {
+      "main": [[{ "node": "Encode prompt", "type": "main", "index": 0 }]]
+    },
+    "Encode prompt": {
+      "main": [[{ "node": "Switch by host", "type": "main", "index": 0 }]]
+    },
+    "Switch by host": {
+      "main": [
+        [{ "node": "Run claude in release-agent", "type": "main", "index": 0 }],
+        [{ "node": "Run claude in qa-agent", "type": "main", "index": 0 }]
+      ]
+    },
+    "Run claude in release-agent": {
+      "main": [[{ "node": "Merge SSH outputs", "type": "main", "index": 0 }]]
+    },
+    "Run claude in qa-agent": {
+      "main": [[{ "node": "Merge SSH outputs", "type": "main", "index": 1 }]]
+    },
+    "Merge SSH outputs": {
+      "main": [[{ "node": "Should comment?", "type": "main", "index": 0 }]]
+    },
+    "Should comment?": {
+      "main": [
+        [{ "node": "Comment on issue", "type": "main", "index": 0 }],
+        []
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": []
+}


### PR DESCRIPTION
## Summary

- Adds workflow **07 Issue mention** so that commenting `@gramyzer please fix X` on a plain issue (not a PR) routes the free-text instruction — along with the full issue body — to the mentioned agent, which then opens a PR on `agent/issue-<N>` the same way workflow 01 does.
- Fills the gap where issue #99 triggered no task queue today: only `issues.assigned` or `agent-task` label hit workflow 01, and issue-comment @-mentions had no handler (workflow 05 is PR-only).
- Reuses `n8n-agent-issue.sh` end-to-end, so workflows 01 and 07 are idempotent against each other (the script's existing-open-PR check returns `SKIPPED=existing-pr` if the other already opened one for the same issue).

## Files

| Path | Change |
|---|---|
| `build/dev-env/n8n/workflows/07-issue-mention.json` | New workflow (11 nodes, mirrors 01's Webhook → IF → Set → Resolve → Encode → Switch → SSH ×2 → Merge → IF → Comment skeleton). |
| `build/dev-env/n8n/README.md` | New § "Workflow 7"; cross-ref added to workflow 1; `N8N_COMMAND_USERS` description updated to call out that both 05 and 07 consume it. |
| `build/dev-env/README.md` | Bump "6 workflows" → "7 workflows" (two places). |
| `build/dev-env/bin/gh-webhooks-sync.sh` | Append `issue-mention issue_comment` to the DESIRED array so `gh-webhooks-sync` installs the hook. |

## Filter rules

- Event: `issue_comment.created`.
- Comment target: plain issue, i.e. `!body.issue.pull_request`. PR comments stay with workflow 05.
- `body.sender.type !== 'Bot'` (GitHub App postings rejected up front).
- Commenter ∈ `N8N_COMMAND_USERS`.
- Body does **not** match `^/(build|merge|review|fix)\b` (slash commands belong to other workflows).
- Body contains a bare `@<implementer>` match — regex `@(<logins>)(?![a-z0-9-])`, case-insensitive, so `@gramyzer-helper` does not match `@gramyzer`.

## Prompt template

```
You are @<implementer>, responding to an instruction from @<commenter> on issue #<N>.

Issue title: <title>

Issue body:
---
<body>
---

Instruction from @<commenter>:
---
<comment minus the @-mention>
---

Implement the change. Keep it minimal and scoped to what was asked. Open a PR…
```

## Test plan

- [ ] Import the workflow (`./bin/n8n-deploy.sh`) and confirm the webhook URL for `issue-mention` prints in the deploy output.
- [ ] Run `./build/dev-env/bin/gh-webhooks-sync.sh` and confirm the new `issue-mention` hook appears on the repo.
- [ ] Comment `@gramyzer draft a fix for this` on a plain issue as `@rinat-enikeev` → expect a new PR on branch `agent/issue-<N>` within ~2 min and a back-post on the issue linking the PR.
- [ ] Same comment on a PR → expect workflow 05 to run (not 07) — 07's filter requires `!issue.pull_request`.
- [ ] `@gramyzer-helper` (non-existent prefix) → expect no trigger (lookahead guard).
- [ ] `/build ios` comment on an issue → expect no trigger (slash exclusion).
- [ ] Comment from a non-`N8N_COMMAND_USERS` login mentioning `@gramyzer` → expect no trigger.
- [ ] With workflow 01 already having opened a PR via `agent-task` label, a subsequent `@gramyzer` comment on the same issue → expect `SKIPPED=existing-pr` and no duplicate back-post comment.

## Notes

- Loop safety mirrors workflow 05: `sender.type === 'Bot'` blocks the App-posted agent comments that are the normal failure mode; `N8N_COMMAND_USERS` gates the human-authored path. Cross-agent delegation works if an agent login is in the command-users list (unchanged from 05's semantics).
- No new env vars introduced. Uses existing `N8N_COMMAND_USERS`, `N8N_AGENT_MAP`, `N8N_REVIEWER_DEFAULT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)