### PR TITLE
docs(mainnet-deployment): rewrite for post-fflonk world

### DIFF
--- a/docs/mainnet-deployment.md
+++ b/docs/mainnet-deployment.md
@@ -1,36 +1,60 @@
 # Mainnet Deployment Guide
 
-Deploy the SEP-XXXX private group membership contract to Stellar mainnet, run a fee-paying relayer, and connect the iOS/Android chat apps — all from a single funded account.
+Deploy the five per-type Onym private group membership contracts (`sep-anarchy`, `sep-democracy`, `sep-oligarchy`, `sep-oneonone`, `sep-tyranny`) to Stellar mainnet, run a fee-paying relayer, and connect the iOS/Android chat apps — all from a single funded account.
+
+This guide reflects the post-migration architecture: fflonk on BLS12-381 consuming Ethereum Foundation's 2023 KZG SRS, with verifier keys compiled into contract bytecode. There is no project-run trusted-setup ceremony, no keyset directory to generate, no on-chain VK rotation, and no `sep-xxxx` monolithic contract. See [`fflonk-migration-design.md`](fflonk-migration-design.md), [`postmortem-ceremony-data-loss.md`](postmortem-ceremony-data-loss.md), and [`group-governance-types-design.md`](group-governance-types-design.md) for the architectural background.
 
 ## Prerequisites
 
 - **Rust 1.75+** with `cargo`
 - **`stellar` CLI** ([install](https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli))
-- **A funded Stellar mainnet account** (minimum 20 XLM, recommended 50 XLM for deployment + initialization)
+- **A funded Stellar mainnet account** (recommended 80 XLM for the full five-contract deployment, less if deploying a subset of governance types)
 - **A second funded account** for the relayer (recommended 100 XLM for ongoing fee payments)
+
+## Architecture overview
+
+Five contracts, one per governance type. Each contract:
+
+- Embeds its verifier key(s) as compile-time `&[u8]` constants. The VK is the deterministic preprocessing of `(circuit, EF_KZG_SRS)`; reproducible bit-for-bit on any clean build of the same workspace revision.
+- Calls `bls12_381::pairing_check` over **2 pairs** per proof verification (fflonk-aggregated openings) plus one G1-MSM (~20 scalars) and SHA-256-based Fiat-Shamir transcript.
+- Has no `update_vk` admin entrypoint and no `DataKey::VK(_)` storage. VK rotation is by deploying a new contract version, not by amending an existing one.
+
+Constructors take only `admin` and (instance-stored) `restricted_mode`. There is no per-tier VK initialization step.
+
+| Contract | Created via | Mutates state? | Tiers | Notes |
+|---|---|---|---|---|
+| `sep-anarchy` | `create_group` | `update_commitment` (any single member) | small/medium/large | No quorum, no admin, no voting |
+| `sep-democracy` | `create_group` | `update_commitment` (in-circuit quorum check) | small/medium/large | Threshold-bound updates |
+| `sep-oligarchy` | `create_oligarchy_group` (verbose) | `update_commitment` (admin-tree co-signing) | small/medium/large | Admin tree + member tree |
+| `sep-oneonone` | `create_group` | (immutable post-creation) | 1v1 only | No `update_commitment` entrypoint |
+| `sep-tyranny` | `create_group` | `update_commitment` (admin-only) | small/medium/large | Single-admin transitions |
+
+You do not need to deploy all five contracts. Each is self-contained; deploy only the governance types you ship to users.
 
 ## Cost Estimates
 
 | Operation | Approximate Cost |
-|-----------|-----------------|
-| Contract deployment (WASM upload) | ~10 XLM |
-| Contract initialization (3 VKs) | ~5 XLM |
-| Each `create_group` | ~0.01 XLM |
-| Each `update_commitment` | ~0.005 XLM |
+|---|---|
+| Contract deployment per type (WASM upload + constructor) | ~12 XLM |
+| Each `create_group` / `create_oligarchy_group` | ~0.013 XLM |
+| Each `update_commitment` | ~0.007 XLM |
 | `verify_membership` (read-only) | Free |
-| **Deployer minimum** | **~20 XLM** |
+| `get_commitment` / `get_history` (read-only) | Free |
+| **Deployer minimum, full suite (5 contracts)** | **~80 XLM** |
+| **Deployer minimum, single contract** | **~20 XLM** |
 | **Relayer recommended** | **~100 XLM** |
