### PR TITLE
Fix unresponsive Load Contacts button after dismissing iOS 18 picker

### DIFF
--- a/clients/ios/StellarChat/StellarChat/Models/InvitedContactStore.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/InvitedContactStore.swift
@@ -129,6 +129,7 @@ struct PhoneContact: Identifiable, Equatable {
 enum ContactsPermission {
     case notDetermined
     case denied
+    case limited
     case authorized
 }
 
@@ -140,18 +141,21 @@ enum SystemContactsImporter {
         case .notDetermined: return .notDetermined
         case .authorized: return .authorized
         #if compiler(>=5.9)
-        case .limited: return .authorized
+        case .limited: return .limited
         #endif
         case .denied, .restricted: return .denied
         @unknown default: return .denied
         }
     }
 
-    static func requestAccess() async -> Bool {
+    /// Returns the resulting permission state (not a bool) so callers can
+    /// distinguish full access from iOS 18 limited access, which may yield
+    /// zero contacts and needs a separate recovery UI.
+    static func requestAccess() async -> ContactsPermission {
         let store = CNContactStore()
         return await withCheckedContinuation { cont in
-            store.requestAccess(for: .contacts) { granted, _ in
-                cont.resume(returning: granted)
+            store.requestAccess(for: .contacts) { _, _ in
+                cont.resume(returning: permission())
             }
         }
     }

--- a/clients/ios/StellarChat/StellarChat/Views/ContactsView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ContactsView.swift
@@ -1,3 +1,5 @@
+import Contacts
+import ContactsUI
 import SwiftUI
 
 struct ContactsView: View {
@@ -11,6 +13,7 @@ struct ContactsView: View {
     @State private var pickerTarget: PhoneContact?
     @State private var phoneFilter = ""
     @State private var resendError: String?
+    @State private var showLimitedAccessPicker = false
 
     private var activeContacts: [(pubkey: String, groupNames: String, lastSeen: Date)] {
         var map: [String: (groups: Set<String>, lastSeen: Date)] = [:]
@@ -58,6 +61,10 @@ struct ContactsView: View {
         .navigationTitle("Contacts")
         .sheet(item: $pickerTarget) { contact in
             TelegramInvitePickerView(contact: contact)
+        }
+        .contactAccessPicker(isPresented: $showLimitedAccessPicker) { _ in
+            contactsPermission = SystemContactsImporter.permission()
+            Task { await loadPhonebook() }
         }
         .alert("Set Name", isPresented: .init(
             get: { aliasTarget != nil },
@@ -223,6 +230,31 @@ struct ContactsView: View {
                 }
                 .padding(.vertical, 4)
 
+            case .limited:
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(phonebook.isEmpty
+                         ? "Onym only sees contacts you select. You haven't picked any yet — choose some to invite to encrypted chats."
+                         : "Onym only sees contacts you've selected. Add more anytime.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Button {
+                        showLimitedAccessPicker = true
+                    } label: {
+                        Label(phonebook.isEmpty ? "Select Contacts" : "Manage Selection",
+                              systemImage: "person.crop.circle.badge.plus")
+                            .fontWeight(.semibold)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                    if importing {
+                        HStack {
+                            ProgressView().controlSize(.small)
+                            Text("Loading contacts…")
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+
             case .authorized:
                 if importing {
                     HStack {
@@ -236,6 +268,8 @@ struct ContactsView: View {
                         Label("Load Contacts", systemImage: "arrow.clockwise")
                     }
                 }
+            }
+            if contactsPermission == .authorized || contactsPermission == .limited {
                 if let importError {
                     Text(importError)
                         .font(.caption)
@@ -271,7 +305,7 @@ struct ContactsView: View {
         } header: {
             Text("From Phonebook")
         } footer: {
-            if contactsPermission == .authorized, !phonebook.isEmpty {
+            if (contactsPermission == .authorized || contactsPermission == .limited), !phonebook.isEmpty {
                 Text("Tap Invite to open Telegram with an encrypted chat link pre-filled.")
                     .font(.caption2)
             }
@@ -346,10 +380,12 @@ struct ContactsView: View {
     }
 
     private func requestAndLoad() async {
-        let granted = await SystemContactsImporter.requestAccess()
-        contactsPermission = granted ? .authorized : .denied
-        if granted {
+        contactsPermission = await SystemContactsImporter.requestAccess()
+        switch contactsPermission {
+        case .authorized, .limited:
             await loadPhonebook()
+        case .denied, .notDetermined:
+            break
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #112. On iOS 18, choosing "Select Contacts" in the system permission dialog and then backing out of the picker without selecting anyone left the **Sync Contacts** button replaced by an inert **Load Contacts** button. The app had treated `.limited` access the same as full `.authorized` access, so `fetchAll()` returned 0 contacts and tapping the button just refetched an empty set forever — no UI affordance to re-open the system picker.

- Add a `.limited` case to `ContactsPermission` and stop conflating it with `.authorized`.
- Change `SystemContactsImporter.requestAccess()` to return the resulting permission state instead of a bool, so callers can branch on limited vs full access.
- In `ContactsView`, render a dedicated limited-access state with a **Select Contacts** / **Manage Selection** button that presents iOS 18's `contactAccessPicker` to let the user add/remove the selected subset. The contact list and search remain shared with the full-access path.

## Test plan

- [ ] Fresh install on iOS 18 → tap **Sync Contacts** → choose **Select Contacts** → tap **Back** without selecting → button now reads **Select Contacts** and presents the limited contact picker on tap.
- [ ] After selecting at least one contact in the limited picker, the chosen contacts appear in the list and the button changes to **Manage Selection**.
- [ ] Tapping **Allow Full Access** still shows the full phonebook with the existing **Load Contacts** behavior unchanged.
- [ ] Denying access still shows the **Open Settings** path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)