### PR TITLE
C.2 prereq: bake-vk tool for deterministic per-tier VK bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,11 +88,20 @@ plonk = [
 # One-shot operator tool for extracting the EF KZG SRS from the published
 # transcript. Activated only when running `cargo run --bin extract-ef-kzg`.
 extract-tool = ["plonk", "dep:serde_json"]
+# Per-tier VK baker. Produces deterministic verifying-key bytes the
+# Soroban contracts embed via `include_bytes!`. Activated only when
+# running `cargo run --bin bake-vk`.
+bake-vk-tool = ["plonk"]
 
 [[bin]]
 name = "extract-ef-kzg"
 path = "src/bin/extract_ef_kzg.rs"
 required-features = ["extract-tool"]
+
+[[bin]]
+name = "bake-vk"
+path = "src/bin/bake_vk.rs"
+required-features = ["bake-vk-tool"]
 
 [profile.release]
 strip = "symbols"

--- a/src/bin/bake_vk.rs
+++ b/src/bin/bake_vk.rs
@@ -1,0 +1,203 @@
+//! Bake a deterministic verifying-key byte file for a Soroban
+//! contract's per-tier embedded VK.
+//!
+//! Phase C.2 contracts include the output via:
+//!
+//! ```rust,ignore
+//! pub const VK_BYTES: &[u8] = include_bytes!("membership-d11.vk.bin");
+//! ```
+//!
+//! Pipeline:
+//! ```text
+//!     cargo run --bin bake-vk --features bake-vk-tool --release -- \
+//!         --circuit membership --depth 11 \
+//!         --out contracts/sep-anarchy/src/vk/membership-d11.vk.bin
+//! ```
+//!
+//! Writes `vk.serialize_uncompressed()` bytes (no header). Prints the
+//! SHA-256 of the output to stderr; the binary fails with exit code 2
+//! if that SHA-256 doesn't match the pinned `VK_SHA256_HEX_*` constants
+//! in [`crate::circuit::plonk::baker`] — guaranteeing the on-chain VK
+//! and the cross-platform-fingerprint tests stay in lock-step.
+//!
+//! The `--circuit` flag is currently `membership`-only; future
+//! tier-aware circuits (the `update_*` circuits per the migration plan)
+//! will register additional values here.
+
+#![cfg(feature = "plonk")]
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use sep_xxxx_circuits::circuit::plonk::baker::{
+    bake_membership_vk, pinned_vk_sha256_hex, vk_sha256_hex,
+};
+
+#[derive(Debug)]
+enum Circuit {
+    Membership,
+}
+
+impl Circuit {
+    fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "membership" => Ok(Self::Membership),
+            other => Err(format!(
+                "unknown --circuit {other:?} (supported: membership)"
+            )),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Membership => "membership",
+        }
+    }
+}
+
+struct Args {
+    circuit: Circuit,
+    depth: usize,
+    out_path: PathBuf,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(BakeCliError::Bake(e)) => {
+            eprintln!("bake error: {e}");
+            ExitCode::FAILURE
+        }
+        Err(BakeCliError::Io(e)) => {
+            eprintln!("io error: {e}");
+            ExitCode::FAILURE
+        }
+        Err(BakeCliError::Usage(s)) => {
+            eprintln!("usage error: {s}");
+            eprintln!();
+            eprintln!("usage: bake-vk --circuit <name> --depth <n> --out <path>");
+            eprintln!("  <name>: membership");
+            eprintln!("  <n>:    5, 8, or 11");
+            ExitCode::FAILURE
+        }
+        Err(BakeCliError::ShaDrift {
+            circuit,
+            depth,
+            computed,
+            pinned,
+        }) => {
+            eprintln!(
+                "fatal: bake of circuit={circuit} depth={depth} produced \
+                 SHA-256 {computed} but pinned baker constant is {pinned}. \
+                 Either the circuit shape changed or the canonical witness \
+                 changed; update VK_SHA256_HEX_* in baker.rs and \
+                 docs/cross-platform-test-vectors.json before re-running."
+            );
+            ExitCode::from(2)
+        }
+    }
+}
+
+#[derive(Debug)]
+enum BakeCliError {
+    Usage(String),
+    Bake(sep_xxxx_circuits::circuit::plonk::baker::BakeError),
+    Io(std::io::Error),
+    ShaDrift {
+        circuit: &'static str,
+        depth: usize,
+        computed: String,
+        pinned: &'static str,
+    },
+}
+
+fn run() -> Result<(), BakeCliError> {
+    let args = parse_args()?;
+
+    let bytes = match args.circuit {
+        Circuit::Membership => bake_membership_vk(args.depth).map_err(BakeCliError::Bake)?,
+    };
+
+    let computed = vk_sha256_hex(&bytes);
+    let pinned = pinned_vk_sha256_hex(args.depth)
+        .expect("pinned constant exists for the same depth set bake_membership_vk accepts");
+    if computed != pinned {
+        return Err(BakeCliError::ShaDrift {
+            circuit: args.circuit.as_str(),
+            depth: args.depth,
+            computed,
+            pinned,
+        });
+    }
+
+    if let Some(parent) = args.out_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(BakeCliError::Io)?;
+        }
+    }
+    fs::write(&args.out_path, &bytes).map_err(BakeCliError::Io)?;
+
+    eprintln!(
+        "[bake-vk] circuit={} depth={} bytes={} sha256={}",
+        args.circuit.as_str(),
+        args.depth,
+        bytes.len(),
+        computed
+    );
+    eprintln!("[bake-vk] wrote {}", args.out_path.display());
+    Ok(())
+}
+
+fn parse_args() -> Result<Args, BakeCliError> {
+    let raw: Vec<String> = env::args().collect();
+    let mut circuit: Option<String> = None;
+    let mut depth: Option<usize> = None;
+    let mut out_path: Option<PathBuf> = None;
+
+    let mut i = 1;
+    while i < raw.len() {
+        let arg = &raw[i];
+        match arg.as_str() {
+            "--circuit" => {
+                circuit = Some(
+                    raw.get(i + 1)
+                        .cloned()
+                        .ok_or_else(|| BakeCliError::Usage("--circuit needs a value".into()))?,
+                );
+                i += 2;
+            }
+            "--depth" => {
+                let s = raw
+                    .get(i + 1)
+                    .ok_or_else(|| BakeCliError::Usage("--depth needs a value".into()))?;
+                depth = Some(s.parse::<usize>().map_err(|_| {
+                    BakeCliError::Usage(format!("--depth must be an integer, got {s:?}"))
+                })?);
+                i += 2;
+            }
+            "--out" => {
+                out_path = Some(PathBuf::from(
+                    raw.get(i + 1)
+                        .ok_or_else(|| BakeCliError::Usage("--out needs a value".into()))?,
+                ));
+                i += 2;
+            }
+            other => {
+                return Err(BakeCliError::Usage(format!("unknown arg {other:?}")));
+            }
+        }
+    }
+
+    let circuit_name = circuit.ok_or_else(|| BakeCliError::Usage("missing --circuit".into()))?;
+    let circuit = Circuit::parse(&circuit_name).map_err(BakeCliError::Usage)?;
+    let depth = depth.ok_or_else(|| BakeCliError::Usage("missing --depth".into()))?;
+    let out_path = out_path.ok_or_else(|| BakeCliError::Usage("missing --out".into()))?;
+
+    Ok(Args {
+        circuit,
+        depth,
+        out_path,
+    })
+}