+
+The fflonk verifier costs roughly 1.3–1.7× the legacy Groth16 verifier on Soroban (2-pair `pairing_check` + extra MSM scalars vs. Groth16's 4-pair `pairing_check`). Update-circuit costs scale similarly. Pre-deployment gas measurements are captured per contract under each crate's `tests/gas_benchmark.rs`.
 
 ---
 
-## Step 1: Deploy the Contract
+## Step 1: Deploy the Contract Suite
 
 ### 1.1 Import your Stellar account
 
 If you already have a funded mainnet account with a secret key (S...):
 
 ```bash
-# Import into stellar CLI
 stellar keys import my-deployer --secret-key
 # Paste your S... key when prompted
 ```
@@ -44,77 +68,73 @@ stellar keys fund my-deployer --network testnet
 
 ### 1.2 Run the deployment script
 
-```bash
-# Mainnet deployment
-IDENTITY=my-deployer ./scripts/deploy-mainnet.sh
+The deployment script no longer reads or generates a `keyset/` directory. Verifier keys are compiled into the contract WASM at build time; the build is deterministic, so the same workspace revision produces the same WASM bytes (and therefore the same contract behavior) on any machine.
 
-# Testnet dry-run (recommended first)
-IDENTITY=my-deployer ./scripts/deploy-mainnet.sh --network testnet
-```
-
-The script will:
-1. Build the Soroban contract WASM
-2. Read verification keys from the keyset directory (see "Generate a keyset" below)
-3. Deploy the contract
-4. Initialize with verification keys for all three tiers (small/medium/large)
-5. Verify the contract is live
-6. Print the contract ID and configuration instructions
-
-### 1.2a Generate a keyset (one-time, before first deployment)
+Deploy a single governance type:
 
 ```bash
-# Generate production proving keys + verification keys with real randomness
-./scripts/generate-keyset.sh --version 1
+# Mainnet, just sep-anarchy
+IDENTITY=my-deployer ./scripts/deploy-mainnet.sh --type anarchy
 
-# Copy proving keys into mobile app assets
-for tier in small medium large; do
-  mkdir -p clients/android/StellarChat/app/src/main/assets/keyset-v1
-  cp keyset-v1/$tier/proving_key.bin clients/android/StellarChat/app/src/main/assets/keyset-v1/$tier.bin
-
-  mkdir -p clients/ios/StellarChat/StellarChat/Resources/keyset-v1
-  cp keyset-v1/$tier/proving_key.bin clients/ios/StellarChat/StellarChat/Resources/keyset-v1/$tier.bin
-done
+# Testnet dry-run (recommended before mainnet)
+IDENTITY=my-deployer ./scripts/deploy-mainnet.sh --type anarchy --network testnet
 ```
 
-Then deploy with:
+Deploy the full suite:
+
 ```bash
-KEYSET_DIR=keyset-v1 IDENTITY=my-deployer ./scripts/deploy-mainnet.sh
+IDENTITY=my-deployer ./scripts/deploy-mainnet.sh --all
 ```
 
-For **testnet** testing only (uses deterministic seed — NOT for production):
-```bash
-VK_SEED=42 KEYSET_DIR=test IDENTITY=my-deployer ./scripts/deploy-mainnet.sh --network testnet
-```
+The script will, for each type:
 
-### 1.3 Save the contract ID
+1. Build the Soroban contract WASM (deterministic; verifier-key bytes embedded via `build.rs`).
+2. Verify the embedded SRS hash matches the EF KZG ceremony's published transcript hash. **The build fails on mismatch** — see Appendix.
+3. Deploy the contract.
+4. Invoke `__constructor(admin)` with the configured admin address.
+5. Verify the contract is live by calling a read-only entrypoint.
+6. Print the contract ID and append it to `deploy/contracts.json` for the relayer + mobile-app config steps.
 
-The script outputs something like:
+### 1.3 Save the contract IDs
+
+The script outputs one block per deployed contract:
 
 ```
 ════════════════════════════════════════════════════════════════
-  Deployment complete!
+  sep-anarchy deployed
 ════════════════════════════════════════════════════════════════
 
   Contract ID:      CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   Admin address:    GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   Network:          mainnet
+  WASM hash:        <sha256>
+  VK fingerprint:   <sha256 of compiled-in vk bytes>
 ```
 
-Save the **Contract ID** — you'll need it for the relayer and app configuration.
+Save the **Contract ID** for each type — you'll need them for the relayer and app configuration. The `VK fingerprint` is logged so you can prove on-chain VK provenance against `docs/cross-platform-test-vectors.json`.
 
 ### 1.4 Script options
 
 | Option | Description |
-|--------|-------------|
+|---|---|
 | `--identity <name>` | Stellar CLI identity to use (alternative to `IDENTITY` env var) |
 | `--network <name>` | `mainnet` (default) or `testnet` |
-| `--keep-artifacts` | Preserve generated VK files and WASM after deployment |
+| `--type <name>` | Deploy a single governance type: `anarchy`, `democracy`, `oligarchy`, `oneonone`, `tyranny` |
+| `--all` | Deploy all five types (uses `--type` for each, in order) |
+| `--admin <G...>` | Override the admin address (default: the deployer identity) |
+| `--keep-artifacts` | Preserve generated WASM artifacts after deployment |
+
+### 1.5 What is no longer required
+
+The pre-migration deployment had a "Generate a keyset" sub-step and `KEYSET_DIR` / `VK_SEED` environment variables. **None of that exists post-migration.** If you find references to `scripts/generate-keyset.sh`, `keyset-v1/`, `keyset-v2/`, `seed=42`, or `install-*-vks-*.sh` in older notes, treat them as historical context only — they refer to the legacy Groth16 ceremony surface that was decommissioned per [`fflonk-migration-design.md`](fflonk-migration-design.md) Phase E.
 
 ---
 
 ## Step 2: Deploy the Relayer
 
-The relayer is an HTTP service that receives contract invocation requests from mobile apps, signs them with its own Stellar account, and submits to the network. This way chat participants don't need funded Stellar accounts.
+The relayer is an HTTP service that receives contract invocation requests from mobile apps, signs them with its own Stellar account, and submits to the network. Chat participants don't need funded Stellar accounts.
+
+A single relayer can route to all five per-type contracts. The relayer's contract-ID whitelist becomes a list rather than a single value.
 
 ### 2.1 Fund a relayer account
 
@@ -137,11 +157,13 @@ cp .env.example .env
 Edit `.env`:
 
 ```bash
-# Your relayer account's secret key (REQUIRED)
+# Relayer account secret key (REQUIRED)
 RELAYER_SECRET_KEY=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-# Contract ID from Step 1 (REQUIRED)
-RELAYER_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# Comma-separated list of allowed contract IDs (REQUIRED).
+# One entry per deployed governance type. The relayer rejects any
+# request whose contractID is not in this list.
+RELAYER_CONTRACT_IDS=CAAA...anarchy,CBBB...democracy,CCCC...oligarchy,CDDD...oneonone,CEEE...tyranny
 
 # RPC endpoint
 RELAYER_RPC_URL=https://soroban.stellar.org
@@ -152,8 +174,7 @@ RELAYER_NETWORK=mainnet
 # Listen address
 RELAYER_BIND=0.0.0.0:8080
 
-# Optional: comma-separated bearer tokens for auth
-# If empty, no authentication is required
+# Optional: comma-separated bearer tokens
 RELAYER_AUTH_TOKENS=my-secret-token-1,my-secret-token-2
 
 # Rate limit per IP
@@ -164,23 +185,26 @@ RELAYER_RATE_LIMIT=30
 
 ```bash
 cd relayer
-
-# Development
 sh ./run.sh --release
 
 # Or build and run
 cargo build --release
-./target/release/sep-xxxx-relayer
+./target/release/onym-relayer
 ```
 
-You should see:
+Expected startup log:
 
 ```
 Relayer address: GXXXXXXX...
-Contract ID:    CXXXXXXX...
-Network:        mainnet
-Auth required:  true
-Rate limit:     30 req/min per IP
+Allowed contracts:
+  sep-anarchy:   CAAA...
+  sep-democracy: CBBB...
+  sep-oligarchy: CCCC...
+  sep-oneonone:  CDDD...
+  sep-tyranny:   CEEE...
+Network:         mainnet
+Auth required:   true
+Rate limit:      30 req/min per IP
 Listening on 0.0.0.0:8080
 ```
 
@@ -188,74 +212,83 @@ Listening on 0.0.0.0:8080
 
 ```bash
 cd relayer
-docker build -t sep-relayer .
+docker build -t onym-relayer .
 docker run -d \
   --env-file .env \
   -p 8080:8080 \
-  --name sep-relayer \
-  sep-relayer
+  --name onym-relayer \
+  onym-relayer
 ```
 
 ### 2.5 Verify the relayer
 
 ```bash
-# Should return an error (group doesn't exist) — confirms the relayer is working
+# Use any of the deployed contract IDs. A get_commitment for a
+# nonexistent group returns "GroupNotFound" — confirms the relayer
+# reached the contract.
 curl -s -X POST http://localhost:8080 \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer my-secret-token-1" \
   -d '{
-    "contractID": "CXXXX...",
-    "function": "get_state",
+    "contractID": "CAAA...",
+    "function": "get_commitment",
     "payload": {
       "groupID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     }
   }'
 ```
 
-Expected: an error response mentioning "GroupNotFound" — this means the relayer successfully reached the contract.
+Expected: `GroupNotFound`. Repeat per deployed contract ID to verify each is reachable.
 
 ### 2.6 Production deployment
 
-For production, deploy the relayer behind HTTPS:
+Deploy the relayer behind HTTPS:
 
-- Use a reverse proxy (nginx, Caddy) with TLS termination
-- Point your domain (e.g., `https://relayer.example.com`) to the relayer
-- The mobile apps support TLS certificate pinning for additional security
+- Use a reverse proxy (nginx, Caddy) with TLS termination.
+- Point your domain (e.g., `https://relayer.example.com`) to the relayer.
+- The mobile apps support TLS certificate pinning for additional security.
 
 ### 2.7 Relayer security
 
 The relayer validates every request:
 
 | Check | Description |
-|-------|-------------|
-| Contract ID whitelist | Only the configured contract ID is allowed |
-| Function whitelist | Only SEP-XXXX functions (`create_group`, `update_commitment`, `verify_membership`, `deactivate_group`, `get_state`, `get_history`) |
-| Proof size | Must decode to exactly 384 bytes |
-| Payload size | Rejected if > 8 KB |
+|---|---|
+| Contract ID whitelist | The `contractID` must appear in `RELAYER_CONTRACT_IDS` |
+| Function whitelist (per contract type) | sep-anarchy / sep-democracy / sep-tyranny: `create_group`, `update_commitment`, `verify_membership`, `get_commitment`, `get_history`. sep-oligarchy: `create_oligarchy_group` instead of `create_group`. sep-oneonone: no `update_commitment`. |
+| Proof size | fflonk wire format: `0x01` version prefix + ≈900 bytes uncompressed. The relayer rejects any payload whose `proof` field doesn't decode to a valid `PlonkProof` of the expected size for that contract+function. |
+| Payload size | Rejected if > 16 KB |
 | Rate limiting | Per IP address (configurable) |
 | Bearer auth | Optional, recommended for production |
+
+The proof-size check upgraded from Groth16's fixed 384 bytes to fflonk's ~900-byte versioned format. The version-prefix byte makes it possible to add a future proof-system swap without breaking the wire format check — the relayer verifies the prefix corresponds to a known proving system before counting bytes.
 
 ---
 
 ## Step 3: Configure Mobile Apps
 
+The mobile apps no longer ship per-tier proving keys generated from a project-run ceremony. They ship a single universal SRS bundle (≈206 KB, identical bytes across iOS/Android/server) plus per-circuit preprocessed prover keys (≈300 KB each). All proving keys are bundled at build time, not deploy time.
+
 ### iOS
 
 1. Open **StellarChat** → **Settings**
-2. In the **Stellar Contract** section:
-   - **Endpoint URL**: `https://soroban.stellar.org` (or your relayer URL if not using the relayer section)
-   - **Contract ID**: paste the contract ID from Step 1
+2. In the **Stellar Contracts** section:
+   - **Endpoint URL**: `https://soroban.stellar.org` (or your relayer URL)
+   - **Anarchy contract ID**: paste the contract ID from Step 1.3
+   - **Democracy contract ID**: same
+   - **Oligarchy contract ID**: same
+   - **OneOnOne contract ID**: same
+   - **Tyranny contract ID**: same
+   (Leave blank any types you didn't deploy.)
 3. If using the relayer, in the **Relayer** section:
-   - **Relayer URL**: `https://relayer.example.com` (or `http://localhost:8080` for local testing)
+   - **Relayer URL**: `https://relayer.example.com`
    - **Auth Token**: your bearer token (if configured)
 4. Tap **Save**
 
 ### Android
 
 1. Open **StellarChat** → **Settings**
-2. In the **Stellar Contract** section:
-   - **Endpoint URL**: `https://soroban.stellar.org`
-   - **Contract ID**: paste the contract ID from Step 1
+2. In the **Stellar Contracts** section, configure the same five contract IDs as iOS.
 3. If using the relayer:
    - **Relayer URL**: `https://relayer.example.com`
    - **Auth Token**: your bearer token
@@ -264,11 +297,15 @@ The relayer validates every request:
 ### How it works
 
 When you create a group in the app:
-1. The app generates a ZK proof of membership using the local proving key (seed 42)
-2. The app sends the proof + group data to the relayer as JSON
-3. The relayer wraps the request in a Stellar transaction, signs with its own account, and submits
-4. The contract verifies the proof on-chain and stores the group's commitment
-5. The app shows "Verified on-chain" status
+
+1. The user picks a governance type (Anarchy / OneOnOne / Democracy / Oligarchy / Tyranny). The app routes the create call to that type's contract ID.
+2. The app generates a fflonk membership proof using the bundled prover key for the chosen circuit + tier and the bundled universal SRS (no per-circuit setup at runtime — the prover key is the deterministic preprocessing of `(circuit, srs)`, baked at build time).
+3. The app sends the proof + group data to the relayer as JSON.
+4. The relayer wraps the request in a Stellar transaction, signs with its own account, and submits.
+5. The contract verifies the proof against its compiled-in VK; on success, stores the group's commitment.
+6. The app shows "Verified on-chain" status.
+
+Subsequent state transitions use the contract's update path (which differs by type — see "Architecture overview" above).
 
 The relayer's Stellar account pays the transaction fee. Chat participants never need their own funded Stellar accounts.
 
@@ -278,53 +315,74 @@ The relayer's Stellar account pays the transaction fee. Chat participants never 
 
 ### 4.1 Create a group
 
-1. Open the app on one device
-2. Tap **+** → **Create Group**
-3. Enter a name → **Create**
-4. If contract + relayer are configured, the app automatically publishes the group on-chain
-5. Check the group list — it should show epoch and member count
+1. Open the app on one device.
+2. Tap **+** → **Create Group**.
+3. Pick a governance type (e.g., "Anarchy") and enter a name → **Create**.
+4. The app generates a fflonk proof, sends it to the relayer, and waits for the contract acceptance.
+5. Check the group list — it should show epoch 0 and the configured tier.
+
+Repeat with each governance type you've deployed.
 
 ### 4.2 Verify on-chain
 
-In the app, the group should display a "Verified" badge indicating its commitment matches the on-chain state.
+In the app, the group should display a "Verified" badge indicating its commitment matches the on-chain state at the corresponding contract.
 
-You can also verify manually:
+You can also verify manually (replace `CAAA...` with the contract ID for that group's type):
 
 ```bash
-# Replace GROUP_ID_HEX with the group's ID (visible in app debug info)
 stellar contract invoke \
   --network mainnet \
-  --id CXXXX... \
+  --id CAAA... \
   --source-account my-deployer \
   --send no \
-  -- get_state \
+  -- get_commitment \
   --group-id GROUP_ID_HEX
 ```
 
 ### 4.3 Cross-platform test
 
-1. Create a group on iOS
-2. Share the invite code with an Android device
-3. Join on Android
-4. Both devices should show the same group with matching epoch and member count
-5. Send messages — they should flow bidirectionally via Nostr relays
+1. Create a group on iOS (any type).
+2. Share the invite code with an Android device.
+3. Join on Android.
+4. Both devices should show the same group with matching commitment and epoch.
+5. Trigger a state change appropriate for the group type:
+   - **Anarchy**: any member updates commitment → both devices reflect epoch+1.
+   - **Democracy**: members vote, threshold met, quorum-bound update lands.
+   - **Oligarchy**: admin co-signs an update.
+   - **OneOnOne**: no update path; verify both endpoints see the same commitment.
+   - **Tyranny**: admin updates commitment unilaterally.
+6. Send messages — they should flow bidirectionally via Nostr relays.
+
+### 4.4 Cross-platform test vectors
+
+`docs/cross-platform-test-vectors.json` pins (witness, public-inputs, VK fingerprint) for each circuit. To assert a fresh build agrees with the canonical reference:
+
+```bash
+cargo run --bin verify-test-vectors --release
+swift run swiftmls-verify-vectors docs/cross-platform-test-vectors.json
+./gradlew :kotlin-mls:run --args="verify-vectors docs/cross-platform-test-vectors.json"
+```
+
+All three platforms must report all entries verifying. A platform reporting a verification failure indicates a build divergence — most likely a stale SRS bundle or out-of-tree circuit edit.
 
 ---
 
 ## Troubleshooting
 
 | Error | Cause | Fix |
-|-------|-------|-----|
-| `InvalidProof` | VK/proving key mismatch | Ensure the contract was deployed with seed-42 VKs (use `deploy-mainnet.sh`) |
-| `NotInitialized` | Contract deployed but not initialized | Re-run the deployment script |
+|---|---|---|
+| `cargo build` fails with "SRS hash mismatch — refusing to build" | The embedded SRS bundle (`src/prover/srs/ef-kzg-2023.bin`) doesn't match the expected EF KZG hash | Re-fetch the SRS from `https://ceremony.ethereum.org` and verify its hash. Do not edit the bundled file by hand. |
+| `InvalidProof` from the contract | Client and contract were built from divergent revisions | Confirm both built from the same workspace revision; the deterministic VK fingerprint in the deploy log should match the VK fingerprint the client sees in `docs/cross-platform-test-vectors.json`. |
+| `NotInitialized` | Constructor was not called or admin was not set | Re-run `deploy-mainnet.sh --type <name>` for that contract; it invokes the constructor as part of the script. |
 | `GroupAlreadyExists` | Duplicate group creation | Normal if retrying — the group already exists on-chain |
-| `AdminOnly` | Restricted mode enabled | The admin can disable it: `set_restricted_mode(false)` |
+| `AdminOnly` | Restricted mode is enabled and the caller is not admin | Admin can disable: `set_restricted_mode(false)` |
 | Relayer returns 401 | Invalid bearer token | Check `RELAYER_AUTH_TOKENS` in `.env` |
-| Relayer returns 429 | Rate limited | Wait 60 seconds or increase `RELAYER_RATE_LIMIT` |
-| Relayer returns 400 | Payload validation failed | Check the error message — usually wrong contract ID or malformed proof |
-| Relayer returns 502 | CLI invocation failed | Check that `stellar` CLI is installed and the relayer account is funded |
-| App shows "Not configured" | Missing contract settings | Enter endpoint URL and contract ID in Settings |
-| App shows verification failure | Epoch mismatch | Local state diverged from on-chain — try re-verifying |
+| Relayer returns 429 | Rate limited | Wait or increase `RELAYER_RATE_LIMIT` |
+| Relayer returns 400 with "unknown contract" | Contract ID not in `RELAYER_CONTRACT_IDS` | Add the contract ID to the relayer config |
+| Relayer returns 400 with "proof size mismatch" | Proof is not a valid versioned `PlonkProof` | Confirm the client and relayer agree on proof version (current: `0x01`); mismatch usually indicates a stale client build |
+| Relayer returns 502 | RPC invocation failed | Check that the relayer account is funded and the Soroban RPC endpoint is reachable |
+| App shows "Not configured" for a governance type | The contract ID for that type is empty in Settings | Enter the contract ID in Settings, or accept that this governance type is unavailable |
+| App shows verification failure | Local state diverged from on-chain | Re-verify; if persistent, the local cache may be stale — clear and re-fetch |
 
 ---
 
@@ -332,39 +390,48 @@ stellar contract invoke \
 
 ### Account separation
 
-- **Deployer account** — becomes the contract admin. Store its secret key securely offline after deployment. Only needed for contract upgrades or enabling restricted mode.
-- **Relayer account** — used for ongoing operations. Keep it funded. If compromised, an attacker can only create/modify groups (requires valid ZK proofs) and spend the relayer's XLM.
+- **Deployer account** — becomes the contract admin. Store its secret key securely offline after deployment. Only needed for `set_restricted_mode` toggles or future contract upgrades. There is no `update_vk` admin action — VKs are bytecode-baked and rotate by deploying a new contract version.
+- **Relayer account** — used for ongoing operations. Keep it funded. If compromised, an attacker can only create/modify groups (still requires valid fflonk proofs from chat participants) and spend the relayer's XLM.
 
-### Proving key lifecycle
+### Proving-system trust model
 
-Production deployments use **real randomness** via `scripts/generate-keyset.sh` (OsRng). This is a single-party trusted setup — acceptable for closed beta.
-
-For public launch, upgrade to an MPC ceremony:
-1. Run multi-party ceremony to produce new `keyset-v2/`
-2. Ship new proving keys in mobile app assets
-3. Rotate VKs on-chain tier-by-tier via `update_vk`
-4. Bump `KEYSET_VERSION` in mobile code
-
-**Testing only**: `VK_SEED=42` flag enables deterministic seed for dev/testnet. This must NEVER be used for production.
+- **Universal SRS:** the project does not run its own trusted-setup ceremony. The fflonk SRS is the public output of Ethereum Foundation's 2023 KZG ceremony (≈141k contributors, finalised 2023-11-14). Soundness reduces to "at least one of ≈141k EF ceremony participants was honest and erased their contribution scalar" — a strictly stronger trust assumption than any small-N project-run ceremony.
+- **Verifier key provenance:** each contract's compile-time VK is the deterministic preprocessing of `(circuit, EF_KZG_SRS)`. Two clean builds of the same workspace revision produce byte-identical WASM and byte-identical VK bytes. The deploy script logs the VK fingerprint; auditors can reproduce by checking out the same revision and rebuilding.
+- **No on-chain VK updates:** the `update_vk` admin entrypoint that existed in the legacy `sep-xxxx` contract was removed in [`fflonk-migration-design.md`](fflonk-migration-design.md) Phase C. Rotating a VK requires deploying a new contract version; existing groups continue to use the contract version they were created against until they migrate.
+- **Prover-key lifecycle:** the mobile apps ship the universal SRS plus per-circuit preprocessed prover keys at build time. Both are reproducible from the public EF KZG transcript; no per-tier randomness, no per-deployment seed, no `KEYSET_VERSION` to bump on rotation. App release cadence and contract release cadence are independent.
 
 ### Privacy model
 
-- **On-chain**: The contract stores only opaque 32-byte commitments — never member lists, keys, or identities. The relayer's address is visible as the transaction signer (not the group member's).
-- **Nostr**: All messages are AES-256-GCM encrypted. Relays see ciphertext and topic tags only.
-- **Relayer**: Sees the JSON payloads (proofs, commitments) but not member identities. For maximum privacy, access the relayer over Tor/VPN.
+- **On-chain:** each contract stores opaque 32-byte commitments, history slots, and used-proof nullifiers. Member identities, keys, lists, and counts are not on-chain. The relayer's address appears as the transaction signer (not the group member's).
+- **Nostr:** messages are AES-256-GCM encrypted; relays see ciphertext and topic tags only.
+- **Relayer:** sees the JSON payloads (proofs, commitments) but not member identities. For maximum privacy, access the relayer over Tor/VPN.
+- **Governance-type leakage:** the choice of contract address reveals the group's governance type. If hiding the governance type is in your threat model, route all contracts through a single front-door (e.g., a dispatcher contract that branches on payload) — out of scope for this guide.
 
 ---
 
-## Appendix: VK Seed Compatibility
+## Appendix: Universal SRS provenance
 
-Both mobile apps generate proving keys at runtime using `generateTestingProvingKey(tier, seed=42)`. The deployment script's VK generator (`generate_mainnet_vks`) uses the same seed 42 for all three tiers:
+The fflonk verifier consumes a universal SRS — a sequence of powers of τ on BLS12-381, of size 4096 G1 + 65 G2 elements (≈206 KB in arkworks-uncompressed encoding). This SRS is the public output of **Ethereum Foundation's 2023 KZG ceremony** for EIP-4844, finalised 2023-11-14 with ≈141k contributors.
 
-| Tier | Depth | Max Members | Seed |
-|------|-------|-------------|------|
-| Small | 5 | 32 | 42 |
-| Medium | 8 | 256 | 42 |
-| Large | 11 | 2,048 | 42 |
+| Property | Value |
+|---|---|
+| Curve | BLS12-381 |
+| G1 elements | 4,096 (covers PLONK row counts up to 2,048 with comfortable headroom) |
+| G2 elements | 65 (sufficient for the fflonk verifier's 2-pair check) |
+| On-disk size | ≈206 KB |
+| Source | `https://ceremony.ethereum.org/api/v1/transcript` |
+| Embedded path | `src/prover/srs/ef-kzg-2023.bin` |
+| Hash file | `src/prover/srs/expected-hash.in` |
+| Build-time check | `build.rs` SHA-256-asserts the embedded bytes against the hash file; mismatch fails the build with "SRS hash mismatch — refusing to build" |
 
-This is critical: the verification key deployed on-chain must correspond to the same `(depth, seed)` as the proving key used by the apps. If you change the seed in the apps, you must redeploy the contract with matching VKs.
+To independently verify the SRS:
 
-Note: The testnet deployment script (`deploy_sep_xxxx_testnet.sh`) uses seeds 1001/1002/1003 for VK generation — those VKs are **incompatible** with the mobile apps' default proving keys. Always use `deploy-mainnet.sh` for app-compatible deployments.
+```bash
+shasum -a 256 src/prover/srs/ef-kzg-2023.bin
+# Compare against the value in src/prover/srs/expected-hash.in
+# and against the hash published by EF at ceremony.ethereum.org.
+```
+
+The same bytes are embedded into the mobile prover bundles (iOS `Resources/srs.bin`, Android `assets/srs/srs.bin`) and into each per-type contract's `build.rs`-driven VK preprocessing pipeline. If you ever see three different SHA-256 hashes for these three locations, treat it as a build-system integrity incident.
+
+If a future circuit needs more than 4,096 G1 elements, the secondary source is **Aztec Ignition** (BLS12-381, 2^21 G1 elements). Switching SRS sources is a one-line change in `src/prover/srs.rs` plus a new hash pin; the rest of the prover/verifier stack is SRS-source-agnostic.

--- a/docs/mainnet-deployment.md
+++ b/docs/mainnet-deployment.md
@@ -19,7 +19,7 @@ Five contracts, one per governance type. Each contract:
 - Calls `bls12_381::pairing_check` over **2 pairs** per proof verification (fflonk-aggregated openings) plus one G1-MSM (~20 scalars) and SHA-256-based Fiat-Shamir transcript.
 - Has no `update_vk` admin entrypoint and no `DataKey::VK(_)` storage. VK rotation is by deploying a new contract version, not by amending an existing one.
 
-Constructors take only `admin` and (instance-stored) `restricted_mode`. There is no per-tier VK initialization step.
+Constructors take only `admin`. `restricted_mode` is instance-stored and toggled post-deployment via `set_restricted_mode(bool)` (defaults to `false`). There is no per-tier VK initialization step.
 
 | Contract | Created via | Mutates state? | Tiers | Notes |
 |---|---|---|---|---|
@@ -40,10 +40,11 @@ You do not need to deploy all five contracts. Each is self-contained; deploy onl
 | Each `update_commitment` | ~0.007 XLM |
 | `verify_membership` (read-only) | Free |
 | `get_commitment` / `get_history` (read-only) | Free |
-| **Deployer minimum, full suite (5 contracts)** | **~80 XLM** |
-| **Deployer minimum, single contract** | **~20 XLM** |
+| **Deployer recommended, full suite (5 contracts)** | **~80 XLM** (5 × ~12 XLM deployment + ~20 XLM buffer for retries / initial smoke tests) |
+| **Deployer recommended, single contract** | **~20 XLM** (~12 XLM deployment + buffer) |
 | **Relayer recommended** | **~100 XLM** |
 
+<!-- TODO: verify post-Phase-C — fflonk-vs-Groth16 ratio is provisional until gas benchmarks land -->
 The fflonk verifier costs roughly 1.3–1.7× the legacy Groth16 verifier on Soroban (2-pair `pairing_check` + extra MSM scalars vs. Groth16's 4-pair `pairing_check`). Update-circuit costs scale similarly. Pre-deployment gas measurements are captured per contract under each crate's `tests/gas_benchmark.rs`.
 
 ---
@@ -88,12 +89,11 @@ IDENTITY=my-deployer ./scripts/deploy-mainnet.sh --all
 
 The script will, for each type:
 
-1. Build the Soroban contract WASM (deterministic; verifier-key bytes embedded via `build.rs`).
-2. Verify the embedded SRS hash matches the EF KZG ceremony's published transcript hash. **The build fails on mismatch** — see Appendix.
-3. Deploy the contract.
-4. Invoke `__constructor(admin)` with the configured admin address.
-5. Verify the contract is live by calling a read-only entrypoint.
-6. Print the contract ID and append it to `deploy/contracts.json` for the relayer + mobile-app config steps.
+1. Build the Soroban contract WASM (deterministic; verifier-key bytes embedded via `build.rs`). The build itself fails if the embedded SRS hash doesn't match the EF KZG ceremony's pinned hash — see Appendix. The deploy script does not re-verify the SRS at deploy time; build-time integrity is the load-bearing check.
+2. Deploy the contract.
+3. Invoke `__constructor(admin)` with the configured admin address.
+4. Verify the contract is live by calling a read-only entrypoint.
+5. Print the contract ID and append it to `deploy/contracts.json` for the relayer + mobile-app config steps.
 
 ### 1.3 Save the contract IDs
 
@@ -114,6 +114,8 @@ The script outputs one block per deployed contract:
 Save the **Contract ID** for each type — you'll need them for the relayer and app configuration. The `VK fingerprint` is logged so you can prove on-chain VK provenance against `docs/cross-platform-test-vectors.json`.
 
 ### 1.4 Script options
+
+<!-- TODO: verify post-Phase-C — script flag set is provisional until deploy-mainnet.sh is rewritten in implementation PR -->
 
 | Option | Description |
 |---|---|
@@ -192,7 +194,7 @@ cargo build --release
 ./target/release/onym-relayer
 ```
 
-Expected startup log:
+Expected startup log (only the contracts in `RELAYER_CONTRACT_IDS` appear; partial deployments show fewer entries):
 
 ```
 Relayer address: GXXXXXXX...
@@ -255,7 +257,7 @@ The relayer validates every request:
 | Check | Description |
 |---|---|
 | Contract ID whitelist | The `contractID` must appear in `RELAYER_CONTRACT_IDS` |
-| Function whitelist (per contract type) | sep-anarchy / sep-democracy / sep-tyranny: `create_group`, `update_commitment`, `verify_membership`, `get_commitment`, `get_history`. sep-oligarchy: `create_oligarchy_group` instead of `create_group`. sep-oneonone: no `update_commitment`. |
+| Function whitelist (per contract type) | <!-- TODO: verify post-Phase-C — exact per-type function set is provisional until contracts land --> sep-anarchy / sep-democracy / sep-tyranny: `create_group`, `update_commitment`, `verify_membership`, `get_commitment`, `get_history`. sep-oligarchy: `create_oligarchy_group` instead of `create_group`. sep-oneonone: no `update_commitment`. |
 | Proof size | fflonk wire format: `0x01` version prefix + ≈900 bytes uncompressed. The relayer rejects any payload whose `proof` field doesn't decode to a valid `PlonkProof` of the expected size for that contract+function. |
 | Payload size | Rejected if > 16 KB |
 | Rate limiting | Per IP address (configurable) |
@@ -355,7 +357,7 @@ stellar contract invoke \
 
 ### 4.4 Cross-platform test vectors
 
-`docs/cross-platform-test-vectors.json` pins (witness, public-inputs, VK fingerprint) for each circuit. To assert a fresh build agrees with the canonical reference:
+`docs/cross-platform-test-vectors.json` pins (public-inputs, proof, VK fingerprint) tuples for each circuit. The proofs are generated from fixed synthetic test witnesses checked into the test harness — they are not real user secrets. To assert a fresh build agrees with the canonical reference:
 
 ```bash
 cargo run --bin verify-test-vectors --release
@@ -411,14 +413,14 @@ All three platforms must report all entries verifying. A platform reporting a ve
 
 ## Appendix: Universal SRS provenance
 
-The fflonk verifier consumes a universal SRS — a sequence of powers of τ on BLS12-381, of size 4096 G1 + 65 G2 elements (≈206 KB in arkworks-uncompressed encoding). This SRS is the public output of **Ethereum Foundation's 2023 KZG ceremony** for EIP-4844, finalised 2023-11-14 with ≈141k contributors.
+The fflonk verifier consumes a universal SRS — a sequence of powers of τ on BLS12-381, of size 4096 G1 + 65 G2 elements (≈206 KB in arkworks-compressed encoding; uncompressed is ≈396 KB). This SRS is the public output of **Ethereum Foundation's 2023 KZG ceremony** for EIP-4844, finalised 2023-11-14 with ≈141k contributors.
 
 | Property | Value |
 |---|---|
 | Curve | BLS12-381 |
 | G1 elements | 4,096 (covers PLONK row counts up to 2,048 with comfortable headroom) |
 | G2 elements | 65 (sufficient for the fflonk verifier's 2-pair check) |
-| On-disk size | ≈206 KB |
+| On-disk size | ≈206 KB (compressed encoding) |
 | Source | `https://ceremony.ethereum.org/api/v1/transcript` |
 | Embedded path | `src/prover/srs/ef-kzg-2023.bin` |
 | Hash file | `src/prover/srs/expected-hash.in` |
@@ -434,4 +436,4 @@ shasum -a 256 src/prover/srs/ef-kzg-2023.bin
 
 The same bytes are embedded into the mobile prover bundles (iOS `Resources/srs.bin`, Android `assets/srs/srs.bin`) and into each per-type contract's `build.rs`-driven VK preprocessing pipeline. If you ever see three different SHA-256 hashes for these three locations, treat it as a build-system integrity incident.
 
-If a future circuit needs more than 4,096 G1 elements, the secondary source is **Aztec Ignition** (BLS12-381, 2^21 G1 elements). Switching SRS sources is a one-line change in `src/prover/srs.rs` plus a new hash pin; the rest of the prover/verifier stack is SRS-source-agnostic.
+If a future circuit needs more than 4,096 G1 elements, an alternative BLS12-381 SRS must be identified and pinned (e.g., a future expansion of the EF KZG transcript). Note that **Aztec Ignition is on BN254**, not BLS12-381, so it is *not* a drop-in fallback for this stack — switching to a BN254 source would require swapping the curve everywhere in the prover/verifier pipeline, not just the SRS bytes. Switching SRS sources within BLS12-381 is a one-line change in `src/prover/srs.rs` plus a new hash pin; the rest of the prover/verifier stack is SRS-source-agnostic so long as the curve is fixed.


### PR DESCRIPTION
## Summary

Rewrites [`docs/mainnet-deployment.md`](https://github.com/rinat-enikeev/stellar-mls/blob/docs/mainnet-deployment-fflonk/docs/mainnet-deployment.md) to assume the fflonk migration ([#162](https://github.com/rinat-enikeev/stellar-mls/pull/162), [#163](https://github.com/rinat-enikeev/stellar-mls/pull/163)) has shipped. The guide now describes deploying the **five per-type contracts** (`sep-anarchy`, `sep-democracy`, `sep-oligarchy`, `sep-oneonone`, `sep-tyranny`) with fflonk verifiers consuming the EF KZG universal SRS — no keyset, no project-run ceremony, no on-chain VK rotation, no `sep-xxxx`.

This PR is **forward-looking documentation**: it does not match the codebase as of `main` today; it describes the state after `implementation-plan-fflonk-migration.md` Phases A–F land. The intent is to have the post-migration guide ready in tree so reviewers of the implementation PRs can check their work against it as they go.

## Notable shape changes

| Section | Before | After |
|---|---|---|
| Title / intro | "SEP-XXXX private group membership" | five per-type Onym contracts |
| Cost estimates | `~10 XLM` deploy + `~5 XLM` init for one contract | `~12 XLM` per type, no init step; `~80 XLM` for the full suite |
| Architecture overview | (absent) | new table with per-type entrypoints + state-mutation semantics |
| Step 1 — deployment | reads `keyset/`, calls init with VKs, supports `KEYSET_DIR`/`VK_SEED` | constructor takes only `admin`; flags become `--type` / `--all`; deploy logs VK fingerprint for reproducibility |
| Step 2 — relayer config | `RELAYER_CONTRACT_ID` (single) | `RELAYER_CONTRACT_IDS` (list); function whitelist documented per gov type; proof-size check is versioned-fflonk |
| Step 3 — mobile config | one Contract ID; "seed 42 proving keys" | five contract IDs; bundled universal SRS + per-circuit pks |
| Step 4 — verification | one path | per-type smoke tests + cross-platform vectors as canonical check |
| Troubleshooting | row about VK/proving-key mismatch | rows about SRS hash mismatch + VK fingerprint divergence; rotation rows removed |
| Security Notes | "Proving key lifecycle: single-party trusted setup, upgrade to MPC for public launch" | "Proving-system trust model: EF KZG (≈141k contributors), deterministic preprocessing, no `update_vk`" |
| Appendix | "VK Seed Compatibility" (seeds, depths) | "Universal SRS provenance" (EF source, hash, build-time check, Aztec Ignition fallback) |

## What's preserved

- Account separation guidance (deployer vs. relayer).
- HTTPS / reverse proxy / TLS pinning recommendations.
- Privacy model framing (on-chain opacity, Nostr ciphertext-only, relayer-Tor option).
- Cross-platform test step.
- Stellar CLI invocation patterns.

## What's deliberately removed

- The "Generate a keyset" subsection.
- All references to `KEYSET_DIR`, `VK_SEED`, `seed=42`, `keyset-v1/`, `keyset-v2/`.
- The MPC-ceremony-upgrade note (we're skipping our own ceremony per the design doc).
- The VK Seed Compatibility appendix.
- Any mention of `update_vk` (entrypoint is gone post-migration).

## Test plan

- [ ] Read end-to-end and challenge any assumption that overstates fflonk verify gas. The 1.3–1.7× baseline number comes from the design doc; will need real numbers from C.5 once measured.
- [ ] Confirm the function-whitelist table per contract type is accurate (extracted from each contract's `lib.rs` entrypoints; sep-oligarchy uses `create_oligarchy_group` instead of `create_group`; sep-oneonone has no `update_commitment`).
- [ ] Confirm the deploy script invocation shape (`--type`/`--all`/`--admin`) matches what the team wants `scripts/deploy-mainnet.sh` to look like post-migration. This PR doesn't touch the script; that's part of Phase F operational work.
- [ ] Confirm the troubleshooting section catches the most likely actual failure modes; SRS hash mismatch is the new high-leverage diagnostic.

## Related

- [#161](https://github.com/rinat-enikeev/stellar-mls/pull/161) — `deploy/blossom/config.yml` hot-fix (merged, deployed)
- [#162](https://github.com/rinat-enikeev/stellar-mls/pull/162) — postmortem + design doc (merged)
- [#163](https://github.com/rinat-enikeev/stellar-mls/pull/163) — implementation plan (open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)