### PR TITLE
fix(ios): add visual feedback to Copy Link on new-group QR screen

### DIFF
--- a/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
@@ -29,6 +29,7 @@ struct CreateGroupView: View {
     @State private var onChainStatus: OnChainPublishStatus = .idle
     @State private var invitationStatuses: [String: InvitationStatus] = [:]
     @State private var showRawInviteCode = false
+    @State private var linkCopied = false
 
     private enum Step { case identity, people }
 
@@ -772,13 +773,21 @@ struct CreateGroupView: View {
                     HStack(spacing: 0) {
                         Button {
                             UIPasteboard.general.string = inviteLink
+                            UINotificationFeedbackGenerator().notificationOccurred(.success)
+                            withAnimation(.snappy) { linkCopied = true }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                withAnimation(.snappy) { linkCopied = false }
+                            }
                         } label: {
-                            Label("Copy Link", systemImage: "link")
+                            Label(
+                                linkCopied ? "Copied!" : "Copy Link",
+                                systemImage: linkCopied ? "checkmark" : "link"
+                            )
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 14)
                         }
                         .buttonStyle(.plain)
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(linkCopied ? Color.green : Color.accentColor)
 
                         Divider().frame(height: 44)
 


### PR DESCRIPTION
## Summary
- Tapping **Copy Link** on the post-creation QR screen on iOS now briefly swaps the label to "Copied!" (with a checkmark icon) for ~2 s and plays a success haptic, restoring parity with Android's toast.
- Follows the same pattern already used in `GroupInfoView.swift` (`linkCopied` state + `withAnimation(.snappy)`).

Fixes #131.

## Test plan
- [ ] On iOS: Create a group → Anarchy → Next → wait for QR screen → tap **Copy Link**.
- [ ] Verify label animates to "Copied!" with a checkmark for ~2 seconds and a success haptic fires.
- [ ] Paste into another app and confirm the invite link was copied.
- [ ] Tap **Copy Link** again to verify the state resets correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)