### PR TITLE
fix(clients): show group avatar + wire pencil icon to image picker (#129)

### DIFF
--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
@@ -475,6 +475,9 @@ fun StellarChatNavHost(
                     onRenameGroup = { newName ->
                         groupListViewModel.renameGroup(groupId, newName)
                     },
+                    onSetGroupAvatar = { avatarBytes ->
+                        groupListViewModel.setGroupAvatar(groupId, avatarBytes)
+                    },
                     epochSnapshots = groupListViewModel.epochSnapshots[groupId] ?: emptyMap(),
                     onPinEpoch = { epoch ->
                         groupListViewModel.pinEpoch(groupId, epoch)

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupInfoScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupInfoScreen.kt
@@ -4,7 +4,14 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -83,6 +90,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -109,6 +119,7 @@ fun GroupInfoScreen(
     onRemoveMember: (ByteArray, (Result<Unit>) -> Unit) -> Unit,
     onRotateKey: () -> Unit = {},
     onRenameGroup: (String) -> Unit = {},
+    onSetGroupAvatar: (ByteArray?) -> Unit = {},
     epochSnapshots: Map<Long, EpochSnapshot> = emptyMap(),
     onPinEpoch: (Long) -> Unit = {},
     onUnpinEpoch: () -> Unit = {},
@@ -195,10 +206,10 @@ fun GroupInfoScreen(
                 group = group,
                 accent = accent,
                 isMember = isMember,
-                onEditName = {
+                onPickAvatar = { uri ->
                     if (isMember) {
-                        newGroupName = group.name
-                        showRenameDialog = true
+                        val bytes = decodeAndDownscaleAvatar(context, uri)
+                        if (bytes != null) onSetGroupAvatar(bytes)
                     }
                 }
             )
@@ -682,8 +693,25 @@ private fun Hero(
     group: ChatGroup,
     accent: GroupAccent,
     isMember: Boolean,
-    onEditName: () -> Unit
+    onPickAvatar: (Uri) -> Unit
 ) {
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia()
+    ) { uri: Uri? ->
+        if (uri != null) onPickAvatar(uri)
+    }
+    val launchPicker: () -> Unit = {
+        photoPickerLauncher.launch(
+            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+        )
+    }
+    val avatarBitmap: ImageBitmap? = remember(group.avatarData) {
+        group.avatarData?.let { bytes ->
+            try {
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.asImageBitmap()
+            } catch (_: Exception) { null }
+        }
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -703,15 +731,24 @@ private fun Hero(
                     .size(96.dp)
                     .clip(CircleShape)
                     .background(accent.brush())
-                    .clickable(enabled = isMember, onClick = onEditName),
+                    .clickable(enabled = isMember, onClick = launchPicker),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    initialsForGroup(group.name),
-                    color = Color.White,
-                    fontSize = 36.sp,
-                    fontWeight = FontWeight.Bold
-                )
+                if (avatarBitmap != null) {
+                    Image(
+                        bitmap = avatarBitmap,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.size(96.dp).clip(CircleShape)
+                    )
+                } else {
+                    Text(
+                        initialsForGroup(group.name),
+                        color = Color.White,
+                        fontSize = 36.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
             }
             if (isMember) {
                 Box(
@@ -721,12 +758,12 @@ private fun Hero(
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.surface)
                         .border(3.dp, MaterialTheme.colorScheme.background, CircleShape)
-                        .clickable(onClick = onEditName),
+                        .clickable(onClick = launchPicker),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         Icons.Filled.Edit,
-                        contentDescription = "Edit",
+                        contentDescription = "Change group photo",
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(16.dp)
                     )
@@ -1527,6 +1564,34 @@ private fun InviteSheetContent(
 }
 
 // MARK: - Helpers
+
+private const val GROUP_AVATAR_MAX_EDGE_PX = 256
+
+/** Decode the picked image URI, downscale it to a max edge of
+ *  [GROUP_AVATAR_MAX_EDGE_PX], and re-encode as JPEG for compact storage. */
+private fun decodeAndDownscaleAvatar(context: Context, uri: Uri): ByteArray? {
+    val resolver = context.contentResolver
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+    val longest = maxOf(bounds.outWidth, bounds.outHeight).coerceAtLeast(1)
+    var sample = 1
+    while (longest / sample > GROUP_AVATAR_MAX_EDGE_PX * 2) sample *= 2
+    val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
+    val bitmap = resolver.openInputStream(uri)?.use {
+        BitmapFactory.decodeStream(it, null, decodeOpts)
+    } ?: return null
+    val w = bitmap.width
+    val h = bitmap.height
+    val scale = maxOf(w, h).let { if (it > GROUP_AVATAR_MAX_EDGE_PX) GROUP_AVATAR_MAX_EDGE_PX.toFloat() / it else 1f }
+    val scaled = if (scale < 1f) {
+        Bitmap.createScaledBitmap(bitmap, (w * scale).toInt(), (h * scale).toInt(), true)
+    } else bitmap
+    val buffer = java.io.ByteArrayOutputStream()
+    scaled.compress(Bitmap.CompressFormat.JPEG, 85, buffer)
+    if (scaled !== bitmap) scaled.recycle()
+    bitmap.recycle()
+    return buffer.toByteArray()
+}
 
 private fun initialsForGroup(name: String): String {
     val parts = name.trim().split(Regex("\\s+")).filter { it.isNotEmpty() }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupInfoScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupInfoScreen.kt
@@ -108,8 +108,10 @@ import chat.onym.android.ui.components.GroupAccent
 import chat.onym.android.ui.components.QRScannerView
 import chat.onym.android.ui.components.SettingsIconBox
 import com.stellarmls.mls.SEPGroupMemberLeaf
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -208,8 +210,12 @@ fun GroupInfoScreen(
                 isMember = isMember,
                 onPickAvatar = { uri ->
                     if (isMember) {
-                        val bytes = decodeAndDownscaleAvatar(context, uri)
-                        if (bytes != null) onSetGroupAvatar(bytes)
+                        scope.launch {
+                            val bytes = withContext(Dispatchers.IO) {
+                                decodeAndDownscaleAvatar(context, uri)
+                            }
+                            if (bytes != null) onSetGroupAvatar(bytes)
+                        }
                     }
                 }
             )

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupListScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupListScreen.kt
@@ -1,6 +1,8 @@
 package chat.onym.android.ui.screens
 
+import android.graphics.BitmapFactory
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -53,7 +55,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -381,6 +387,13 @@ private fun GroupListItem(
     val initial = remember(group.name) {
         group.name.take(1).uppercase()
     }
+    val avatarBitmap: ImageBitmap? = remember(group.avatarData) {
+        group.avatarData?.let { bytes ->
+            try {
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.asImageBitmap()
+            } catch (_: Exception) { null }
+        }
+    }
 
     Row(
         modifier = Modifier
@@ -400,12 +413,21 @@ private fun GroupListItem(
                 modifier = Modifier.size(48.dp)
             ) {
                 Box(contentAlignment = Alignment.Center) {
-                    Text(
-                        text = initial,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = Color.White
-                    )
+                    if (avatarBitmap != null) {
+                        Image(
+                            bitmap = avatarBitmap,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.size(48.dp).clip(CircleShape)
+                        )
+                    } else {
+                        Text(
+                            text = initial,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.White
+                        )
+                    }
                 }
             }
             if (group.isPublishedOnChain) {

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -2702,7 +2702,11 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         val updated = groups[index].copy(avatarData = avatarData)
         groups[index] = updated
         viewModelScope.launch {
-            try { store.saveGroup(updated) } catch (_: Exception) { }
+            try {
+                store.saveGroup(updated)
+            } catch (e: Exception) {
+                if (BuildConfig.DEBUG) Log.e("GroupListVM", "setGroupAvatar persist failed: ${e.message}")
+            }
         }
     }
 

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/viewmodel/GroupListViewModel.kt
@@ -2694,6 +2694,18 @@ class GroupListViewModel(application: Application) : AndroidViewModel(applicatio
         transport.sendProtocolMessage(group, json.toString())
     }
 
+    /** Update a group's locally-held avatar image. Held on this device only;
+     *  not propagated to other members. */
+    fun setGroupAvatar(groupID: String, avatarData: ByteArray?) {
+        val index = groups.indexOfFirst { it.id == groupID }
+        if (index < 0) return
+        val updated = groups[index].copy(avatarData = avatarData)
+        groups[index] = updated
+        viewModelScope.launch {
+            try { store.saveGroup(updated) } catch (_: Exception) { }
+        }
+    }
+
     /** Send an invitation for a group to a recipient identified by their X25519 inbox key hex.
      *  Fire-and-forget: validates inputs synchronously, then sends in background. */
     fun sendInvitation(groupID: String, recipientKeyHex: String, onResult: (Result<Unit>) -> Unit) {

--- a/clients/ios/StellarChat/StellarChat/Models/PersistenceStore.swift
+++ b/clients/ios/StellarChat/StellarChat/Models/PersistenceStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftData
 import SwiftMLS
+import os.log
 
 /// SwiftData-backed persistence with field-level AES-256-GCM encryption
 /// and FileProtectionType.complete on the store directory.
@@ -9,6 +10,8 @@ final class PersistenceStore {
         label: "chat.onym.ios.persistence.write",
         qos: .utility
     )
+
+    private static let logger = Logger(subsystem: "chat.onym.ios", category: "PersistenceStore")
 
     let container: ModelContainer
     private let context: ModelContext
@@ -82,7 +85,11 @@ final class PersistenceStore {
             for item in existing { context.delete(item) }
         }
         context.insert(persisted)
-        try? context.save()
+        do {
+            try context.save()
+        } catch {
+            Self.logger.error("saveGroup failed for \(groupID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     func deleteGroup(id: String) {

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -2647,6 +2647,14 @@ final class AppState {
         }
     }
 
+    /// Update a group's locally-held avatar image. Held on this device only;
+    /// not propagated to other members.
+    func setGroupAvatar(groupID: String, avatarData: Data?) {
+        guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
+        groups[index].avatarData = avatarData
+        store.saveGroup(groups[index])
+    }
+
     func setPushNotifications(enabled: Bool, forGroup groupID: String) {
         guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
 

--- a/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
@@ -1,3 +1,4 @@
+import ImageIO
 import PhotosUI
 import SwiftUI
 import SwiftMLS
@@ -599,9 +600,8 @@ struct GroupInfoView: View {
                     guard let newItem else { return }
                     Task {
                         if let data = try? await newItem.loadTransferable(type: Data.self),
-                           let image = UIImage(data: data) {
-                            let processed = Self.downscaleAvatar(image)
-                            appState.setGroupAvatar(groupID: currentGroup.id, avatarData: processed.data)
+                           let processed = Self.downscaleAvatar(data) {
+                            appState.setGroupAvatar(groupID: currentGroup.id, avatarData: processed)
                         }
                         selectedAvatarItem = nil
                     }
@@ -628,22 +628,20 @@ struct GroupInfoView: View {
         .padding(.bottom, 14)
     }
 
-    /// Downscale the picked image so the long edge is at most 256 px and re-encode
-    /// as JPEG quality 0.85 so the persisted row stays small.
-    private static func downscaleAvatar(_ source: UIImage) -> (image: UIImage, data: Data) {
-        let maxEdge: CGFloat = 256
-        let longest = max(source.size.width, source.size.height)
-        let scale = longest > maxEdge ? maxEdge / longest : 1
-        let targetSize = CGSize(
-            width: source.size.width * scale,
-            height: source.size.height * scale
-        )
-        let renderer = UIGraphicsImageRenderer(size: targetSize)
-        let resized = renderer.image { _ in
-            source.draw(in: CGRect(origin: .zero, size: targetSize))
-        }
-        let data = resized.jpegData(compressionQuality: 0.85) ?? Data()
-        return (resized, data)
+    /// ImageIO thumbnail path so a 50+ MP HEIC is never fully decoded; returns nil rather than 0-byte data.
+    private static func downscaleAvatar(_ data: Data) -> Data? {
+        let maxEdge = 256
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxEdge,
+        ]
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else { return nil }
+        guard let jpeg = UIImage(cgImage: thumbnail).jpegData(compressionQuality: 0.85),
+              !jpeg.isEmpty else { return nil }
+        return jpeg
     }
 
     private func chip(icon: String, text: String, tint: Color, bgAlpha: Double = 0.06) -> some View {

--- a/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
@@ -1,3 +1,4 @@
+import PhotosUI
 import SwiftUI
 import SwiftMLS
 
@@ -46,6 +47,9 @@ struct GroupInfoView: View {
 
     // Search
     @State private var showSearch = false
+
+    // Avatar
+    @State private var selectedAvatarItem: PhotosPickerItem?
 
     private var currentGroup: ChatGroup {
         appState.groups.first(where: { $0.id == group.id }) ?? group
@@ -539,6 +543,7 @@ struct GroupInfoView: View {
 
     private var hero: some View {
         let (c1, c2) = groupGradient(seed: currentGroup.id)
+        let avatarUIImage: UIImage? = currentGroup.avatarData.flatMap { UIImage(data: $0) }
         return VStack(spacing: 14) {
             ZStack {
                 // soft halo
@@ -547,25 +552,31 @@ struct GroupInfoView: View {
                     .frame(width: 240, height: 240)
                     .blur(radius: 40)
                     .offset(y: -30)
-                // avatar
-                Button {
-                    guard isMember else { return }
-                    newGroupName = currentGroup.name
-                    showRenameAlert = true
-                } label: {
+                // avatar — tap anywhere to pick a new photo
+                PhotosPicker(selection: $selectedAvatarItem, matching: .images) {
                     ZStack(alignment: .bottomTrailing) {
-                        Circle()
-                            .fill(
-                                LinearGradient(colors: [c1, c2], startPoint: .topLeading, endPoint: .bottomTrailing)
-                            )
-                            .frame(width: 96, height: 96)
-                            .shadow(color: c1.opacity(0.35), radius: 14, y: 8)
-                            .overlay(
-                                Text(initials(currentGroup.name))
-                                    .font(.system(size: 38, weight: .semibold))
-                                    .foregroundStyle(.white)
-                                    .minimumScaleFactor(0.6)
-                            )
+                        Group {
+                            if let avatarUIImage {
+                                Image(uiImage: avatarUIImage)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 96, height: 96)
+                                    .clipShape(Circle())
+                            } else {
+                                Circle()
+                                    .fill(
+                                        LinearGradient(colors: [c1, c2], startPoint: .topLeading, endPoint: .bottomTrailing)
+                                    )
+                                    .frame(width: 96, height: 96)
+                                    .overlay(
+                                        Text(initials(currentGroup.name))
+                                            .font(.system(size: 38, weight: .semibold))
+                                            .foregroundStyle(.white)
+                                            .minimumScaleFactor(0.6)
+                                    )
+                            }
+                        }
+                        .shadow(color: c1.opacity(0.35), radius: 14, y: 8)
                         if isMember {
                             ZStack {
                                 Circle()
@@ -583,6 +594,18 @@ struct GroupInfoView: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .disabled(!isMember)
+                .onChange(of: selectedAvatarItem) { _, newItem in
+                    guard let newItem else { return }
+                    Task {
+                        if let data = try? await newItem.loadTransferable(type: Data.self),
+                           let image = UIImage(data: data) {
+                            let processed = Self.downscaleAvatar(image)
+                            appState.setGroupAvatar(groupID: currentGroup.id, avatarData: processed.data)
+                        }
+                        selectedAvatarItem = nil
+                    }
+                }
             }
             .padding(.top, 20)
 
@@ -603,6 +626,24 @@ struct GroupInfoView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.bottom, 14)
+    }
+
+    /// Downscale the picked image so the long edge is at most 256 px and re-encode
+    /// as JPEG quality 0.85 so the persisted row stays small.
+    private static func downscaleAvatar(_ source: UIImage) -> (image: UIImage, data: Data) {
+        let maxEdge: CGFloat = 256
+        let longest = max(source.size.width, source.size.height)
+        let scale = longest > maxEdge ? maxEdge / longest : 1
+        let targetSize = CGSize(
+            width: source.size.width * scale,
+            height: source.size.height * scale
+        )
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        let resized = renderer.image { _ in
+            source.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+        let data = resized.jpegData(compressionQuality: 0.85) ?? Data()
+        return (resized, data)
     }
 
     private func chip(icon: String, text: String, tint: Color, bgAlpha: Double = 0.06) -> some View {

--- a/clients/ios/StellarChat/StellarChat/Views/GroupListView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupListView.swift
@@ -234,13 +234,21 @@ struct GroupRow: View {
         HStack(spacing: 12) {
             // Avatar
             ZStack {
-                Circle()
-                    .fill(avatarColor.gradient)
-                    .frame(width: 48, height: 48)
-                Text(avatarInitial)
-                    .font(.title3)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.white)
+                if let data = group.avatarData, let uiImage = UIImage(data: data) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 48, height: 48)
+                        .clipShape(Circle())
+                } else {
+                    Circle()
+                        .fill(avatarColor.gradient)
+                        .frame(width: 48, height: 48)
+                    Text(avatarInitial)
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                }
             }
             .overlay(alignment: .bottomTrailing) {
                 if group.isPublishedOnChain {


### PR DESCRIPTION
## Summary

Fixes issue #129 — two follow-up bugs that surfaced once avatar upload started working during group creation:

- **Avatar not shown after creation.** The hero in `GroupInfoView`/`GroupInfoScreen` and the row in the group list only rendered initials/gradient, silently ignoring `group.avatarData`. The bytes were persisted but never read back. Both screens now decode `avatarData` and render it when present.
- **Pencil icon opened rename dialog.** The edit badge on the avatar triggered the group-rename dialog. It now launches the device photo picker, downscales the selection, and saves it via a new `setGroupAvatar` on the view model / `AppState`. The existing top-right "Edit" toolbar button continues to handle renaming.

Applied on both Android (Compose) and iOS (SwiftUI).

## Test plan

- [ ] **Android** — Create a group with an avatar → open the group → the picked avatar shows in the chat list row and on the GroupInfo hero (not initials).
- [ ] **Android** — Tap the pencil icon on GroupInfo → photo picker opens → pick a new image → avatar updates immediately and persists across app restart.
- [ ] **Android** — Tap top-right "Edit" button on GroupInfo → rename dialog still opens (unchanged).
- [ ] **iOS** — Create a group with an avatar → avatar renders in GroupListView row and on the GroupInfoView hero.
- [ ] **iOS** — Tap the pencil icon on the hero → `PhotosPicker` opens → selecting an image updates the avatar and persists.
- [ ] **iOS** — Top-right "Edit" toolbar button still opens the rename alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)