--- a/src/circuit/plonk/baker.rs
+++ b/src/circuit/plonk/baker.rs
@@ -1,0 +1,242 @@
+//! VK-baking helpers — produce deterministic verifying-key bytes for
+//! the on-chain Soroban verifier.
+//!
+//! Phase C.2 contracts embed VKs as `static` byte slices:
+//!
+//! ```rust,ignore
+//! pub const VK_BYTES: &[u8] = include_bytes!("membership-d11.vk.bin");
+//! ```
+//!
+//! Those bytes are produced here via `bake_membership_vk(depth)`,
+//! which mirrors the canonical-witness preprocessing path also
+//! exercised by `test_vectors::verify_plonk_membership_vk_fingerprints`.
+//! The cross-platform-anchor SHA-256 constants are the source of truth;
+//! `bake_membership_vk` is verified against them in the same test.
+//!
+//! The CLI wrapper at `src/bin/bake_vk.rs` (under `feature =
+//! "bake-vk-tool"`) calls `bake_membership_vk` and writes the result
+//! to disk. Contracts then `include_bytes!` that file — no jf-plonk
+//! types cross the contract boundary.
+
+#![cfg(feature = "plonk")]
+
+use ark_bls12_381_v05::Fr;
+use ark_ff_v05::PrimeField;
+use ark_serialize_v05::CanonicalSerialize;
+use jf_relation::PlonkCircuit;
+use sha2::{Digest, Sha256};
+
+use crate::circuit::plonk::membership::{synthesize_membership, MembershipWitness};
+use crate::circuit::plonk::poseidon::{poseidon_hash_one_v05, poseidon_hash_two_v05};
+use crate::prover::plonk;
+
+// ---------------------------------------------------------------------------
+// Pinned VK fingerprints — the cross-platform invariant.
+//
+// If any of these change, either:
+// - the circuit shape changed (gate order, public-input order, gadget
+//   internals) — review the diff carefully and update;
+// - the SRS changed (build.rs would also have caught the hash mismatch
+//   first);
+// - jf-plonk's `preprocess` output format changed at the byte level —
+//   in which case all consumers (Soroban verifier, mobile clients)
+//   need a coordinated update too.
+//
+// Mirror these into `docs/cross-platform-test-vectors.json` under
+// `plonk_membership_vk_fingerprints`. Non-Rust platforms compute the
+// same SHA-256 over their `VerifyingKey::serialize_uncompressed`
+// output and assert byte-equality.
+// ---------------------------------------------------------------------------
+
+/// SHA-256 of the canonical small-tier (depth=5) VK, hex-encoded.
+pub const VK_SHA256_HEX_SMALL: &str =
+    "a552b41c2e40167b74ccbec36d83cc931279d278e364cacb99a3a5ce9c26e5ab";
+
+/// SHA-256 of the canonical medium-tier (depth=8) VK, hex-encoded.
+pub const VK_SHA256_HEX_MEDIUM: &str =
+    "b4f98a146dad1de3447dde3b686ac2ddf8b4cdb153ad69f407684558e749b3d6";
+
+/// SHA-256 of the canonical large-tier (depth=11) VK, hex-encoded.
+pub const VK_SHA256_HEX_LARGE: &str =
+    "36e96f9bf3b834f81c73a2d402b33ef8c32bc01fe47cf6ee66978e29ab0d5849";
+
+/// Look up the pinned SHA-256 hex digest for a given tier depth.
+/// Returns `None` for any depth other than 5/8/11.
+pub fn pinned_vk_sha256_hex(depth: usize) -> Option<&'static str> {
+    match depth {
+        5 => Some(VK_SHA256_HEX_SMALL),
+        8 => Some(VK_SHA256_HEX_MEDIUM),
+        11 => Some(VK_SHA256_HEX_LARGE),
+        _ => None,
+    }
+}
+
+/// Deterministic canonical witness for tier `(depth)`. The hash inputs
+/// depend only on `depth`, so the circuit shape and resulting VK
+/// depend only on `depth`.
+///
+/// Used as the canonical fixture for VK preprocessing and as the
+/// cross-platform fingerprint anchor; non-Rust platforms reproducing
+/// the canonical witness must match the same `(secret_keys,
+/// prover_index, epoch, salt)` quadruple shown below.
+pub fn build_canonical_membership_witness(depth: usize) -> MembershipWitness {
+    // Deterministic secret-key set: 1, 2, ..., 8.
+    let secret_keys: Vec<Fr> = (1u64..=8).map(Fr::from).collect();
+    let prover_index = 3usize;
+    let epoch: u64 = 1234;
+    let salt: [u8; 32] = [0xEE; 32];
+
+    // Native v0.5 leaf + tree build (matches what the gadget computes
+    // in-circuit).
+    let leaves: Vec<Fr> = secret_keys.iter().map(poseidon_hash_one_v05).collect();
+    let num_leaves = 1usize << depth;
+    let mut nodes = vec![Fr::from(0u64); 2 * num_leaves];
+    for (i, leaf) in leaves.iter().enumerate() {
+        nodes[num_leaves + i] = *leaf;
+    }
+    for i in (1..num_leaves).rev() {
+        nodes[i] = poseidon_hash_two_v05(&nodes[2 * i], &nodes[2 * i + 1]);
+    }
+    let root = nodes[1];
+
+    let mut path = Vec::with_capacity(depth);
+    let mut cur = num_leaves + prover_index;
+    for _ in 0..depth {
+        let sib = if cur % 2 == 0 { cur + 1 } else { cur - 1 };
+        path.push(nodes[sib]);
+        cur /= 2;
+    }
+
+    let salt_fr = Fr::from_le_bytes_mod_order(&salt);
+    let inner = poseidon_hash_two_v05(&root, &Fr::from(epoch));
+    let commitment = poseidon_hash_two_v05(&inner, &salt_fr);
+
+    MembershipWitness {
+        commitment,
+        epoch,
+        secret_key: secret_keys[prover_index],
+        poseidon_root: root,
+        salt,
+        merkle_path: path,
+        leaf_index: prover_index,
+        depth,
+    }
+}
+
+/// Errors raised by the baker. Disjoint from `jf_plonk::PlonkError` so
+/// callers can distinguish "invalid input" from "preprocess failed".
+#[derive(Debug)]
+pub enum BakeError {
+    /// `depth` is outside the supported tier set (5, 8, 11).
+    UnsupportedDepth(usize),
+    /// `synthesize_membership` rejected the canonical witness — should
+    /// not happen for the supported depths; indicates a code change
+    /// broke the canonical-witness invariant.
+    Synthesize(jf_relation::CircuitError),
+    /// `preprocess` failed; usually `IndexTooLarge` if the SRS is too
+    /// small for the circuit.
+    Preprocess(jf_plonk::errors::PlonkError),
+    /// VK serialisation failed; arkworks `CanonicalSerialize` raised.
+    Serialize(ark_serialize_v05::SerializationError),
+}
+
+impl core::fmt::Display for BakeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnsupportedDepth(d) => write!(f, "unsupported depth {d} (expected 5, 8, or 11)"),
+            Self::Synthesize(e) => write!(f, "synthesize_membership failed: {e:?}"),
+            Self::Preprocess(e) => write!(f, "preprocess failed: {e:?}"),
+            Self::Serialize(e) => write!(f, "VK serialise failed: {e:?}"),
+        }
+    }
+}
+
+impl std::error::Error for BakeError {}
+
+/// Build the canonical membership circuit for `depth`, run jf-plonk's
+/// preprocessing against the embedded EF KZG SRS, and return the
+/// arkworks-uncompressed verifying-key bytes.
+///
+/// Output is deterministic: the canonical witness is bit-deterministic,
+/// the SRS is content-pinned, and `preprocess` is `(circuit, srs)`-
+/// deterministic (proven by `prover::plonk::tests::preprocess_is_deterministic`).
+/// Two invocations with the same `depth` therefore produce byte-identical
+/// output.
+///
+/// Cross-check the SHA-256 of the returned bytes against
+/// `pinned_vk_sha256_hex(depth)` — that comparison is the single anchor
+/// shared by the cross-platform tests, the on-chain VK pin, and any
+/// non-Rust prover.
+pub fn bake_membership_vk(depth: usize) -> Result<Vec<u8>, BakeError> {
+    if pinned_vk_sha256_hex(depth).is_none() {
+        return Err(BakeError::UnsupportedDepth(depth));
+    }
+
+    let witness = build_canonical_membership_witness(depth);
+    let mut circuit = PlonkCircuit::<Fr>::new_turbo_plonk();
+    synthesize_membership(&mut circuit, &witness).map_err(BakeError::Synthesize)?;
+    circuit
+        .finalize_for_arithmetization()
+        .map_err(BakeError::Synthesize)?;
+
+    let keys = plonk::preprocess(&circuit).map_err(BakeError::Preprocess)?;
+
+    let mut vk_bytes = Vec::new();
+    keys.vk
+        .serialize_uncompressed(&mut vk_bytes)
+        .map_err(BakeError::Serialize)?;
+    Ok(vk_bytes)
+}
+
+/// SHA-256 of `bytes`, hex-encoded (lowercase). Format-compatible with
+/// `pinned_vk_sha256_hex`.
+pub fn vk_sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each tier's bake produces the pinned SHA-256. This is the load-
+    /// bearing test for the cross-platform anchor: if it fails, either
+    /// (a) `bake_membership_vk` drifted, (b) the canonical witness
+    /// changed, or (c) jf-plonk / arkworks shifted byte layout.
+    #[test]
+    fn bake_membership_vk_matches_pinned_for_all_tiers() {
+        for &depth in &[5usize, 8, 11] {
+            let bytes = bake_membership_vk(depth)
+                .unwrap_or_else(|e| panic!("bake_membership_vk(depth={depth}) failed: {e}"));
+            let computed = vk_sha256_hex(&bytes);
+            let pinned = pinned_vk_sha256_hex(depth).unwrap();
+            assert_eq!(
+                computed, pinned,
+                "bake_membership_vk(depth={depth}) drifted from pinned SHA-256. \
+                 Either the circuit shape changed (audit the diff) or the canonical \
+                 witness changed (update both VK_SHA256_HEX_* in baker.rs and \
+                 docs/cross-platform-test-vectors.json)."
+            );
+        }
+    }
+
+    /// Determinism: re-baking the same tier produces byte-identical
+    /// output. Cheap regression check that nothing in the preprocessing
+    /// path picked up RNG or wall-clock state.
+    #[test]
+    fn bake_membership_vk_is_deterministic() {
+        let a = bake_membership_vk(5).expect("first bake");
+        let b = bake_membership_vk(5).expect("second bake");
+        assert_eq!(a, b, "bake output is non-deterministic");
+    }
+
+    /// Unsupported depths are rejected up-front, before doing any
+    /// preprocessing work.
+    #[test]
+    fn bake_membership_vk_rejects_unsupported_depth() {
+        match bake_membership_vk(7) {
+            Err(BakeError::UnsupportedDepth(7)) => {}
+            other => panic!("expected UnsupportedDepth(7), got {other:?}"),
+        }
+    }
+}

