### PR TITLE
fix: user-friendly error for invalid invite code on Join Group (#111)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/JoinGroupViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/JoinGroupViewModel.kt
@@ -56,7 +56,7 @@ class JoinGroupViewModel : ViewModel() {
             verificationResult = null
             error = null
         } catch (e: Exception) {
-            error = "Invalid invite code: ${e.message}"
+            error = "Invalid invite code. Please check the code and try again."
             decodedGroup = null
         }
     }


### PR DESCRIPTION
## Summary
- Replace raw exception message in `JoinGroupViewModel.decodeInvite()` with a user-friendly validation message.
- Previously, an invalid invite code surfaced internal Java type info (e.g. `Value N of type java.lang.String cannot be converted to JSONObject`).
- Now, users see: *"Invalid invite code. Please check the code and try again."*

Fixes #111

## Test plan
- [ ] Open the app on Android, navigate to **Join Group**.
- [ ] Enter random digits (e.g. `149`) into the Invite Code field and tap **Preview**.
- [ ] Verify the displayed error reads *"Invalid invite code. Please check the code and try again."* with no Java/JSON internals.
- [ ] Enter an empty value and tap **Preview** — the existing "Please enter an invite code" message should still appear.
- [ ] Enter a valid invite code and confirm preview still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)