### PR TITLE
fix: handle denied notification permission in push banner

### DIFF
--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -2641,17 +2641,61 @@ final class AppState {
 
     func setPushNotifications(enabled: Bool, forGroup groupID: String) {
         guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
-        groups[index].pushNotificationsEnabled = enabled
-        store.saveGroupAsync(groups[index])
 
-        let group = groups[index]
-        Task {
-            if enabled {
-                await ensurePushPermissionAndRegister(group: group)
-            } else {
-                await pushManager.unregisterGroup(groupID)
-            }
+        if enabled {
+            // Don't flip the flag optimistically — iOS may deny the permission,
+            // in which case we'd silently claim push is on while delivering nothing.
+            // enablePushNotifications flips it only after a successful grant+register.
+            Task { _ = await enablePushNotifications(forGroup: groupID) }
+        } else {
+            groups[index].pushNotificationsEnabled = false
+            store.saveGroupAsync(groups[index])
+            Task { await pushManager.unregisterGroup(groupID) }
         }
+    }
+
+    /// Outcome of attempting to enable push notifications for a group.
+    /// Callers (e.g. the chat banner) use this to decide whether to surface an
+    /// alert that points the user at iOS Settings.
+    enum PushEnableOutcome {
+        case enabled
+        case deniedJustNow
+        case deniedPreviously
+        case failed
+    }
+
+    /// Request notification permission and register the group. Returns the
+    /// outcome so the UI can react (e.g. show a Settings prompt on denial).
+    /// Only flips `pushNotificationsEnabled` on a confirmed grant.
+    @discardableResult
+    func enablePushNotifications(forGroup groupID: String) async -> PushEnableOutcome {
+        guard let group = groups.first(where: { $0.id == groupID }) else {
+            return .failed
+        }
+        let status = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+        switch status {
+        case .denied:
+            return .deniedPreviously
+        case .authorized, .provisional, .ephemeral:
+            let ok = await ensurePushPermissionAndRegister(group: group)
+            if ok { persistPushEnabled(groupID: groupID) }
+            return ok ? .enabled : .failed
+        case .notDetermined:
+            let ok = await ensurePushPermissionAndRegister(group: group)
+            if ok {
+                persistPushEnabled(groupID: groupID)
+                return .enabled
+            }
+            return .deniedJustNow
+        @unknown default:
+            return .failed
+        }
+    }
+
+    private func persistPushEnabled(groupID: String) {
+        guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
+        groups[index].pushNotificationsEnabled = true
+        store.saveGroupAsync(groups[index])
     }
 
     // MARK: - Rekey Health & Diagnostics
@@ -3680,12 +3724,13 @@ final class AppState {
     }
 
     /// Request notification permission, wait for APNs token, and register a group.
-    /// Called when the user first enables push for a group.
-    func ensurePushPermissionAndRegister(group: ChatGroup) async {
+    /// Returns true iff permission was granted and registration proceeded.
+    @discardableResult
+    func ensurePushPermissionAndRegister(group: ChatGroup) async -> Bool {
         do {
             let center = UNUserNotificationCenter.current()
             let granted = try await center.requestAuthorization(options: [.alert, .sound, .badge])
-            guard granted else { return }
+            guard granted else { return false }
 
             UIApplication.shared.registerForRemoteNotifications()
 
@@ -3713,10 +3758,12 @@ final class AppState {
             }
 
             await pushManager.registerGroup(group)
+            return true
         } catch {
             #if DEBUG
             print("[Push] Authorization error: \(error)")
             #endif
+            return false
         }
     }
 

--- a/clients/ios/StellarChat/StellarChat/Views/ChatView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ChatView.swift
@@ -21,6 +21,8 @@ struct ChatView: View {
     @State private var showForkSheet = false
     @State private var pushBannerDismissed = false
     @State private var governanceBannerDismissed: [String: Bool] = [:]
+    @State private var pushDeniedAlertShown = false
+    @State private var isRequestingPushPermission = false
     @AppStorage("hasSeenFirstGroupWelcome") private var hasSeenFirstGroupWelcome = false
 
     var body: some View {
@@ -75,11 +77,24 @@ struct ChatView: View {
                         .font(.caption)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Button("Enable") {
-                        appState.setPushNotifications(enabled: true, forGroup: group.id)
-                        pushBannerDismissed = true
+                        guard !isRequestingPushPermission else { return }
+                        isRequestingPushPermission = true
+                        let groupID = group.id
+                        Task {
+                            let outcome = await appState.enablePushNotifications(forGroup: groupID)
+                            isRequestingPushPermission = false
+                            switch outcome {
+                            case .enabled:
+                                // Banner hides on its own once pushNotificationsEnabled flips.
+                                break
+                            case .deniedJustNow, .deniedPreviously, .failed:
+                                pushDeniedAlertShown = true
+                            }
+                        }
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .disabled(isRequestingPushPermission)
                     Button {
                         pushBannerDismissed = true
                     } label: {
@@ -499,6 +514,16 @@ struct ChatView: View {
             if let error = viewModel.errorMessage {
                 Text(error)
             }
+        }
+        .alert("Notifications are disabled", isPresented: $pushDeniedAlertShown) {
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            Button("Not now", role: .cancel) {}
+        } message: {
+            Text("Enable notifications for this app in iOS Settings to receive messages from this chat.")
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #114. The per-chat "Enable push notifications for this chat?" banner did not distinguish between iOS granting and denying the notification permission.

- **Before:** Tapping "Enable" optimistically set `pushNotificationsEnabled = true` and always dismissed the banner. A denial was treated as success (Issue A). On later groups, iOS wouldn't re-prompt — leaving a dead button and no explanation (Issue B).
- **After:** `AppState.enablePushNotifications(forGroup:)` checks the current `UNAuthorizationStatus`, only flips the flag after a confirmed grant + registration, and returns an outcome. The banner stays visible on denial, and an alert offers "Open Settings" so the user can recover.

## Changes

- `StellarChatApp.swift`: Introduce `AppState.PushEnableOutcome` and `enablePushNotifications(forGroup:)`. Drop the optimistic flag flip from `setPushNotifications`. `ensurePushPermissionAndRegister` now returns `Bool` so callers can react to denial.
- `ChatView.swift`: Banner "Enable" button runs the async request; on denial it shows a new alert with "Open Settings" / "Not now". Disables the button while in-flight to prevent duplicate requests.

## Test plan

- [ ] Fresh install, new profile. Accept invites to 2 groups.
- [ ] Open group 1, tap **Enable**, tap **Don't Allow** on the iOS prompt. Expect banner to remain and the "Notifications are disabled" alert with an **Open Settings** button.
- [ ] Navigate to group 2. Tap **Enable**. Expect the same alert immediately (no system prompt, since iOS only prompts once); banner remains until permission is granted.
- [ ] From the alert, tap **Open Settings**, enable notifications in iOS Settings, return to the app, tap **Enable** again in the banner. Expect the banner to disappear and push registration to proceed.
- [ ] The **x** dismiss button still hides the banner without touching permissions.
- [ ] Existing flow: on a fresh install where the user taps **Allow**, the banner disappears and push is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)