### PR TITLE
C.2 prereq: Soroban-portable transcript module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "rand_chacha",
  "serde_json",
  "sha2",
+ "sha3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,12 @@ rand_chacha = "0.3"
 k256 = { version = "0.13", features = ["schnorr"] }
 jni = { version = "0.21", optional = true }
 
+# Keccak-256 for the SolidityTranscript port (Phase C.2 verifier). Optional —
+# only the plonk feature activates it. The Soroban contract port replaces
+# this with `env.crypto().keccak256()` host calls; this crate-side dep keeps
+# the prover-side reference + byte-exactness tests self-contained.
+sha3 = { version = "0.10", default-features = false, optional = true }
+
 # Used only by the one-shot `extract-ef-kzg` binary (gated behind
 # `feature = "extract-tool"`). Keeps the JSON dep out of the library
 # build — every other consumer should never need this.
@@ -84,6 +90,7 @@ plonk = [
     "dep:ark-bls12-381-v05", "dep:ark-ec-v05", "dep:ark-ff-v05",
     "dep:ark-serialize-v05", "dep:ark-std-v05",
     "dep:ark-crypto-primitives-v05",
+    "dep:sha3",
 ]
 # One-shot operator tool for extracting the EF KZG SRS from the published
 # transcript. Activated only when running `cargo run --bin extract-ef-kzg`.

--- a/src/circuit/plonk/mod.rs
+++ b/src/circuit/plonk/mod.rs
@@ -26,6 +26,7 @@ pub mod membership;
 pub mod proof_format;
 pub mod vk_format;
 pub mod baker;
+pub mod transcript;
 
 #[cfg(test)]
 mod test_vectors;

