### PR TITLE
fix: wire group avatar picker on both Android and iOS (#98)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/model/ChatGroup.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/model/ChatGroup.kt
@@ -55,7 +55,10 @@ data class ChatGroup(
      *  ordering (most recent first). 0 = no messages yet, falls back to [createdAt]. */
     var lastMessageAt: Long = 0,
     /** Whether this chat is pinned to the top of the chat list. */
-    var isPinned: Boolean = false
+    var isPinned: Boolean = false,
+    /** JPEG/PNG bytes of a locally-set group avatar (downscaled at pick time).
+     *  Held on the creator's device only; not propagated to other members yet. */
+    var avatarData: ByteArray? = null
 ) {
     /** Group ID as raw bytes (hex string → ByteArray). */
     val groupIDData: ByteArray get() = id.hexToBytes()

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/PersistedModels.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/PersistedModels.kt
@@ -33,7 +33,10 @@ data class PersistedGroup(
     val groupTypeRawValue: Int = 0,
     /** Encrypted JSON-encoded list of admin BLS pubkey hex strings (lowercase).
      *  Only populated for Oligarchy groups; existing groups migrate in as null. */
-    val encryptedAdminPubkeys: ByteArray? = null
+    val encryptedAdminPubkeys: ByteArray? = null,
+    /** Encrypted avatar image bytes (JPEG, downscaled at pick time). Null for
+     *  groups without a locally-set avatar and for pre-migration rows. */
+    val encryptedAvatar: ByteArray? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/PersistenceStore.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/PersistenceStore.kt
@@ -175,7 +175,8 @@ class PersistenceStore(context: Context) {
             pushNotificationsEnabled = group.pushNotificationsEnabled,
             lastMessageAt = group.lastMessageAt,
             isPinned = group.isPinned,
-            encryptedAdminPubkeys = encAdmins
+            encryptedAdminPubkeys = encAdmins,
+            encryptedAvatar = group.avatarData?.let { StorageEncryption.encrypt(it) }
         )
     }
 
@@ -203,6 +204,10 @@ class PersistenceStore(context: Context) {
             } catch (_: Exception) { mutableSetOf() }
         } ?: mutableSetOf()
 
+        val avatarData: ByteArray? = persisted.encryptedAvatar?.let { enc ->
+            try { StorageEncryption.decrypt(enc) } catch (_: Exception) { null }
+        }
+
         return ChatGroup(
             id = persisted.id,
             name = name,
@@ -223,7 +228,8 @@ class PersistenceStore(context: Context) {
             removedByPubkeyHex = persisted.removedByPubkeyHex,
             pushNotificationsEnabled = persisted.pushNotificationsEnabled,
             lastMessageAt = persisted.lastMessageAt,
-            isPinned = persisted.isPinned
+            isPinned = persisted.isPinned,
+            avatarData = avatarData
         )
     }
 

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/StellarChatDatabase.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/persistence/StellarChatDatabase.kt
@@ -20,7 +20,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PersistedTransportBundle::class, PersistedPendingRekey::class,
         PersistedEpochSnapshot::class, PersistedInvitedContact::class
     ],
-    version = 16
+    version = 17
 )
 abstract class StellarChatDatabase : RoomDatabase() {
     abstract fun dao(): StellarChatDao
@@ -159,13 +159,21 @@ abstract class StellarChatDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_16_17 = object : Migration(16, 17) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Locally-set group avatar: encrypted JPEG bytes. Null for groups
+                // without an avatar and for pre-existing rows.
+                db.execSQL("ALTER TABLE groups ADD COLUMN encryptedAvatar BLOB")
+            }
+        }
+
         fun getInstance(context: Context): StellarChatDatabase {
             return instance ?: synchronized(this) {
                 instance ?: Room.databaseBuilder(
                     context.applicationContext,
                     StellarChatDatabase::class.java,
                     "stellar_chat.db"
-                ).addMigrations(MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16)
+                ).addMigrations(MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17)
                 .fallbackToDestructiveMigration()
                 .build().also { instance = it }
             }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
@@ -4,13 +4,19 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.graphics.BitmapFactory
+import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -74,6 +80,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -83,7 +91,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate as drawRotate
 import androidx.compose.ui.platform.LocalContext
