### PR TITLE
android: fix Scan QR back button in group creation flow (#97)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
@@ -143,6 +143,7 @@ fun CreateGroupScreen(
     }
 
     if (showScanner) {
+        BackHandler { showScanner = false }
         Box(modifier = Modifier.fillMaxSize()) {
             QRScannerView { scanned ->
                 val trimmed = scanned.trim().lowercase()


### PR DESCRIPTION
## Summary

Fixes #97. In the group creation flow, the QR scanner view inside `CreateGroupScreen` had no `BackHandler`, so back presses fell through to the outer `PEOPLE → IDENTITY` step handler:

- **First press:** silently flipped the step from PEOPLE to IDENTITY. The scanner was still on-screen (because `showScanner` was true), so nothing appeared to change.
- **Second press:** the PEOPLE handler was now disabled, so back fell through and popped the whole `create` route to home, discarding the flow.

The fix registers a `BackHandler` inside the `if (showScanner)` branch that simply sets `showScanner = false`. Because it is registered later in composition than the outer handlers, it takes priority (LIFO dispatch), so it closes the scanner and lets the enclosing step/route handlers stay in charge of subsequent back presses.

## Test plan

- [ ] Build `:app:compilePlayDebugKotlin` (verified locally — BUILD SUCCESSFUL).
- [ ] Manual on Android: Create group → name + Anarchy → Next → Invite by inbox key → Scan QR → back.
  - [ ] First back closes scanner, returns to PEOPLE step with key dialog state preserved.
  - [ ] Subsequent back presses step back through PEOPLE → IDENTITY → home as expected.

## Notes

The same QR-scanner-without-BackHandler pattern exists in `JoinGroupScreen` and `InviteMemberScreen`. Those aren't part of the reported flow, so they're left out of this PR; happy to follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)