### PR TITLE
n8n: allow @innovesss to run /build and @-mention agents

### DIFF
--- a/build/dev-env/n8n.env.example
+++ b/build/dev-env/n8n.env.example
@@ -67,4 +67,4 @@ N8N_MERGE_AUTHORIZED_LOGINS=alexpovstin,gramyzer
 # the mentioned agent. Includes agent logins on purpose so agents can
 # delegate to each other; the @<login> + free-text pattern is what loop-proof
 # templated bot comments never produce, so this does not enable loops.
-N8N_COMMAND_USERS=rinat-enikeev,alexpovstin,gramyzer,releaseng
+N8N_COMMAND_USERS=rinat-enikeev,alexpovstin,innovesss,gramyzer,releaseng


### PR DESCRIPTION
## Summary

- Adds `innovesss` to `N8N_COMMAND_USERS` in `build/dev-env/n8n.env.example`.
- That var gates the authorised-commander allowlist used by workflow 03 (`/build ios|android`), workflow 05 (@-mention agents in PR comments), and workflow 07 (@-mention agents in issue comments, pending #101).

## Follow-up on the Mac mini

This PR only edits the checked-in example. The live file is `build/dev-env/n8n.env` on the Mac mini (gitignored). After merge:

1. Edit `n8n.env` there to match: `N8N_COMMAND_USERS=rinat-enikeev,alexpovstin,innovesss,gramyzer,releaseng`
2. Restart the n8n container so env changes are picked up:
   `docker compose -f build/dev-env/docker-compose.dev.yml restart n8n`
3. Verify: `docker exec stellar-n8n node -e "console.log(process.env.N8N_COMMAND_USERS)"`

## Test plan

- [ ] After the live env is updated, have `@innovesss` comment `/build android` on an open PR → expect a build to run and a result comment.
- [ ] Have `@innovesss` comment `@gramyzer please ...` on an open PR → expect a follow-up commit from the agent (workflow 05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)