### PR TITLE
Fix #102: make "Show raw invite code" fully tappable

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -1259,6 +1260,7 @@ private fun DoneStage(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .heightIn(min = 48.dp)
                     .clickable { showRawCode = !showRawCode }
                     .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically

--- a/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
@@ -790,8 +790,10 @@ struct CreateGroupView: View {
                                 .foregroundStyle(.tertiary)
                                 .rotationEffect(.degrees(showRawInviteCode ? 90 : 0))
                         }
+                        .frame(minHeight: 44)
                         .padding(.vertical, 12)
                         .padding(.horizontal, 16)
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
 


### PR DESCRIPTION
Fixes #102

## Summary
- **iOS**: the toggle row used `Button { HStack { Text; Spacer(); Image } }.buttonStyle(.plain)`. With `.plain`, SwiftUI only hit-tests the filled content, leaving the `Spacer` area between label and chevron unresponsive. Added `.contentShape(Rectangle())` so the whole framed area is tappable, plus a `minHeight: 44` to meet Apple's touch-target guideline.
- **Android**: the row's effective height (14 sp label + 12 dp vertical padding ≈ 42 dp) sits below Material's 48 dp accessibility minimum. Added `.heightIn(min = 48.dp)` above the `clickable` so the entire visible row is comfortably tappable.

Copy-to-clipboard was already wired on both platforms after the original 1.10.1 report (Android `TextButton` with Toast, iOS `Button` writing to `UIPasteboard`), so no additional Copy work was needed.

## Test plan
- [ ] Android: build the app, create a group, tap anywhere in the "Show raw invite code" row (left edge, center, near chevron) — row toggles on every tap
- [ ] Android: reveal raw code, tap "Copy code", confirm Toast appears and clipboard contains the code
- [ ] iOS: build the app, create a group, tap anywhere in the "Show raw invite code" row including the empty space between label and chevron — row toggles on every tap
- [ ] iOS: reveal raw code, tap "Copy code", confirm clipboard contains the code