### PR TITLE
fix(blossom): pin ceremony coordinator blobs against LRU prune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ crates/ceremony-wasm/pkg/
 /deploy/ceremony/wasm/*.js
 /deploy/ceremony/wasm/*.d.ts
 .minisign/*.key
+ceremony-backup/

--- a/deploy/blossom/config.yml
+++ b/deploy/blossom/config.yml
@@ -1,0 +1,25 @@
+# hzrd149/blossom-server config — overrides the built-in defaults.
+#
+# Without this file the server falls back to a wildcard rule with a 1-week
+# LRU expiration, which prunes cold blobs (notably the small ceremony
+# state.txt / receipt.txt sidecars). The first rule below pins everything
+# uploaded by the ceremony coordinator pubkey indefinitely; remaining rules
+# preserve the prior chat-blob retention.
+
+storage:
+  rules:
+    # Onym ceremony coordinator — never expire ceremony artifacts (state.srs,
+    # state.txt, receipt.txt, future phase-2 zkeys). Matches by uploader
+    # pubkey so this scope is not at the mercy of MIME labels.
+    - type: "*"
+      expiration: "100 years"
+      pubkeys:
+        - "0ce1e21a66d7860ab60af9d1eaf00b1f2f96a47429fd05ad548cdb1f26b66403"
+
+    # Default retention for chat-app uploads (encrypted media blobs).
+    - type: "image/*"
+      expiration: "1 month"
+    - type: "video/*"
+      expiration: "1 week"
+    - type: "*"
+      expiration: "1 week"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - PORT=3000
     volumes:
       - blossom-data:/app/data
+      - ./deploy/blossom/config.yml:/app/config.yml:ro
     restart: unless-stopped
     networks:
       - internal


### PR DESCRIPTION
## Summary

The blossom-server image runs with no `config.yml` mounted, so it falls back to its default prune ruleset:

```yaml
- type: image/* expiration: 1 month
- type: video/* expiration: 1 week
- type: "*"     expiration: 1 week
```

Prune is **last-access based**. Small ceremony sidecars (`state.txt` ~360 B, `receipt.txt` ~1.4 KB) are rarely fetched after the next round's claimer pulls `prev.zip` once, so they idle past the 7-day window and get deleted by `[prune] deleted=N` cycles. Larger `state.srs` blobs are re-fetched constantly (every claim, every public download), so they survive.

Effect on `ceremony.onym.chat` as of audit on 2026-04-29: 22 of 30 phase-1 sidecars were already irreversibly pruned across the small/medium/large tiers. SRS files are intact.

## Fix

Mount a `config.yml` that pins everything uploaded by the coordinator pubkey for 100 years; chat-app uploads keep the prior defaults.

```yaml
storage:
  rules:
    - type: "*"
      expiration: "100 years"
      pubkeys:
        - "0ce1e21a66d7860ab60af9d1eaf00b1f2f96a47429fd05ad548cdb1f26b66403"
    - type: "image/*"  expiration: "1 month"
    - type: "video/*"  expiration: "1 week"
    - type: "*"        expiration: "1 week"
```

The pubkey-pinned rule wins for coordinator uploads; chat blobs fall through to the default rules. The MIME `*` fallback also satisfies blossom's upload allowlist (rules act as both retention and allowlist).

## Hot-fix already applied to droplet

The same change has been applied to `/opt/onym-chat/docker-compose.yml` and `/opt/onym-chat/deploy/blossom/config.yml` and the blossom container restarted, to stop further data loss while this PR is in review. Verified post-restart:

```
  Config:   config.yml
  Prune:    storage rules active (4 rules, first run in 60s)
[prune] (first cycle) deleted=0 errors=0
```

## Test plan

- [ ] On a fresh blossom container, `docker compose up -d blossom` and confirm logs show `Config: config.yml` and `4 rules` (not the default 3).
- [ ] PUT a small text/plain blob signed by the coordinator key, wait one prune cycle, confirm it persists.
- [ ] PUT a small text/plain blob signed by an unrelated key, confirm it is pruned per the 1-week rule (not coordinator-pinned).
- [ ] Confirm chat clients can still upload images/videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)