### PR TITLE
fix(ios): surface permission denial when toggling push in group info

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -59,6 +59,8 @@ import com.stellarmls.mls.SEPSaltResponse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
@@ -180,6 +182,10 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
     private var pushManager: PushNotificationManager? = null
     private val pushPrefs = application.getSharedPreferences("stellar_push_config", Context.MODE_PRIVATE)
     private val pushTokenProvider = PushTokenProviderFactory.create(application)
+    /** Serializes register/unregister toggles so rapid taps can't race the local sub store —
+     *  without this, an unregister can read the store before a prior register has saved, find
+     *  nothing, and skip the network request. */
+    private val pushToggleMutex = Mutex()
     /** Observable push-enabled state per group — separate from groups list for reliable Compose recomposition. */
     val pushEnabledStates = androidx.compose.runtime.mutableStateMapOf<String, Boolean>()
     /** Set by MainActivity.onNewIntent to navigate to a chat from a notification tap. */
@@ -2643,31 +2649,33 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         val group = groups[index]
         viewModelScope.launch {
             withContext(Dispatchers.IO) { store.saveGroup(group) }
-            if (enabled) {
-                val mgr = getOrCreatePushManager()
-                if (mgr == null) {
-                    Log.w("GroupListVM", "Cannot register push: no relay URL")
-                    return@launch
-                }
-                val token = getPushToken()
-                if (token == null) {
-                    Log.w("GroupListVM", "Cannot register push: no push token")
-                    return@launch
-                }
-                val registered = mgr.registerGroup(group, token, pushTokenProvider.getPlatformName())
-                if (registered) {
-                    if (BuildConfig.DEBUG) Log.d("GroupListVM", "Push registered for group ${groupID.take(8)}")
+            pushToggleMutex.withLock {
+                if (enabled) {
+                    val mgr = getOrCreatePushManager()
+                    if (mgr == null) {
+                        Log.w("GroupListVM", "Cannot register push: no relay URL")
+                        return@withLock
+                    }
+                    val token = getPushToken()
+                    if (token == null) {
+                        Log.w("GroupListVM", "Cannot register push: no push token")
+                        return@withLock
+                    }
+                    val registered = mgr.registerGroup(group, token, pushTokenProvider.getPlatformName())
+                    if (registered) {
+                        if (BuildConfig.DEBUG) Log.d("GroupListVM", "Push registered for group ${groupID.take(8)}")
+                    } else {
+                        Log.w("GroupListVM", "Push registration failed for group ${groupID.take(8)}")
+                    }
                 } else {
-                    Log.w("GroupListVM", "Push registration failed for group ${groupID.take(8)}")
+                    val mgr = getOrCreatePushManager()
+                    if (mgr == null) {
+                        Log.w("GroupListVM", "Cannot unregister push: no relay URL")
+                        return@withLock
+                    }
+                    mgr.unregisterGroup(groupID)
+                    if (BuildConfig.DEBUG) Log.d("GroupListVM", "Push unregistered for group ${groupID.take(8)}")
                 }
-            } else {
-                val mgr = getOrCreatePushManager()
-                if (mgr == null) {
-                    Log.w("GroupListVM", "Cannot unregister push: no relay URL")
-                    return@launch
-                }
-                mgr.unregisterGroup(groupID)
-                if (BuildConfig.DEBUG) Log.d("GroupListVM", "Push unregistered for group ${groupID.take(8)}")
             }
         }
     }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -2661,7 +2661,12 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
                     Log.w("GroupListVM", "Push registration failed for group ${groupID.take(8)}")
                 }
             } else {
-                pushManager?.unregisterGroup(groupID)
+                val mgr = getOrCreatePushManager()
+                if (mgr == null) {
+                    Log.w("GroupListVM", "Cannot unregister push: no relay URL")
+                    return@launch
+                }
+                mgr.unregisterGroup(groupID)
                 if (BuildConfig.DEBUG) Log.d("GroupListVM", "Push unregistered for group ${groupID.take(8)}")
             }
         }

--- a/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
@@ -47,6 +47,10 @@ struct GroupInfoView: View {
     // Search
     @State private var showSearch = false
 
+    // Push notifications
+    @State private var isRequestingPushPermission = false
+    @State private var pushDeniedAlertShown = false
+
     private var currentGroup: ChatGroup {
         appState.groups.first(where: { $0.id == group.id }) ?? group
     }
@@ -204,6 +208,34 @@ struct GroupInfoView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("You'll no longer receive messages. The group key will be rotated so future messages stay private from you.")
+            }
+            .alert("Notifications Disabled", isPresented: $pushDeniedAlertShown) {
+                Button("Open Settings") {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Enable notifications for Onym in Settings to receive push notifications for this chat.")
+            }
+        }
+    }
+
+    private func requestEnablePush() {
+        guard !isRequestingPushPermission else { return }
+        isRequestingPushPermission = true
+        let groupID = currentGroup.id
+        Task {
+            let outcome = await appState.enablePushNotifications(forGroup: groupID)
+            await MainActor.run {
+                isRequestingPushPermission = false
+                switch outcome {
+                case .enabled:
+                    break
+                case .deniedJustNow, .deniedPreviously, .failed:
+                    pushDeniedAlertShown = true
+                }
             }
         }
     }
@@ -406,7 +438,11 @@ struct GroupInfoView: View {
         Binding(
             get: { currentGroup.pushNotificationsEnabled },
             set: { enabled in
-                appState.setPushNotifications(enabled: enabled, forGroup: currentGroup.id)
+                if enabled {
+                    requestEnablePush()
+                } else {
+                    appState.setPushNotifications(enabled: false, forGroup: currentGroup.id)
+                }
             }
         )
     }
@@ -649,10 +685,11 @@ struct GroupInfoView: View {
                 tint: currentGroup.pushNotificationsEnabled ? .orange : .gray,
                 invertedLabel: true
             ) {
-                appState.setPushNotifications(
-                    enabled: !currentGroup.pushNotificationsEnabled,
-                    forGroup: currentGroup.id
-                )
+                if currentGroup.pushNotificationsEnabled {
+                    appState.setPushNotifications(enabled: false, forGroup: currentGroup.id)
+                } else {
+                    requestEnablePush()
+                }
             }
             QuickActionTile(
                 icon: "magnifyingglass",


### PR DESCRIPTION
The mute/unmute toggle silently no-oped after the first tap when the
user denied notification permission. setPushNotifications(enabled: true)
kicks off a Task that checks permission and only flips the flag on a
grant — but the outcome was discarded, so a denial (just now or
previously) gave no visible feedback. Subsequent taps hit the same
denied branch and again did nothing.

Route the enable path through enablePushNotifications directly (as
ChatView already does) and show a Settings alert on denial, so every
tap produces a visible response.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
