### PR TITLE
fix(android): propagate group member removal in real-time (#115)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -3335,6 +3335,13 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                 processedProtocolEventIDs.add(eventID)
             }
             if (isNew) {
+                // Transport invokes this callback on Dispatchers.IO. Dispatching to
+                // Main ensures writes to SnapshotStateList (`groups`, `chatMessages`)
+                // happen on the Compose frame thread, so that recomposition of
+                // ChatScreen / GroupInfoScreen fires immediately when a member is
+                // added/removed — rather than deferring until the user forces a
+                // re-read by navigating away and back (issue #115).
+                viewModelScope.launch {
                 try {
                     val obj = JSONObject(json)
                     val msgType = obj.optString("type")
@@ -3363,7 +3370,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                             // Phase 4: Refuse salt responses for removal epochs — the requester
                             // should use SEPRekeyResendRequest via inbox instead.
                             val isRemoval = try {
-                                kotlinx.coroutines.runBlocking { store.isRemovalEpoch(groupID, epoch.toInt()) }
+                                store.isRemovalEpoch(groupID, epoch.toInt())
                             } catch (_: Exception) { false }
                             if (isRemoval) {
                                 if (BuildConfig.DEBUG) Log.d("GroupListVM", "Salt request for removal epoch $epoch — refusing")
@@ -3461,6 +3468,7 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                         }
                     }
                 } catch (_: Exception) { }
+                }
             }
         }
     }


### PR DESCRIPTION
The protocol message handler was invoked on Dispatchers.IO by the Nostr
transport. Writes to SnapshotStateList (groups, chatMessages) from that
thread did not reliably reach the Compose recomposer, so a removed user
stayed visible in GroupInfoScreen and the "You were removed" banner did
not appear on ChatScreen until the user navigated away and back — which
forced a fresh read.

Dispatching the handler body through viewModelScope.launch routes all
mutations through Dispatchers.Main.immediate, so the recomposer sees
them on the frame thread and the UI updates immediately after a
SEPRemovalNotice (or any other protocol message) arrives. Also drops
the runBlocking wrapper around store.isRemovalEpoch — the suspend
function can now be awaited directly inside the launched coroutine.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
