### PR TITLE
fix(android): match iOS QR scan label and move it below reticle

### DIFF
--- a/clients/android/StellarChat/app/src/fdroid/java/chat/onym/android/ui/components/QRScannerView.kt
+++ b/clients/android/StellarChat/app/src/fdroid/java/chat/onym/android/ui/components/QRScannerView.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -219,12 +220,12 @@ private fun CameraPreview(onCodeScanned: (String) -> Unit) {
 
         // Instruction text below the reticle
         Text(
-            text = "Scan a group invitation QR code\nshared by a group member",
+            text = "Point camera at QR code",
             color = Color.White,
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(top = reticleSizeDp / 2 + 32.dp)
+                .offset(y = reticleSizeDp / 2 + 40.dp)
         )
     }
 }

--- a/clients/android/StellarChat/app/src/play/java/chat/onym/android/ui/components/QRScannerView.kt
+++ b/clients/android/StellarChat/app/src/play/java/chat/onym/android/ui/components/QRScannerView.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -204,12 +205,12 @@ private fun CameraPreview(onCodeScanned: (String) -> Unit) {
 
         // Instruction text below the reticle
         Text(
-            text = "Scan a group invitation QR code\nshared by a group member",
+            text = "Point camera at QR code",
             color = Color.White,
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(top = reticleSizeDp / 2 + 32.dp)
+                .offset(y = reticleSizeDp / 2 + 40.dp)
         )
     }
 }


### PR DESCRIPTION
Closes #100

The Android Scan QR overlay used different copy than iOS and combined
`align(Center) + padding(top = ...)` which centers the (text+padding)
box on screen, leaving the visible text inside the reticle's lower half
where it can interfere with QR detection.

Switch to the iOS copy ("Point camera at QR code") and use `offset(y =
reticleSizeDp/2 + 40.dp)` so the text is rendered below the reticle's
bottom edge, matching the iOS layout.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
