### PR TITLE
Fix duplicate QR scan corrupting group-creation state

### DIFF
--- a/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
@@ -1175,12 +1175,23 @@ private struct InviteByKeyDetailView: View {
             }
             .sheet(isPresented: $showScanner) {
                 QRScannerView { scanned in
-                    let t = scanned.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                    if isValidKey(t) {
-                        keyInput = t
-                        addTapped()
-                    }
                     showScanner = false
+                    let t = scanned.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                    guard isValidKey(t) else {
+                        error = "Scanned code is not a valid 64-character inbox key."
+                        return
+                    }
+                    if t == ownInboxKey.lowercased() {
+                        error = "Cannot add your own inbox key."
+                        return
+                    }
+                    if existing.contains(t) {
+                        error = "This user has already been added."
+                        return
+                    }
+                    error = nil
+                    onAdd(t)
+                    dismiss()
                 }
             }
         }


### PR DESCRIPTION
Scanning a QR code in InviteByKeyDetailView wrote directly into
`keyInput` and then called `addTapped()`, coupling the scan path with
the manual-add path. On a duplicate scan the text field was left filled
with the duplicate key while the error was shown, causing confusing UI
state and (per issue #108) making the pending-member flow feel broken
with no way to recover.

Replace the indirection with inline validation in the scan callback:
close the scanner first, then validate, check ownership, check
duplicates, and only call `onAdd` + `dismiss()` on a clean accept.
Duplicate scans now show "This user has already been added." and leave
both the pending list and the text field untouched.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
