### PR TITLE
fix(clients): lock app orientation to portrait on iOS and Android

### DIFF
--- a/clients/android/StellarChat/app/src/main/AndroidManifest.xml
+++ b/clients/android/StellarChat/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.StellarChat">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/clients/ios/StellarChat/project.yml
+++ b/clients/ios/StellarChat/project.yml
@@ -30,8 +30,8 @@ targets:
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
         CODE_SIGN_ENTITLEMENTS: StellarChat/StellarChat.entitlements


### PR DESCRIPTION
Rotating the Scan QR screen on iOS produced a half-black display after
landscape→portrait rotation (#99). Restricting the app to portrait
sidesteps the broken rotation path on both platforms.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