@@ -299,6 +310,13 @@ private fun IdentityStep(
     accent: GroupAccent,
     onAccentChange: (GroupAccent) -> Unit
 ) {
+    val context = LocalContext.current
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia()
+    ) { uri: Uri? ->
+        if (uri != null) viewModel.onAvatarPicked(context, uri)
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -308,14 +326,25 @@ private fun IdentityStep(
     ) {
         Spacer(Modifier.height(16.dp))
 
-        // Hero avatar with camera badge
-        Box(contentAlignment = Alignment.BottomEnd) {
+        // Hero avatar with camera badge — tap anywhere on it to pick a photo.
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(54.dp))
+                .clickable {
+                    photoPickerLauncher.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                    )
+                }
+                .semantics { contentDescription = "Change group photo" },
+            contentAlignment = Alignment.BottomEnd
+        ) {
             GroupAvatar(
                 size = 108.dp,
                 accent = accent,
                 name = viewModel.groupName,
                 filled = viewModel.groupName.isNotBlank(),
-                corner = 54.dp
+                corner = 54.dp,
+                avatarBytes = viewModel.avatarBytes
             )
             Box(
                 modifier = Modifier
@@ -328,7 +357,7 @@ private fun IdentityStep(
             ) {
                 Icon(
                     Icons.Filled.PhotoCamera,
-                    contentDescription = "Change photo",
+                    contentDescription = null,
                     tint = Color.White,
                     modifier = Modifier.size(18.dp)
                 )
@@ -844,8 +873,16 @@ private fun GroupAvatar(
     accent: GroupAccent,
     name: String,
     filled: Boolean,
-    corner: androidx.compose.ui.unit.Dp
+    corner: androidx.compose.ui.unit.Dp,
+    avatarBytes: ByteArray? = null
 ) {
+    val imageBitmap: ImageBitmap? = remember(avatarBytes) {
+        avatarBytes?.let { bytes ->
+            try {
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.asImageBitmap()
+            } catch (_: Exception) { null }
+        }
+    }
     val brush: Brush = if (filled) accent.brush() else SolidColor(MaterialTheme.colorScheme.surfaceContainerHighest)
     Box(
         modifier = Modifier
@@ -854,15 +891,20 @@ private fun GroupAvatar(
             .background(brush),
         contentAlignment = Alignment.Center
     ) {
-        if (filled) {
-            Text(
+        when {
+            imageBitmap != null -> Image(
+                bitmap = imageBitmap,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.size(size).clip(RoundedCornerShape(corner))
+            )
+            filled -> Text(
                 initialsFor(name),
                 color = Color.White,
                 fontSize = (size.value * 0.36f).sp,
                 fontWeight = FontWeight.Bold
             )
-        } else {
-            Icon(
+            else -> Icon(
                 Icons.Filled.PhotoCamera,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -933,7 +975,8 @@ private fun ProgressStage(
                     accent = accent,
                     name = viewModel.groupName,
                     filled = true,
-                    corner = 60.dp
+                    corner = 60.dp,
+                    avatarBytes = viewModel.avatarBytes
                 )
             }
         }
@@ -1119,7 +1162,8 @@ private fun DoneStage(
                 accent = accent,
                 name = viewModel.groupName,
                 filled = true,
-                corner = 42.dp
+                corner = 42.dp,
+                avatarBytes = viewModel.avatarBytes
             )
             Box(
                 modifier = Modifier

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/CreateGroupViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/CreateGroupViewModel.kt
@@ -1,5 +1,9 @@
 package chat.onym.android.viewmodel
 
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -22,6 +26,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
 import java.security.SecureRandom
 import kotlin.coroutines.resume
 
@@ -40,6 +45,8 @@ sealed class InvitationStatus {
     data class Failed(val reason: String) : InvitationStatus()
 }
 
+private const val AVATAR_MAX_EDGE_PX = 256
+
 class CreateGroupViewModel : ViewModel() {
     var groupName by mutableStateOf("")
     var groupType by mutableStateOf(SEPGroupType.ANARCHY)
@@ -54,6 +61,11 @@ class CreateGroupViewModel : ViewModel() {
     var keyValidationError by mutableStateOf<String?>(null)
     var onChainStatus by mutableStateOf<OnChainPublishStatus>(OnChainPublishStatus.Idle)
     val invitationStatuses = mutableStateMapOf<String, InvitationStatus>()
+
+    /** Downscaled JPEG bytes of the user-picked avatar, ready for persistence. */
+    var avatarBytes by mutableStateOf<ByteArray?>(null)
+    /** Source URI of the picked avatar, used for inline preview. */
+    var avatarUri by mutableStateOf<Uri?>(null)
 
     fun selectGroupType(type: SEPGroupType) {
         groupType = type
@@ -87,7 +99,8 @@ class CreateGroupViewModel : ViewModel() {
                 epoch = 0,
                 salt = SEPCommitmentBuilder.generateSalt(),
                 tier = effectiveTier,
-                groupType = groupType
+                groupType = groupType,
+                avatarData = avatarBytes
             )
             // Oligarchy creator is seeded as the initial admin. Demoting this
             // member (via future on-chain flows) requires another admin's consent.
@@ -143,6 +156,38 @@ class CreateGroupViewModel : ViewModel() {
 
     fun removeParticipant(key: String) {
         participantKeys.remove(key)
+    }
+
+    /** Decode the picked image, downscale it, and store both the source URI (for
+     *  inline preview) and compressed JPEG bytes (for persistence). Caps the
+     *  long edge at [AVATAR_MAX_EDGE_PX] to keep the persisted row small. */
+    fun onAvatarPicked(context: Context, uri: Uri) {
+        val resolver = context.contentResolver
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+        val longest = maxOf(bounds.outWidth, bounds.outHeight).coerceAtLeast(1)
+        var sample = 1
+        while (longest / sample > AVATAR_MAX_EDGE_PX * 2) sample *= 2
+        val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
+        val bitmap = resolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, decodeOpts)
+        } ?: return
+        val scaled = downscale(bitmap, AVATAR_MAX_EDGE_PX)
+        val buffer = ByteArrayOutputStream()
+        scaled.compress(Bitmap.CompressFormat.JPEG, 85, buffer)
+        if (scaled !== bitmap) scaled.recycle()
+        bitmap.recycle()
+        avatarBytes = buffer.toByteArray()
+        avatarUri = uri
+    }
+
+    private fun downscale(src: Bitmap, maxEdge: Int): Bitmap {
+        val w = src.width
+        val h = src.height
+        val longest = maxOf(w, h)
+        if (longest <= maxEdge) return src
+        val scale = maxEdge.toFloat() / longest.toFloat()
+        return Bitmap.createScaledBitmap(src, (w * scale).toInt(), (h * scale).toInt(), true)
     }
 
     fun startCreation(

--- a/clients/ios/StellarChat/StellarChat/Models/ChatGroup.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/ChatGroup.swift
@@ -41,6 +41,9 @@ struct ChatGroup: Identifiable, Codable {
     var lastMessageAt: Date?
     /// Whether this chat is pinned to the top of the chat list.
     var isPinned: Bool = false
+    /// JPEG bytes of a locally-set group avatar (downscaled at pick time).
+    /// Held on the creator's device only; not propagated to other members yet.
+    var avatarData: Data?
 
     /// Nostr subscription topic tag for this group.
     /// Derivation (SEP-XXXX §3.1): `topicTag = hex(SHA-256("sep-topic-v1" || groupSecret)[0..8])`

--- a/clients/ios/StellarChat/StellarChat/Models/PersistedModels.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/PersistedModels.swift
@@ -31,6 +31,9 @@ final class PersistedGroup {
     /// Encrypted JSON-encoded `[String]` of admin BLS pubkey hex. Optional so
     /// existing SwiftData stores migrate in as `nil` (empty set).
     var encryptedAdminPubkeys: Data?
+    /// Encrypted JPEG bytes of a locally-set group avatar. Optional so existing
+    /// SwiftData stores migrate in as `nil`.
+    var encryptedAvatar: Data?
 
     init(
         id: String,
@@ -52,7 +55,8 @@ final class PersistedGroup {
         lastMessageAt: Date? = nil,
         isPinned: Bool = false,
         groupTypeRawValue: Int? = nil,
-        encryptedAdminPubkeys: Data? = nil
+        encryptedAdminPubkeys: Data? = nil,
+        encryptedAvatar: Data? = nil
     ) {
         self.id = id
         self.encryptedName = encryptedName
@@ -74,6 +78,7 @@ final class PersistedGroup {
         self.isPinned = isPinned
         self.groupTypeRawValue = groupTypeRawValue
         self.encryptedAdminPubkeys = encryptedAdminPubkeys
+        self.encryptedAvatar = encryptedAvatar
     }
 }
 

--- a/clients/ios/StellarChat/StellarChat/Models/PersistenceStore.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/PersistenceStore.swift
@@ -652,6 +652,8 @@ final class PersistenceStore {
             }
         }
 
+        let encAvatar: Data? = group.avatarData.flatMap { try? StorageEncryption.encrypt($0) }
+
         return PersistedGroup(
             id: group.id,
             encryptedName: encName,
@@ -672,7 +674,8 @@ final class PersistenceStore {
             lastMessageAt: group.lastMessageAt,
             isPinned: group.isPinned,
             groupTypeRawValue: Int(group.groupType.rawValue),
-            encryptedAdminPubkeys: encAdmins
+            encryptedAdminPubkeys: encAdmins,
+            encryptedAvatar: encAvatar
         )
     }
 
@@ -722,6 +725,10 @@ final class PersistenceStore {
            let adminJSON = try? StorageEncryption.decrypt(encAdmins),
            let admins = try? JSONDecoder().decode([String].self, from: adminJSON) {
             group.adminPubkeys = Set(admins)
+        }
+        if let encAvatar = persisted.encryptedAvatar,
+           let avatar = try? StorageEncryption.decrypt(encAvatar) {
+            group.avatarData = avatar
         }
         return group
     }

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -575,7 +575,7 @@ final class AppState {
     }
 
     /// Create a group with the local user as the first member, computing the initial commitment.
-    func createGroup(name: String, groupType: SEPGroupType = .anarchy) throws -> (ChatGroup, String) {
+    func createGroup(name: String, groupType: SEPGroupType = .anarchy, avatarData: Data? = nil) throws -> (ChatGroup, String) {
         var groupIDBytes = [UInt8](repeating: 0, count: 32)
         _ = SecRandomCopyBytes(kSecRandomDefault, 32, &groupIDBytes)
         let groupID = Data(groupIDBytes)
@@ -604,6 +604,7 @@ final class AppState {
             tier: tier
         )
         group.groupType = groupType
+        group.avatarData = avatarData
         // Oligarchy creator is seeded as the initial admin. Demoting this
         // member (via future on-chain flows) requires another admin's consent.
         if groupType == .oligarchy {

--- a/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
@@ -1,3 +1,4 @@
+import PhotosUI
 import SwiftMLS
 import SwiftUI
 
@@ -9,6 +10,9 @@ struct CreateGroupView: View {
     @State private var groupName = ""
     @State private var accent: GroupAccent = .blue
     @State private var groupType: SEPGroupType = .anarchy
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var avatarImage: UIImage?
+    @State private var avatarData: Data?
 
     // Participants (Step 2)
     @State private var participantKeys: [String] = []
@@ -105,22 +109,37 @@ struct CreateGroupView: View {
     private var identityStep: some View {
         ScrollView {
             VStack(spacing: 0) {
-                // Hero avatar
-                ZStack(alignment: .bottomTrailing) {
-                    groupAvatar(
-                        size: 108,
-                        filled: nameIsValid,
-                        corner: 54
-                    )
-                    Circle()
-                        .fill(Color.accentColor)
-                        .frame(width: 36, height: 36)
-                        .overlay(Image(systemName: "camera.fill").font(.system(size: 15, weight: .semibold)).foregroundStyle(.white))
-                        .overlay(Circle().stroke(Color(.systemGroupedBackground), lineWidth: 3))
-                        .offset(x: 2, y: 2)
+                // Hero avatar — tap to pick a photo.
+                PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+                    ZStack(alignment: .bottomTrailing) {
+                        groupAvatar(
+                            size: 108,
+                            filled: nameIsValid,
+                            corner: 54
+                        )
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 36, height: 36)
+                            .overlay(Image(systemName: "camera.fill").font(.system(size: 15, weight: .semibold)).foregroundStyle(.white))
+                            .overlay(Circle().stroke(Color(.systemGroupedBackground), lineWidth: 3))
+                            .offset(x: 2, y: 2)
+                    }
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Change group photo")
                 .padding(.top, 12)
                 .padding(.bottom, 20)
+                .onChange(of: selectedPhotoItem) { _, newItem in
+                    guard let newItem else { return }
+                    Task {
+                        if let data = try? await newItem.loadTransferable(type: Data.self),
+                           let image = UIImage(data: data) {
+                            let processed = Self.downscaleAvatar(image)
+                            avatarImage = processed.image
+                            avatarData = processed.data
+                        }
+                    }
+                }
 
                 // Name input
                 VStack(alignment: .leading, spacing: 8) {
@@ -856,7 +875,13 @@ struct CreateGroupView: View {
     private func groupAvatar(size: CGFloat, filled: Bool, corner: CGFloat) -> some View {
         let label = nameIsValid ? groupName.trimmingCharacters(in: .whitespaces) : ""
         ZStack {
-            if filled {
+            if let avatarImage {
+                Image(uiImage: avatarImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: size, height: size)
+                    .clipShape(RoundedRectangle(cornerRadius: corner))
+            } else if filled {
                 RoundedRectangle(cornerRadius: corner)
                     .fill(accent.gradient)
                 Text(initials(for: label))
@@ -871,6 +896,24 @@ struct CreateGroupView: View {
             }
         }
         .frame(width: size, height: size)
+    }
+
+    /// Downscale the picked image so the long edge is at most 256 px and re-encode
+    /// as JPEG quality 0.85 so the persisted row stays small.
+    private static func downscaleAvatar(_ source: UIImage) -> (image: UIImage, data: Data) {
+        let maxEdge: CGFloat = 256
+        let longest = max(source.size.width, source.size.height)
+        let scale = longest > maxEdge ? maxEdge / longest : 1
+        let targetSize = CGSize(
+            width: source.size.width * scale,
+            height: source.size.height * scale
+        )
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        let resized = renderer.image { _ in
+            source.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+        let data = resized.jpegData(compressionQuality: 0.85) ?? Data()
+        return (resized, data)
     }
 
     private func avatarCircle(seed: String, size: CGFloat, name: String) -> some View {
@@ -906,7 +949,11 @@ struct CreateGroupView: View {
 
         Task {
             do {
-                let (group, code) = try appState.createGroup(name: sanitizedName, groupType: groupType)
+                let (group, code) = try appState.createGroup(
+                    name: sanitizedName,
+                    groupType: groupType,
+                    avatarData: avatarData
+                )
                 createdGroup = group
                 inviteCode = code
                 GroupAccentStore.set(accent, for: group.id)


### PR DESCRIPTION
## Summary
- Android + iOS: the avatar placeholder in the group creation flow rendered a camera badge but had no tap handler — nothing happened on tap (#98). Wire the system photo picker to the placeholder and render the selected image inline.
- Persist the picked JPEG bytes on the creator's device via the existing field-encryption pipelines (Room v17 migration on Android, optional SwiftData property on iOS).
- Downscale each pick to 256 px / JPEG quality 0.85 so persisted rows stay small (typically <30 KB).

## Scope boundaries (intentional)
- No propagation of the avatar to other members yet (no Blossom upload, no change to `InviteCode`/`BootstrapPayload`). Remote members continue to see initials. Cross-device sync is tracked as a follow-up.
- No camera-only capture path; the system photo picker already exposes the camera entry point.
- No avatar edit from group-info; same follow-up.

## Test plan
- [ ] Android 13+ fresh install: tap avatar → picker opens → image previews inline → create group → kill and relaunch → avatar still renders (decrypts from `encryptedAvatar`).
- [ ] Android 10 (API 29): same flow — `PickVisualMedia` uses the compat backport; no runtime permission prompt.
- [ ] iOS 18: tap avatar → `PhotosPicker` sheet opens → image previews inline → create group → kill and relaunch → avatar still renders.
- [ ] Cancel the picker → returns to placeholder, no state change.
- [ ] Upgrade from a v16 Room database → column added via `MIGRATION_16_17`, existing groups decode with `avatarData = null`.
- [ ] Create a group with a 4000×3000 source image → persisted bytes <50 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)