### PR TITLE
fix: read iOS Settings version from bundle

### DIFF
--- a/clients/ios/StellarChat/StellarChat/Views/SettingsView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/SettingsView.swift
@@ -273,7 +273,7 @@ struct SettingsView: View {
                 row(
                     icon: SettingsIconBox(systemImage: "info.circle.fill", background: .gray),
                     title: "Version",
-                    detail: "1.6.1"
+                    detail: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
                 )
                 row(
                     icon: SettingsIconBox(systemImage: "lock.shield.fill", background: .blue),


### PR DESCRIPTION
Closes #122

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