--- a/src/circuit/plonk/mod.rs
+++ b/src/circuit/plonk/mod.rs
@@ -24,6 +24,7 @@ pub mod poseidon;
 pub mod merkle;
 pub mod membership;
 pub mod proof_format;
+pub mod baker;
 
 #[cfg(test)]
 mod test_vectors;

--- a/src/circuit/plonk/proof_format.rs
+++ b/src/circuit/plonk/proof_format.rs
@@ -227,7 +227,7 @@ mod tests {
     use ark_ff_v05::PrimeField;
     use ark_serialize_v05::{CanonicalDeserialize, CanonicalSerialize};
     use jf_plonk::proof_system::structs::Proof;
-    use jf_relation::{Circuit, PlonkCircuit};
+    use jf_relation::PlonkCircuit;
     use rand_chacha::rand_core::SeedableRng;
 
     use crate::circuit::plonk::membership::{synthesize_membership, MembershipWitness};

--- a/src/circuit/plonk/test_vectors.rs
+++ b/src/circuit/plonk/test_vectors.rs
@@ -21,6 +21,11 @@
 //! is `(circuit, srs)`-deterministic (proven by
 //! `prover::plonk::tests::preprocess_is_deterministic`).
 //!
+//! The canonical-witness builder, the pinned VK SHA-256 constants, and
+//! the bake helper itself live in [`super::baker`] and are used both
+//! here (for the cross-platform fingerprint test) and by the
+//! `bake-vk` CLI binary that produces the on-chain VK byte files.
+//!
 //! `docs/cross-platform-test-vectors.json` carries the same
 //! fingerprints + canonical witnesses so non-Rust platforms can
 //! reproduce them.
@@ -29,102 +34,14 @@
 #![cfg(test)]
 
 use ark_bls12_381_v05::Fr;
-use ark_ff_v05::PrimeField;
 use ark_serialize_v05::CanonicalSerialize;
-use jf_relation::{Circuit, PlonkCircuit};
-use sha2::{Digest, Sha256};
+use jf_relation::PlonkCircuit;
 
-use crate::circuit::plonk::membership::{synthesize_membership, MembershipWitness};
-use crate::circuit::plonk::poseidon::{poseidon_hash_one_v05, poseidon_hash_two_v05};
+use crate::circuit::plonk::baker::{
+    bake_membership_vk, build_canonical_membership_witness, pinned_vk_sha256_hex, vk_sha256_hex,
+};
+use crate::circuit::plonk::membership::synthesize_membership;
 use crate::prover::plonk;
-
-/// Deterministic canonical witness for tier `(depth)`. Caller picks
-/// `prover_index` and produces a complete `MembershipWitness` whose
-/// hash inputs depend only on `depth` — so the circuit shape and the
-/// resulting VK depend only on `depth`.
-fn build_canonical_witness(depth: usize) -> MembershipWitness {
-    // Deterministic secret-key set: 1, 2, ..., 8.
-    let secret_keys: Vec<Fr> = (1u64..=8).map(Fr::from).collect();
-    let prover_index = 3usize;
-    let epoch: u64 = 1234;
-    let salt: [u8; 32] = [0xEE; 32];
-
-    // Native v0.5 leaf + tree build (matches what the gadget computes
-    // in-circuit).
-    let leaves: Vec<Fr> = secret_keys.iter().map(poseidon_hash_one_v05).collect();
-    let num_leaves = 1usize << depth;
-    let mut nodes = vec![Fr::from(0u64); 2 * num_leaves];
-    for (i, leaf) in leaves.iter().enumerate() {
-        nodes[num_leaves + i] = *leaf;
-    }
-    for i in (1..num_leaves).rev() {
-        nodes[i] = poseidon_hash_two_v05(&nodes[2 * i], &nodes[2 * i + 1]);
-    }
-    let root = nodes[1];
-
-    let mut path = Vec::with_capacity(depth);
-    let mut cur = num_leaves + prover_index;
-    for _ in 0..depth {
-        let sib = if cur % 2 == 0 { cur + 1 } else { cur - 1 };
-        path.push(nodes[sib]);
-        cur /= 2;
-    }
-
-    let salt_fr = Fr::from_le_bytes_mod_order(&salt);
-    let inner = poseidon_hash_two_v05(&root, &Fr::from(epoch));
-    let commitment = poseidon_hash_two_v05(&inner, &salt_fr);
-
-    MembershipWitness {
-        commitment,
-        epoch,
-        secret_key: secret_keys[prover_index],
-        poseidon_root: root,
-        salt,
-        merkle_path: path,
-        leaf_index: prover_index,
-        depth,
-    }
-}
-
-/// Build the canonical circuit for a tier and return its
-/// (vk_sha256_hex, num_gates_after_finalize, public_inputs).
-fn fingerprint(depth: usize) -> (String, usize, Vec<Fr>) {
-    let witness = build_canonical_witness(depth);
-    let mut circuit = PlonkCircuit::<Fr>::new_turbo_plonk();
-    synthesize_membership(&mut circuit, &witness).expect("synthesize");
-    circuit.finalize_for_arithmetization().expect("finalize");
-
-    let keys = plonk::preprocess(&circuit).expect("preprocess");
-    let mut vk_bytes = Vec::new();
-    keys.vk.serialize_uncompressed(&mut vk_bytes).expect("serialize vk");
-    let vk_sha256 = Sha256::digest(&vk_bytes);
-    let vk_sha256_hex = vk_sha256.iter().map(|b| format!("{:02x}", b)).collect();
-
-    let public_inputs = vec![witness.commitment, Fr::from(witness.epoch)];
-    (vk_sha256_hex, circuit.num_gates(), public_inputs)
-}
-
-/// Pinned VK fingerprints — the cross-platform invariant.
-///
-/// If any of these change, either:
-/// - the circuit shape changed (gate order, public-input order, gadget
-///   internals) — review the diff carefully and update;
-/// - the SRS changed (build.rs would also have caught the hash mismatch
-///   first);
-/// - jf-plonk's `preprocess` output format changed at the byte level —
-///   in which case all consumers (Soroban verifier, mobile clients)
-///   need a coordinated update too.
-///
-/// Mirror these into `docs/cross-platform-test-vectors.json` under
-/// `plonk_membership_vk_fingerprints`. Non-Rust platforms compute the
-/// same SHA-256 over their `VerifyingKey::serialize_uncompressed`
-/// output and assert byte-equality.
-const PINNED_VK_SHA256_SMALL:  &str =
-    "a552b41c2e40167b74ccbec36d83cc931279d278e364cacb99a3a5ce9c26e5ab";
-const PINNED_VK_SHA256_MEDIUM: &str =
-    "b4f98a146dad1de3447dde3b686ac2ddf8b4cdb153ad69f407684558e749b3d6";
-const PINNED_VK_SHA256_LARGE:  &str =
-    "36e96f9bf3b834f81c73a2d402b33ef8c32bc01fe47cf6ee66978e29ab0d5849";
 
 /// Cross-platform-anchor test: VK fingerprints must match the pinned
 /// values. Diagnostic info (gate count, public inputs) is logged via
@@ -132,31 +49,39 @@ const PINNED_VK_SHA256_LARGE:  &str =
 /// the load-bearing part.
 ///
 /// To bootstrap a fresh fingerprint set (after a deliberate circuit
-/// change): set the pinned constants to the dummy literal `""`,
-/// run `cargo test … verify_plonk_membership_vk_fingerprints
+/// change): set the pinned constants in `baker.rs` to the dummy
+/// literal `""`, run `cargo test … verify_plonk_membership_vk_fingerprints
 /// -- --nocapture`, and copy the printed `vk_sha256=…` values into
-/// both `PINNED_VK_SHA256_*` above and
+/// both `baker::VK_SHA256_HEX_*` and
 /// `docs/cross-platform-test-vectors.json`.
 #[test]
 fn verify_plonk_membership_vk_fingerprints() {
-    let cases = [
-        (5usize, "small", PINNED_VK_SHA256_SMALL),
-        (8, "medium", PINNED_VK_SHA256_MEDIUM),
-        (11, "large", PINNED_VK_SHA256_LARGE),
-    ];
-    for (depth, tier, pinned) in cases {
-        let (computed, n_gates, pub_inputs) = fingerprint(depth);
+    for &depth in &[5usize, 8, 11] {
+        let tier = match depth {
+            5 => "small",
+            8 => "medium",
+            11 => "large",
+            _ => unreachable!(),
+        };
+        let vk_bytes = bake_membership_vk(depth)
+            .unwrap_or_else(|e| panic!("bake_membership_vk(depth={depth}) failed: {e}"));
+        let computed = vk_sha256_hex(&vk_bytes);
+        let pinned = pinned_vk_sha256_hex(depth).expect("pinned constant for supported depth");
+
+        let witness = build_canonical_membership_witness(depth);
         eprintln!(
             "[plonk-vk-fingerprint] depth={depth:>2} ({tier:>6}): \
-             gates={n_gates}, vk_sha256={computed}"
+             vk_bytes={} bytes, vk_sha256={computed}",
+            vk_bytes.len()
         );
-        eprintln!("  public_inputs[0] (commitment) = {}", pub_inputs[0]);
-        eprintln!("  public_inputs[1] (epoch)      = {}", pub_inputs[1]);
+        eprintln!("  public_inputs[0] (commitment) = {}", witness.commitment);
+        eprintln!("  public_inputs[1] (epoch)      = {}", Fr::from(witness.epoch));
+
         assert_eq!(
             computed, pinned,
             "VK SHA-256 for depth={depth} ({tier}) drifted from the pinned canonical \
              value. Either the circuit/SRS changed (audit the diff) or the canonical \
-             witness changed (update both PINNED_VK_SHA256_* and \
+             witness changed (update both VK_SHA256_HEX_* in baker.rs and \
              docs/cross-platform-test-vectors.json)."
         );
     }
@@ -187,11 +112,10 @@ const PROOF_COMPRESSED_LEN: usize = 977;
 
 #[test]
 fn canonical_proof_serialised_byte_length_per_tier() {
-    use ark_serialize_v05::CanonicalSerialize;
     use rand_chacha::rand_core::SeedableRng;
 
     for &depth in &[5usize, 8, 11] {
-        let witness = build_canonical_witness(depth);
+        let witness = build_canonical_membership_witness(depth);
         let mut circuit = PlonkCircuit::<Fr>::new_turbo_plonk();
         synthesize_membership(&mut circuit, &witness).expect("synthesize");
         circuit.finalize_for_arithmetization().expect("finalize");
@@ -235,8 +159,8 @@ fn canonical_proof_serialised_byte_length_per_tier() {
         // Sanity check that the serialised bytes parse back without
         // error. This is **not** a semantic round-trip — `Proof` does
         // not derive `PartialEq`, and we don't re-verify the parsed
-        // proof here. Phase C.1 (PR #174) adds the byte-level parser
-        // and a stronger oracle test against jf-plonk's deserialiser.
+        // proof here. Phase C.1's byte-level parser
+        // (`super::proof_format`) handles the stronger oracle test.
         use ark_bls12_381_v05::Bls12_381;
         use ark_serialize_v05::CanonicalDeserialize;
         use jf_plonk::proof_system::structs::Proof;
@@ -255,7 +179,7 @@ fn canonical_witness_proves_and_verifies_for_all_tiers() {
     use rand_chacha::rand_core::SeedableRng;
 
     for &depth in &[5usize, 8, 11] {
-        let witness = build_canonical_witness(depth);
+        let witness = build_canonical_membership_witness(depth);
         let mut circuit = PlonkCircuit::<Fr>::new_turbo_plonk();
         synthesize_membership(&mut circuit, &witness).expect("synthesize");
         circuit.finalize_for_arithmetization().expect("finalize");


### PR DESCRIPTION
## Summary

Adds the `bake-vk` CLI binary that produces deterministic per-(circuit, tier) verifying-key byte files for the Soroban contracts to embed via `include_bytes!`. Prerequisite for the per-contract C.2.x verifier rewrites.

- **`src/circuit/plonk/baker.rs` (new)** — canonical-witness builder (promoted from test-only), pinned VK SHA-256 constants, `bake_membership_vk(depth) -> Vec<u8>`, `vk_sha256_hex(...)`, `BakeError`.
- **`src/bin/bake_vk.rs` (new)** — thin CLI, gated on `feature = "bake-vk-tool"`. Prints SHA-256 of output to stderr; exits with code 2 (distinct from usage / IO failure) if the computed SHA-256 ever drifts from the pinned baker constants.
- **`src/circuit/plonk/test_vectors.rs`** — refactored to consume `baker.rs` instead of duplicating the canonical-witness builder + constants. Same assertions, same coverage, smaller surface.
- **`Cargo.toml`** — new `bake-vk-tool = ["plonk"]` feature and `[[bin]] name = "bake-vk"` entry alongside `extract-ef-kzg`.

Drive-by: drops a dead `Circuit` import in `proof_format.rs` (compile warning under `--tests`).

## Smoke test

```
$ cargo run --features bake-vk-tool --bin bake-vk --release -- \
      --circuit membership --depth 11 --out /tmp/d11.vk.bin
[bake-vk] circuit=membership depth=11 bytes=3002 sha256=36e96f9b…b0d5849
[bake-vk] wrote /tmp/d11.vk.bin
```

Hex matches `baker::VK_SHA256_HEX_LARGE` and the pinned cross-platform fingerprint in `docs/cross-platform-test-vectors.json`. Same for d=5 / d=8.

## Test plan

- [x] `cargo test --features plonk --lib --release plonk` — 37 / 37 pass (was 34 + 3 new baker tests).
- [x] `cargo run --features bake-vk-tool --bin bake-vk --release -- --circuit membership --depth 5/8/11` — SHA-256 matches pinned for all three tiers.
- [x] Re-running with same args produces byte-identical output (deterministic).
- [x] `--depth 7` rejected with `unsupported depth 7 (expected 5, 8, or 11)`, exit code 1.
- [x] `--circuit unknown` rejected with usage error, exit code 1.
- [x] Default-features (groth16) build still compiles unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)