--- a/src/circuit/plonk/transcript.rs
+++ b/src/circuit/plonk/transcript.rs
@@ -1,0 +1,506 @@
+//! Soroban-portable port of jf-plonk's `SolidityTranscript`.
+//!
+//! The transcript is the Fiat-Shamir state machine the verifier uses
+//! to derive challenges (β, γ, α, ζ, v, u) from a deterministic
+//! sequence of public-input + commitment + evaluation appends. For
+//! the verifier to accept a proof, the prover and verifier must agree
+//! on the transcript byte-for-byte.
+//!
+//! jf-plonk's `SolidityTranscript` (`plonk/src/transcript/solidity.rs`)
+//! is the reference. It uses Keccak-256 with this state machine:
+//!
+//! ```text
+//!   state = [0u8; 32]
+//!   transcript = Vec::new()
+//!
+//!   append_message(msg):
+//!     transcript.extend(msg)
+//!
+//!   squeeze() -> [u8; 32]:
+//!     state = keccak256(state || transcript)
+//!     transcript.clear()
+//!     return state
+//! ```
+//!
+//! Field elements and G1 commitments are appended in **big-endian**
+//! form (Solidity's native order). For BLS12-381 specifically:
+//!
+//! - The base field Fp (G1/G2 coordinates) is **already serialised BE**
+//!   by arkworks 0.5, matching the IETF / EIP-2537 canonical encoding.
+//!   Splitting `serialize_uncompressed` bytes in half gives `(x_be, y_be)`
+//!   directly — only flag bits need stripping.
+//! - The scalar field Fr (k constants, public inputs, evaluations) is
+//!   serialised **LE**. [`arkworks_fr_le_to_be`] reverses it.
+//!
+//! The conversion helpers handle both cases.
+//!
+//! The Soroban port (Phase C.2) replaces `sha3::Keccak256` with
+//! `env.crypto().keccak256_simple(bytes)` and the `Vec<u8>`
+//! accumulator with Soroban `Bytes`. Everything else carries over
+//! unchanged. Byte-exactness with jf-plonk is verified by
+//! [`tests::transcript_matches_jf_plonk_oracle`].
+//!
+//! # Public-input encoding
+//!
+//! Membership proofs have two public inputs `(commitment, epoch)`,
+//! both `Fr` (32 BE bytes). The transcript appends them as a single
+//! sequence of length-prefixed BE field elements, matching jf-plonk's
+//! `append_field_elems`. Callers that hold their public inputs as
+//! arkworks-LE bytes should use [`arkworks_fr_le_to_be`] before
+//! feeding them to [`SolidityTranscript::append_vk_and_public_inputs`].
+
+#![cfg(feature = "plonk")]
+
+use sha3::{Digest, Keccak256};
+
+use crate::circuit::plonk::vk_format::{
+    ParsedVerifyingKey, FR_LEN, G1_LEN, G2_LEN, NUM_K_CONSTANTS, NUM_SELECTOR_COMMS,
+    NUM_SIGMA_COMMS,
+};
+
+/// BLS12-381 scalar-field modulus bit size, used in
+/// `append_vk_and_public_inputs` (matches jf-plonk's
+/// `E::ScalarField::MODULUS_BIT_SIZE`).
+pub const FR_MODULUS_BITS: u32 = 255;
+
+/// Half of the uncompressed G1 byte length — one field-element x or y.
+const G1_HALF: usize = G1_LEN / 2; // 48
+
+/// Soroban-portable Fiat-Shamir transcript, byte-compatible with
+/// jf-plonk's `SolidityTranscript`.
+///
+/// Holds a 32-byte rolling state and a buffered byte vector of
+/// not-yet-squeezed input. Each `squeeze` call hashes
+/// `state || transcript` and rolls the result into `state`.
+#[derive(Clone, Debug)]
+pub struct SolidityTranscript {
+    state: [u8; 32],
+    transcript: Vec<u8>,
+}
+
+impl Default for SolidityTranscript {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SolidityTranscript {
+    /// Create a fresh transcript with zero-state.
+    pub fn new() -> Self {
+        Self {
+            state: [0u8; 32],
+            transcript: Vec::new(),
+        }
+    }
+
+    /// Append raw bytes to the unsqueezed buffer.
+    pub fn append_message(&mut self, msg: &[u8]) {
+        self.transcript.extend_from_slice(msg);
+    }
+
+    /// Append a G1 commitment in Solidity-BE form (`x_be(48) || y_be(48)`).
+    /// Callers holding arkworks-LE bytes should convert with
+    /// [`arkworks_g1_uncompressed_to_be_xy`] first.
+    pub fn append_g1_commitment_be(&mut self, x_be: &[u8; G1_HALF], y_be: &[u8; G1_HALF]) {
+        self.transcript.extend_from_slice(x_be);
+        self.transcript.extend_from_slice(y_be);
+    }
+
+    /// Append a 32-byte BE field element.
+    pub fn append_field_elem_be(&mut self, fe_be: &[u8; FR_LEN]) {
+        self.transcript.extend_from_slice(fe_be);
+    }
+
+    /// Squeeze a 32-byte raw challenge: `state := keccak256(state || transcript);
+    /// transcript.clear(); return state`. Caller reduces `mod r` as needed.
+    pub fn squeeze(&mut self) -> [u8; 32] {
+        let mut hasher = Keccak256::new();
+        hasher.update(self.state);
+        hasher.update(&self.transcript);
+        let buf = hasher.finalize();
+        self.state.copy_from_slice(&buf);
+        self.transcript.clear();
+        self.state
+    }
+
+    /// Test-only inspection: peek at the unsqueezed buffer.
+    #[cfg(test)]
+    pub(crate) fn buffered_bytes(&self) -> &[u8] {
+        &self.transcript
+    }
+
+    /// Mirror of jf-plonk's `append_vk_and_pub_input`. Drives the
+    /// initial state of the transcript before the verifier consumes
+    /// the proof. `srs_g2_compressed` is `to_bytes!(&vk.open_key.powers_of_h[1])`
+    /// (arkworks-compressed, 96 LE bytes). Public inputs must already
+    /// be in BE form.
+    ///
+    /// The 12-byte zero pad after the three header fields is the
+    /// EVM-word-alignment quirk from `SolidityTranscript`: 4 (field
+    /// modulus bits) + 8 (domain size) + 8 (input size) = 20 bytes;
+    /// pad to the 32-byte EVM word boundary.
+    pub fn append_vk_and_public_inputs(
+        &mut self,
+        vk: &ParsedVerifyingKey,
+        srs_g2_compressed: &[u8; G2_LEN / 2],
+        public_inputs_be: &[[u8; FR_LEN]],
+    ) {
+        // 1. field size in bits — 4 bytes BE u32
+        self.append_message(&FR_MODULUS_BITS.to_be_bytes());
+        // 2. domain size — 8 bytes BE u64
+        self.append_message(&vk.domain_size.to_be_bytes());
+        // 3. input size — 8 bytes BE u64
+        self.append_message(&vk.num_inputs.to_be_bytes());
+        // 4. EVM-word-alignment pad
+        self.append_message(&[0u8; 12]);
+        // 5. SRS G2 element — 96 bytes compressed LE
+        self.append_message(srs_g2_compressed);
+        // 6. wire-subset separators (k constants) — 5 × Fr BE
+        for k_le in &vk.k_constants {
+            let k_be = arkworks_fr_le_to_be(k_le);
+            self.append_field_elem_be(&k_be);
+        }
+        // 7. selector commitments — 13 × G1 BE
+        for sel_le in &vk.selector_commitments {
+            let (x_be, y_be) = arkworks_g1_uncompressed_to_be_xy(sel_le);
+            self.append_g1_commitment_be(&x_be, &y_be);
+        }
+        // 8. sigma commitments — 5 × G1 BE
+        for sig_le in &vk.sigma_commitments {
+            let (x_be, y_be) = arkworks_g1_uncompressed_to_be_xy(sig_le);
+            self.append_g1_commitment_be(&x_be, &y_be);
+        }
+        // 9. public inputs — N × Fr BE
+        for pi in public_inputs_be {
+            self.append_field_elem_be(pi);
+        }
+        // Sanity bounds — prevents silently feeding mis-sized inputs.
+        debug_assert_eq!(vk.k_constants.len(), NUM_K_CONSTANTS);
+        debug_assert_eq!(vk.selector_commitments.len(), NUM_SELECTOR_COMMS);
+        debug_assert_eq!(vk.sigma_commitments.len(), NUM_SIGMA_COMMS);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Byte-format conversions: arkworks-uncompressed-LE ↔ Solidity-BE.
+// ---------------------------------------------------------------------------
+
+/// Reverse a 32-byte LE Fr representation into 32 BE bytes. arkworks
+/// `Fr::serialize_uncompressed` writes LE; jf-plonk's transcript
+/// expects `Fr::into_bigint().to_bytes_be()` form.
+///
+/// Identical to a byte-reverse — Fr has no flag bits, so the high
+/// byte is unmasked.
+pub fn arkworks_fr_le_to_be(le: &[u8; FR_LEN]) -> [u8; FR_LEN] {
+    let mut out = [0u8; FR_LEN];
+    for i in 0..FR_LEN {
+        out[i] = le[FR_LEN - 1 - i];
+    }
+    out
+}
+
+/// Split a 96-byte arkworks-uncompressed G1 into `(x_be, y_be)`.
+///
+/// arkworks-bls12-381 0.5 has a custom serialiser for its SWCurveConfig
+/// (`curves/util.rs::serialize_fq` + `EncodingFlags::encode_flags`)
+/// that writes BLS12-381 G1 in **big-endian** bytes (IETF / EIP-2537
+/// canonical encoding) and packs flag bits in the **top 3 bits of
+/// `bytes[0]`** — the high byte of x:
+///
+///   bit 7: compression flag (0 for uncompressed)
+///   bit 6: infinity flag
+///   bit 5: lexographically-largest sort flag (compressed-only)
+///
+/// We mask those bits off so callers get the canonical x regardless
+/// of the point's encoding flags. y has no flag bits in this format
+/// but we mask its high byte too for defence-in-depth (BLS12-381
+/// base-field values fit in the bottom 5 bits of byte 0 since `p` is
+/// 381 bits, so the mask is a no-op on valid y values).
+///
+/// Note the asymmetry vs [`arkworks_fr_le_to_be`]: the **scalar**
+/// field Fr serialises LE (`[lsb, …, msb]`) while the **base** field
+/// Fp serialises BE. That's an arkworks-bls12-381 quirk, not a typo.
+pub fn arkworks_g1_uncompressed_to_be_xy(
+    bytes: &[u8; G1_LEN],
+) -> ([u8; G1_HALF], [u8; G1_HALF]) {
+    let mut x_be = [0u8; G1_HALF];
+    let mut y_be = [0u8; G1_HALF];
+    x_be.copy_from_slice(&bytes[0..G1_HALF]);
+    y_be.copy_from_slice(&bytes[G1_HALF..G1_LEN]);
+    x_be[0] &= 0x1F;
+    y_be[0] &= 0x1F;
+    (x_be, y_be)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bls12_381_v05::{Bls12_381, Fr, G1Affine};
+    use ark_ec_v05::AffineRepr;
+    use ark_ff_v05::{BigInteger, PrimeField};
+    use ark_serialize_v05::{CanonicalDeserialize, CanonicalSerialize};
+    use jf_plonk::{
+        proof_system::structs::VerifyingKey,
+        transcript::{PlonkTranscript, SolidityTranscript as JfTranscript},
+    };
+
+    use crate::circuit::plonk::baker::bake_membership_vk;
+    use crate::circuit::plonk::vk_format::parse_vk_bytes;
+
+    /// G1 conversion round-trips through arkworks `xy()`.
+    #[test]
+    fn g1_le_to_be_matches_arkworks_xy() {
+        let g = G1Affine::generator();
+        let mut le_bytes = [0u8; G1_LEN];
+        g.serialize_uncompressed(&mut le_bytes[..]).unwrap();
+
+        let (x_be, y_be) = arkworks_g1_uncompressed_to_be_xy(&le_bytes);
+
+        let (x, y) = g.xy().unwrap();
+        let expected_x_be = x.into_bigint().to_bytes_be();
+        let expected_y_be = y.into_bigint().to_bytes_be();
+        assert_eq!(x_be.as_slice(), expected_x_be.as_slice(), "x_be mismatch");
+        assert_eq!(y_be.as_slice(), expected_y_be.as_slice(), "y_be mismatch");
+    }
+
+    /// Fr conversion matches arkworks `into_bigint().to_bytes_be()`.
+    #[test]
+    fn fr_le_to_be_matches_arkworks() {
+        for &raw in &[1u64, 42, 1u64 << 50, u64::MAX] {
+            let f = Fr::from(raw);
+            let mut le = [0u8; FR_LEN];
+            f.serialize_uncompressed(&mut le[..]).unwrap();
+            let be = arkworks_fr_le_to_be(&le);
+            let expected = f.into_bigint().to_bytes_be();
+            assert_eq!(be.as_slice(), expected.as_slice(), "raw={raw}");
+        }
+    }
+
+    /// Squeezing a fresh transcript matches `Keccak256(0^32)` —
+    /// catches silly state-init mistakes.
+    #[test]
+    fn squeeze_empty_matches_keccak_of_zeros() {
+        let mut t = SolidityTranscript::new();
+        let chal = t.squeeze();
+
+        let expected = Keccak256::digest([0u8; 32]);
+        assert_eq!(chal.as_slice(), expected.as_slice());
+    }
+
+    /// Diagnostic: walk through `append_vk_and_public_inputs` step
+    /// by step, recreating jf-plonk's byte sequence by hand, and assert
+    /// the cumulative buffered bytes match after each step. Pinpoints
+    /// the exact diverging append if the oracle test fails.
+    #[test]
+    fn append_vk_step_by_step_matches_manual_byte_stream() {
+        let vk_bytes = bake_membership_vk(5).expect("bake d=5");
+        let parsed_vk = parse_vk_bytes(&vk_bytes).expect("parse vk");
+        let oracle_vk: VerifyingKey<Bls12_381> =
+            VerifyingKey::deserialize_uncompressed(&vk_bytes[..]).unwrap();
+
+        let public_inputs_fr: Vec<Fr> = vec![Fr::from(7u64), Fr::from(13u64)];
+        let public_inputs_be: Vec<[u8; FR_LEN]> = public_inputs_fr
+            .iter()
+            .map(|fr| {
+                let bytes = fr.into_bigint().to_bytes_be();
+                let mut arr = [0u8; FR_LEN];
+                arr.copy_from_slice(&bytes);
+                arr
+            })
+            .collect();
+
+        let mut srs_g2_compressed = [0u8; G2_LEN / 2];
+        oracle_vk.open_key.powers_of_h[1]
+            .serialize_compressed(&mut srs_g2_compressed[..])
+            .unwrap();
+
+        // What our port buffers
+        let mut ours = SolidityTranscript::new();
+        ours.append_vk_and_public_inputs(&parsed_vk, &srs_g2_compressed, &public_inputs_be);
+        let ours_buf = ours.buffered_bytes().to_vec();
+
+        // What jf-plonk's logic would produce, recreated manually
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&FR_MODULUS_BITS.to_be_bytes());
+        expected.extend_from_slice(&(oracle_vk.domain_size as u64).to_be_bytes());
+        expected.extend_from_slice(&(oracle_vk.num_inputs as u64).to_be_bytes());
+        expected.extend_from_slice(&[0u8; 12]);
+        expected.extend_from_slice(&srs_g2_compressed);
+        for k in &oracle_vk.k {
+            expected.extend_from_slice(&k.into_bigint().to_bytes_be());
+        }
+        // Mirror jf-plonk's `append_commitment`: substitute (0, 0) for
+        // points at infinity. Some selector polynomials are zero, so
+        // their commitments are the identity G1 element.
+        let g1_xy_be_or_zero = |p: &<Bls12_381 as ark_ec_v05::pairing::Pairing>::G1Affine| {
+            use ark_bls12_381_v05::Fq;
+            use ark_ff_v05::Zero;
+            if p.is_zero() {
+                let zero_bytes = Fq::zero().into_bigint().to_bytes_be();
+                (zero_bytes.clone(), zero_bytes)
+            } else {
+                let (x, y) = p.xy().unwrap();
+                (x.into_bigint().to_bytes_be(), y.into_bigint().to_bytes_be())
+            }
+        };
+        for sel in &oracle_vk.selector_comms {
+            let (x, y) = g1_xy_be_or_zero(&sel.0);
+            expected.extend_from_slice(&x);
+            expected.extend_from_slice(&y);
+        }
+        for sig in &oracle_vk.sigma_comms {
+            let (x, y) = g1_xy_be_or_zero(&sig.0);
+            expected.extend_from_slice(&x);
+            expected.extend_from_slice(&y);
+        }
+        for pi in &public_inputs_fr {
+            expected.extend_from_slice(&pi.into_bigint().to_bytes_be());
+        }
+
+        if ours_buf != expected {
+            // Find first divergence offset for an actionable error message.
+            let off = ours_buf
+                .iter()
+                .zip(expected.iter())
+                .position(|(a, b)| a != b)
+                .unwrap_or_else(|| ours_buf.len().min(expected.len()));
+            panic!(
+                "buffered bytes diverge at offset {off}: \
+                 ours[{off}..{}]={:02x?} expected[{off}..{}]={:02x?}",
+                (off + 8).min(ours_buf.len()),
+                &ours_buf[off..(off + 8).min(ours_buf.len())],
+                (off + 8).min(expected.len()),
+                &expected[off..(off + 8).min(expected.len())],
+            );
+        }
+    }
+
+    /// Run jf-plonk's `SolidityTranscript` and our port on the same
+    /// inputs (drawn from a real baked VK + canonical proof). Both
+    /// must produce byte-equal challenge sequences after each squeeze.
+    /// This is the load-bearing test: byte-equality across the
+    /// transcript flow guarantees the verifier challenges agree.
+    #[test]
+    fn transcript_matches_jf_plonk_oracle() {
+        // Build a real VK + proof at depth=5.
+        let vk_bytes = bake_membership_vk(5).expect("bake d=5");
+        let parsed_vk = parse_vk_bytes(&vk_bytes).expect("parse vk");
+        let oracle_vk: VerifyingKey<Bls12_381> =
+            VerifyingKey::deserialize_uncompressed(&vk_bytes[..]).unwrap();
+
+        // Build a canonical proof to extract a consistent set of
+        // commitments + evaluations to feed into both transcripts.
+        use crate::circuit::plonk::baker::build_canonical_membership_witness;
+        use crate::circuit::plonk::membership::synthesize_membership;
+        use crate::prover::plonk;
+        use jf_relation::PlonkCircuit;
+        use rand_chacha::rand_core::SeedableRng;
+
+        let depth = 5usize;
+        let witness = build_canonical_membership_witness(depth);
+        let mut circuit = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_membership(&mut circuit, &witness).unwrap();
+        circuit.finalize_for_arithmetization().unwrap();
+        let keys = plonk::preprocess(&circuit).unwrap();
+        let mut rng = rand_chacha::ChaCha20Rng::from_seed([0u8; 32]);
+        let oracle_proof =
+            plonk::prove(&mut rng, &keys.pk, &circuit).unwrap();
+
+        let public_inputs_fr: Vec<Fr> =
+            vec![witness.commitment, Fr::from(witness.epoch)];
+        let public_inputs_be: Vec<[u8; FR_LEN]> = public_inputs_fr
+            .iter()
+            .map(|fr| {
+                let bytes = fr.into_bigint().to_bytes_be();
+                let mut arr = [0u8; FR_LEN];
+                arr.copy_from_slice(&bytes);
+                arr
+            })
+            .collect();
+
+        // ---- Reference transcript (jf-plonk) ----
+        let mut jf = <JfTranscript as PlonkTranscript<
+            <Bls12_381 as ark_ec_v05::pairing::Pairing>::BaseField,
+        >>::new(b"membership-test");
+        <JfTranscript as PlonkTranscript<_>>::append_vk_and_pub_input::<Bls12_381, _>(
+            &mut jf,
+            &oracle_vk,
+            &public_inputs_fr,
+        )
+        .unwrap();
+
+        // ---- Our port ----
+        let mut srs_g2_compressed = [0u8; G2_LEN / 2];
+        oracle_vk
+            .open_key
+            .powers_of_h[1]
+            .serialize_compressed(&mut srs_g2_compressed[..])
+            .unwrap();
+
+        let mut ours = SolidityTranscript::new();
+        ours.append_vk_and_public_inputs(
+            &parsed_vk,
+            &srs_g2_compressed,
+            &public_inputs_be,
+        );
+
+        // After append_vk_and_public_inputs, both transcripts must
+        // squeeze the same first challenge.
+        let jf_chal_1 = <JfTranscript as PlonkTranscript<_>>::get_challenge::<Bls12_381>(
+            &mut jf,
+            b"chal-1",
+        )
+        .unwrap();
+        let our_chal_1 = ours.squeeze();
+        assert_eq!(
+            jf_chal_1.into_bigint().to_bytes_be().as_slice(),
+            // jf returns Fr — reducing mod r.  We return raw bytes;
+            // for a fair comparison reduce on our side too.
+            arkworks_fr_le_to_be(&{
+                let mut le = [0u8; FR_LEN];
+                Fr::from_be_bytes_mod_order(&our_chal_1)
+                    .serialize_uncompressed(&mut le[..])
+                    .unwrap();
+                le
+            })
+            .as_slice(),
+            "first challenge after append_vk_and_public_inputs",
+        );
+
+        // Now mirror the verifier's commit → squeeze flow on a few
+        // wire commitments. We append wire commitments in
+        // arkworks-uncompressed form on our side, going through the
+        // BE conversion helper; jf-plonk uses its own append_commitment.
+        for (i, wire_comm) in oracle_proof
+            .wires_poly_comms
+            .iter()
+            .enumerate()
+            .take(3)
+        {
+            <JfTranscript as PlonkTranscript<_>>::append_commitment::<Bls12_381, _>(
+                &mut jf,
+                b"wire",
+                wire_comm,
+            )
+            .unwrap();
+
+            let mut wc_le = [0u8; G1_LEN];
+            wire_comm.0.serialize_uncompressed(&mut wc_le[..]).unwrap();
+            let (x_be, y_be) = arkworks_g1_uncompressed_to_be_xy(&wc_le);
+            ours.append_g1_commitment_be(&x_be, &y_be);
+
+            let jf_chal = <JfTranscript as PlonkTranscript<_>>::get_challenge::<Bls12_381>(
+                &mut jf,
+                b"after-wire",
+            )
+            .unwrap();
+            let our_raw = ours.squeeze();
+            let our_reduced = Fr::from_be_bytes_mod_order(&our_raw);
+            assert_eq!(
+                jf_chal, our_reduced,
+                "challenge mismatch after wire commitment {i}"
+            );
+        }
+    }
+}
+

--- a/src/circuit/plonk/transcript.rs
+++ b/src/circuit/plonk/transcript.rs
@@ -43,11 +43,15 @@
 //! # Public-input encoding
 //!
 //! Membership proofs have two public inputs `(commitment, epoch)`,
-//! both `Fr` (32 BE bytes). The transcript appends them as a single
-//! sequence of length-prefixed BE field elements, matching jf-plonk's
-//! `append_field_elems`. Callers that hold their public inputs as
-//! arkworks-LE bytes should use [`arkworks_fr_le_to_be`] before
-//! feeding them to [`SolidityTranscript::append_vk_and_public_inputs`].
+//! both `Fr` (32 BE bytes). The transcript appends them back-to-back
+//! with no explicit length prefix — the count is implicit, carried
+//! by the `num_inputs: u64` field appended earlier in
+//! [`SolidityTranscript::append_vk_and_public_inputs`] (step 3 of
+//! the VK header). This matches jf-plonk's `append_field_elems`,
+//! which also omits a per-call length and relies on the VK header
+//! prefix. Callers that hold their public inputs as arkworks-LE
+//! bytes should use [`arkworks_fr_le_to_be`] before feeding them to
+//! [`SolidityTranscript::append_vk_and_public_inputs`].
 
 #![cfg(feature = "plonk")]
 
@@ -254,6 +258,16 @@ pub fn arkworks_g1_uncompressed_to_be_xy(
     let mut y_be = [0u8; G1_HALF];
     x_be.copy_from_slice(&bytes[0..G1_HALF]);
     y_be.copy_from_slice(&bytes[G1_HALF..G1_LEN]);
+    // y has no flag bits in this format; bits 5-7 of `y_be[0]` must
+    // be zero for any valid y < p (since BLS12-381's `p` is 381 bits).
+    // Catch upstream bugs that feed non-canonical y bytes through the
+    // helper — release builds keep the defensive mask below.
+    debug_assert_eq!(
+        y_be[0] & 0xE0,
+        0,
+        "y high byte has bits 5-7 set (0x{:02x}); upstream parser corrupted or fed non-canonical bytes",
+        y_be[0]
+    );
     x_be[0] &= 0x1F;
     y_be[0] &= 0x1F;
     (x_be, y_be)

--- a/src/circuit/plonk/transcript.rs
+++ b/src/circuit/plonk/transcript.rs
@@ -54,7 +54,7 @@
 use sha3::{Digest, Keccak256};
 
 use crate::circuit::plonk::vk_format::{
-    ParsedVerifyingKey, FR_LEN, G1_LEN, G2_LEN, NUM_K_CONSTANTS, NUM_SELECTOR_COMMS,
+    ParsedVerifyingKey, FR_LEN, G1_LEN, G2_COMPRESSED_LEN, NUM_K_CONSTANTS, NUM_SELECTOR_COMMS,
     NUM_SIGMA_COMMS,
 };
 
@@ -132,8 +132,9 @@ impl SolidityTranscript {
     /// Mirror of jf-plonk's `append_vk_and_pub_input`. Drives the
     /// initial state of the transcript before the verifier consumes
     /// the proof. `srs_g2_compressed` is `to_bytes!(&vk.open_key.powers_of_h[1])`
-    /// (arkworks-compressed, 96 LE bytes). Public inputs must already
-    /// be in BE form.
+    /// (arkworks-compressed, 96 BE bytes — Fp is BE for BLS12-381 in
+    /// arkworks 0.5, with sign + infinity flags packed in the top
+    /// bits of `bytes[0]`). Public inputs must already be in BE form.
     ///
     /// The 12-byte zero pad after the three header fields is the
     /// EVM-word-alignment quirk from `SolidityTranscript`: 4 (field
@@ -142,9 +143,30 @@ impl SolidityTranscript {
     pub fn append_vk_and_public_inputs(
         &mut self,
         vk: &ParsedVerifyingKey,
-        srs_g2_compressed: &[u8; G2_LEN / 2],
+        srs_g2_compressed: &[u8; G2_COMPRESSED_LEN],
         public_inputs_be: &[[u8; FR_LEN]],
     ) {
+        // Validate VK shape *before* writing anything, so a malformed
+        // `ParsedVerifyingKey` fails fast rather than poisoning the
+        // transcript buffer with partial state. The parser itself
+        // already enforces these counts, but this is the function-
+        // boundary contract — runs in release builds too.
+        assert_eq!(
+            vk.k_constants.len(),
+            NUM_K_CONSTANTS,
+            "ParsedVerifyingKey::k_constants has wrong length"
+        );
+        assert_eq!(
+            vk.selector_commitments.len(),
+            NUM_SELECTOR_COMMS,
+            "ParsedVerifyingKey::selector_commitments has wrong length"
+        );
+        assert_eq!(
+            vk.sigma_commitments.len(),
+            NUM_SIGMA_COMMS,
+            "ParsedVerifyingKey::sigma_commitments has wrong length"
+        );
+
         // 1. field size in bits — 4 bytes BE u32
         self.append_message(&FR_MODULUS_BITS.to_be_bytes());
         // 2. domain size — 8 bytes BE u64
@@ -153,7 +175,7 @@ impl SolidityTranscript {
         self.append_message(&vk.num_inputs.to_be_bytes());
         // 4. EVM-word-alignment pad
         self.append_message(&[0u8; 12]);
-        // 5. SRS G2 element — 96 bytes compressed LE
+        // 5. SRS G2 element — 96 bytes compressed BE
         self.append_message(srs_g2_compressed);
         // 6. wire-subset separators (k constants) — 5 × Fr BE
         for k_le in &vk.k_constants {
@@ -174,10 +196,6 @@ impl SolidityTranscript {
         for pi in public_inputs_be {
             self.append_field_elem_be(pi);
         }
-        // Sanity bounds — prevents silently feeding mis-sized inputs.
-        debug_assert_eq!(vk.k_constants.len(), NUM_K_CONSTANTS);
-        debug_assert_eq!(vk.selector_commitments.len(), NUM_SELECTOR_COMMS);
-        debug_assert_eq!(vk.sigma_commitments.len(), NUM_SIGMA_COMMS);
     }
 }
 
@@ -193,8 +211,8 @@ impl SolidityTranscript {
 /// byte is unmasked.
 pub fn arkworks_fr_le_to_be(le: &[u8; FR_LEN]) -> [u8; FR_LEN] {
     let mut out = [0u8; FR_LEN];
-    for i in 0..FR_LEN {
-        out[i] = le[FR_LEN - 1 - i];
+    for (o, &b) in out.iter_mut().zip(le.iter().rev()) {
+        *o = b;
     }
     out
 }
@@ -212,7 +230,10 @@ pub fn arkworks_fr_le_to_be(le: &[u8; FR_LEN]) -> [u8; FR_LEN] {
 ///   bit 5: lexographically-largest sort flag (compressed-only)
 ///
 /// We mask those bits off so callers get the canonical x regardless
-/// of the point's encoding flags. y has no flag bits in this format
+/// of the point's encoding flags. For an infinity point arkworks
+/// writes `(0, 0)` bytes plus the infinity flag in `bytes[0] = 0x40`;
+/// after masking we recover `(0, 0)` — matching jf-plonk's
+/// `append_commitment` substitution. y has no flag bits in this format
 /// but we mask its high byte too for defence-in-depth (BLS12-381
 /// base-field values fit in the bottom 5 bits of byte 0 since `p` is
 /// 381 bits, so the mask is a no-op on valid y values).
@@ -220,6 +241,12 @@ pub fn arkworks_fr_le_to_be(le: &[u8; FR_LEN]) -> [u8; FR_LEN] {
 /// Note the asymmetry vs [`arkworks_fr_le_to_be`]: the **scalar**
 /// field Fr serialises LE (`[lsb, …, msb]`) while the **base** field
 /// Fp serialises BE. That's an arkworks-bls12-381 quirk, not a typo.
+///
+/// **This function is not validation.** It silently strips flag bits
+/// rather than rejecting malformed encodings. Caller is responsible
+/// for confirming the parent VK / proof bytes were validated upstream
+/// (e.g. by `vk_format::parse_vk_bytes` / `proof_format::parse_proof_bytes`,
+/// and ultimately by Soroban's on-curve check at pairing time).
 pub fn arkworks_g1_uncompressed_to_be_xy(
     bytes: &[u8; G1_LEN],
 ) -> ([u8; G1_HALF], [u8; G1_HALF]) {
@@ -261,6 +288,30 @@ mod tests {
         let expected_y_be = y.into_bigint().to_bytes_be();
         assert_eq!(x_be.as_slice(), expected_x_be.as_slice(), "x_be mismatch");
         assert_eq!(y_be.as_slice(), expected_y_be.as_slice(), "y_be mismatch");
+    }
+
+    /// Infinity (= identity) point round-trips through the helper to
+    /// `([0; 48], [0; 48])`. arkworks-bls12-381 writes the infinity
+    /// flag bit (`0x40`) in `bytes[0]`; after the helper's `& 0x1F`
+    /// mask, both halves come out as 48 zero bytes — matching
+    /// jf-plonk's `append_commitment` `(0, 0)` substitution for
+    /// `comm.0.is_zero()` points (which our membership VK has, e.g.
+    /// for unused selector polynomials).
+    #[test]
+    fn g1_le_to_be_returns_zero_for_infinity_point() {
+        let infinity = G1Affine::zero();
+        let mut le_bytes = [0u8; G1_LEN];
+        infinity.serialize_uncompressed(&mut le_bytes[..]).unwrap();
+
+        // Sanity: arkworks set the infinity flag bit somewhere in bytes[0].
+        assert_ne!(
+            le_bytes[0], 0,
+            "infinity flag should be encoded in bytes[0]; got all-zero high byte"
+        );
+
+        let (x_be, y_be) = arkworks_g1_uncompressed_to_be_xy(&le_bytes);
+        assert_eq!(x_be, [0u8; G1_HALF], "x_be should be all zeros for infinity");
+        assert_eq!(y_be, [0u8; G1_HALF], "y_be should be all zeros for infinity");
     }
 
     /// Fr conversion matches arkworks `into_bigint().to_bytes_be()`.
@@ -309,7 +360,7 @@ mod tests {
             })
             .collect();
 
-        let mut srs_g2_compressed = [0u8; G2_LEN / 2];
+        let mut srs_g2_compressed = [0u8; G2_COMPRESSED_LEN];
         oracle_vk.open_key.powers_of_h[1]
             .serialize_compressed(&mut srs_g2_compressed[..])
             .unwrap();
@@ -430,7 +481,7 @@ mod tests {
         .unwrap();
 
         // ---- Our port ----
-        let mut srs_g2_compressed = [0u8; G2_LEN / 2];
+        let mut srs_g2_compressed = [0u8; G2_COMPRESSED_LEN];
         oracle_vk
             .open_key
             .powers_of_h[1]

--- a/src/circuit/plonk/vk_format.rs
+++ b/src/circuit/plonk/vk_format.rs
@@ -85,6 +85,14 @@ pub const G1_LEN: usize = 96;
 /// Length of an arkworks-uncompressed BLS12-381 G2Affine point.
 pub const G2_LEN: usize = 192;
 
+/// Length of an arkworks-compressed BLS12-381 G2Affine point — used by
+/// the transcript when appending the SRS G2 element. Half the
+/// uncompressed size (only x, with sign + infinity flags packed in
+/// the high bits), but spelled out as its own constant so readers
+/// don't have to know that `G2_LEN / 2` happens to equal the
+/// compressed size.
+pub const G2_COMPRESSED_LEN: usize = G2_LEN / 2;
+
 /// Length of an arkworks-canonical-serialised Fr element.
 pub const FR_LEN: usize = 32;
 


### PR DESCRIPTION
## Summary

Adds `src/circuit/plonk/transcript.rs` — the Soroban-portable port of jf-plonk's `SolidityTranscript`, the Fiat-Shamir state machine used to derive challenges (β, γ, α, ζ, v, u) during verification. Byte-exact with jf-plonk; without that agreement, the contract verifier rejects valid proofs.

The `Vec<u8>` accumulator and `sha3::Keccak256` swap cleanly for Soroban's `Bytes` and `env.crypto().keccak256()` host primitive in the contract port. The state machine is identical.

## API

```rust
SolidityTranscript::new()
.append_message(&[u8])
.append_g1_commitment_be(x_be: &[u8; 48], y_be: &[u8; 48])
.append_field_elem_be(&[u8; 32])
.squeeze() -> [u8; 32]
.append_vk_and_public_inputs(&ParsedVerifyingKey, &srs_g2_compressed, &public_inputs_be)
```

Plus byte-format converters from arkworks-uncompressed bytes to Solidity-BE:
- `arkworks_fr_le_to_be`
- `arkworks_g1_uncompressed_to_be_xy`

## Two arkworks 0.5 BLS12-381 quirks (documented in the code)

1. **Asymmetric endianness.** Fr (scalar field) is LE, Fp (base field, G1/G2 coords) is BE — arkworks-bls12-381 0.5 ships a custom `serialize_fq` matching IETF / EIP-2537 canonical encoding instead of the generic LE path. So Fr needs reversal but Fp doesn't.
2. **Flags in `bytes[0]`, not `bytes[48]`.** The custom serialiser packs compression / infinity / sort flags in the top 3 bits of the first buffer byte (high byte of x in BE), not in y's high byte like the generic SWAffine path. Mask `bytes[0] &= 0x1F` recovers the canonical x.

Both took a bit of arkworks source-spelunking; both are documented inline so the next reader doesn't trip.

## Tests (5)

- `squeeze_empty_matches_keccak_of_zeros` — state init sanity.
- `g1_le_to_be_matches_arkworks_xy` — converter vs `xy() + into_bigint().to_bytes_be()`.
- `fr_le_to_be_matches_arkworks` — Fr converter vs `into_bigint().to_bytes_be()`.
- `append_vk_step_by_step_matches_manual_byte_stream` — diagnostic: byte-by-byte match against a manually-recreated jf-plonk byte stream with first-divergence-offset reporting.
- `transcript_matches_jf_plonk_oracle` — load-bearing: jf-plonk's `SolidityTranscript` and our port walked through `append_vk_and_pub_input` + N wire-commitment appends; every squeezed challenge must match (reduced mod r).

46 / 46 plonk tests pass (was 41 + 5 new). Default-features (groth16) build unchanged.

`sha3 = "0.10"` added as optional dep gated on the existing `plonk` feature; the Soroban contract port replaces it with `env.crypto().keccak256()` and never pulls in `sha3`.

## Test plan

- [x] `cargo test --features plonk --lib --release plonk` — 46 / 46 pass.
- [x] Byte-exact transcript match vs jf-plonk over real baked VK + canonical proof at depth=5.
- [x] Default-features build still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)