### PR TITLE
fix(ios): purge invitations when a group is deleted (#110)

### DIFF
--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -559,6 +559,13 @@ final class AppState {
         store.deleteGroup(id: id)
         chatMessages.removeValue(forKey: id)
         seenMessageIDs.removeValue(forKey: id)
+        // Suppress stale invitations for this group: drop any currently pending
+        // and remember the ID so relay-replayed invitation events aren't
+        // re-surfaced on next launch (Issue #110).
+        pendingInvitations.removeAll { invitation in
+            invitation.payload.groupID.map { String(format: "%02x", $0) }.joined() == id
+        }
+        declinedGroupIDs.insert(id)
     }
 
     func removePendingInvitation(id: String) {


### PR DESCRIPTION
Deleting a group left its Nostr invitation events addressable to the
user; after restart the inbox listener re-received them and the stale
invitations reappeared in Notifications, still actionable. Mirror the
decline path by dropping pending invitations for the removed group and
adding its ID to the persisted declinedGroupIDs set so replayed events
are suppressed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
