### PR TITLE
fix(android): guard popBackStack against rapid back taps (#134)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
@@ -29,7 +29,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -114,6 +116,16 @@ private enum class Tab(val route: String, val label: String, val icon: ImageVect
 private val defaultTab = Tab.Chats
 private val tabs = listOf(Tab.Contacts, Tab.Chats, Tab.Search, Tab.Settings)
 private val tabRoutes = tabs.map { it.route }.toSet()
+
+// Guard against rapid back-button taps popping past the current screen.
+// During a pop transition the current entry leaves RESUMED before the next
+// entry becomes RESUMED; without this check, a second tap fires a second pop
+// and the stack can be emptied, leaving a blank screen.
+private fun NavController.popBackStackIfResumed(): Boolean {
+    val entry = currentBackStackEntry ?: return false
+    if (!entry.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return false
+    return popBackStack()
+}
 
 @Composable
 fun StellarChatNavHost(
@@ -257,7 +269,7 @@ fun StellarChatNavHost(
 
                 ChatScreen(
                     viewModel = chatViewModel,
-                    onBack = { navController.popBackStack() },
+                    onBack = { navController.popBackStackIfResumed() },
                     onGroupInfo = { navController.navigate("groupinfo/$groupId") },
                     contactAliasStore = groupListViewModel.contactAliasStore,
                     onUnpinEpoch = {
@@ -287,7 +299,7 @@ fun StellarChatNavHost(
                     keyManager = groupListViewModel.keyManager,
                     groupListViewModel = groupListViewModel,
                     invitationTransport = groupListViewModel.invitationTransport,
-                    onBack = { navController.popBackStack() },
+                    onBack = { navController.popBackStackIfResumed() },
                     onNavigateToChat = { groupId ->
                         navController.navigate("chat/$groupId") {
                             popUpTo("create") { inclusive = true }
@@ -305,7 +317,7 @@ fun StellarChatNavHost(
                 JoinGroupScreen(
                     viewModel = joinViewModel,
                     groupListViewModel = groupListViewModel,
-                    onBack = { navController.popBackStack() },
+                    onBack = { navController.popBackStackIfResumed() },
                     onGroupJoined = { group ->
                         // Mark as published if on-chain verification passed
                         if (joinViewModel.verificationResult is chat.onym.android.onchain.OnChainVerificationResult.Verified) {
@@ -324,7 +336,7 @@ fun StellarChatNavHost(
                         }
                         groupListViewModel.addGroup(group)
                         groupListViewModel.announceMemberJoined(group)
-                        navController.popBackStack()
+                        navController.popBackStackIfResumed()
                     }
                 )
             }
@@ -360,28 +372,28 @@ fun StellarChatNavHost(
             composable("relays") {
                 RelaysScreen(
                     viewModel = groupListViewModel,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
 
             composable("blossom_servers") {
                 BlossomServersScreen(
                     viewModel = groupListViewModel,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
 
             composable("stellar_contract") {
                 StellarContractScreen(
                     viewModel = groupListViewModel,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
 
             composable("advanced_settings") {
                 AdvancedSettingsScreen(
                     viewModel = groupListViewModel,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
 
@@ -390,11 +402,11 @@ fun StellarChatNavHost(
                 if (phrase != null) {
                     RecoveryPhraseScreen(
                         recoveryPhrase = phrase,
-                        onBack = { navController.popBackStack() }
+                        onBack = { navController.popBackStackIfResumed() }
                     )
                 } else {
                     // Legacy (pre-BIP39) install — no recovery phrase available
-                    LegacyIdentityScreen(onBack = { navController.popBackStack() })
+                    LegacyIdentityScreen(onBack = { navController.popBackStackIfResumed() })
                 }
             }
 
@@ -419,7 +431,7 @@ fun StellarChatNavHost(
                             }
                         }
                     },
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
 
@@ -434,7 +446,7 @@ fun StellarChatNavHost(
                     group = group,
                     invitationTransport = groupListViewModel.invitationTransport,
                     keyManager = groupListViewModel.keyManager,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
 
@@ -509,7 +521,7 @@ fun StellarChatNavHost(
                     },
                     contactAliasStore = groupListViewModel.contactAliasStore,
                     dao = groupListViewModel.store.dao,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
 
@@ -534,7 +546,7 @@ fun StellarChatNavHost(
                         }
                     },
                     contactAliasStore = groupListViewModel.contactAliasStore,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
 
@@ -551,7 +563,7 @@ fun StellarChatNavHost(
                     inviterX25519Hex = inviter,
                     nonceHex = nonce,
                     groupListViewModel = groupListViewModel,
-                    onDone = { navController.popBackStack() }
+                    onDone = { navController.popBackStackIfResumed() }
                 )
             }
 
@@ -576,12 +588,12 @@ fun StellarChatNavHost(
                         groupListViewModel.addGroup(group)
                         groupListViewModel.announceMemberJoined(group)
                         groupListViewModel.removePendingInvitation(invitation.id)
-                        navController.popBackStack()
+                        navController.popBackStackIfResumed()
                     },
                     onDecline = { invitation ->
                         groupListViewModel.removePendingInvitation(invitation.id)
                     },
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStackIfResumed() }
                 )
             }
         }


### PR DESCRIPTION
Rapid taps on the in-app back arrow could fire popBackStack() multiple
times while the first pop's transition was still in flight, popping past
the target screen and leaving the app on a blank black screen. This was
reproducible from Settings → Scan invite QR, but affected every screen
whose back button called navController.popBackStack() directly.

Route all back/done callbacks through a new NavController extension that
pops only when the current entry is still in the RESUMED state. During a
transition the entry leaves RESUMED before the next entry becomes
RESUMED, so subsequent taps become no-ops until the first pop lands.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
