### PR TITLE
Phase C: Soroban top-level verifier + pairing check

### DIFF
--- a/contracts/plonk-verifier/src/byte_helpers.rs
+++ b/contracts/plonk-verifier/src/byte_helpers.rs
@@ -1,0 +1,85 @@
+//! Shared byte ↔ Fr / G1 / G2 conversion helpers.
+//!
+//! Multiple modules need the same handful of Soroban-`Fr` /
+//! Soroban-`G1Affine` / Soroban-`G2Affine` constructors from byte
+//! arrays, plus a fixed-size `decode_fr_array`. Centralising them
+//! here:
+//!
+//! - Avoids the byte-for-byte duplication previously copy-pasted
+//!   into `verifier_aggregate.rs`, `verifier_aggregate_evals.rs`,
+//!   and `verifier.rs`.
+//! - Means a future Soroban SDK change (e.g. an Fr-encoding tweak,
+//!   though unlikely) only needs to touch one place.
+//!
+//! `pub(crate)` because the verifier crate's public surface should
+//! remain the verifier modules themselves; downstream contracts use
+//! `verifier::verify` and don't need to know about Fr-byte
+//! conversions.
+
+use soroban_sdk::crypto::bls12_381::{Fr, G1Affine, G2Affine};
+use soroban_sdk::{BytesN, Env};
+
+use crate::proof_format::{FR_LEN, G1_LEN};
+use crate::vk_format::G2_LEN;
+
+/// Convert a 32-byte arkworks-LE Fr representation into a Soroban
+/// `Fr`. Soroban's `Fr::from_bytes` consumes BE, so we reverse first.
+pub(crate) fn fr_from_le_bytes(env: &Env, le: &[u8; FR_LEN]) -> Fr {
+    let mut be = [0u8; FR_LEN];
+    for (o, &b) in be.iter_mut().zip(le.iter().rev()) {
+        *o = b;
+    }
+    Fr::from_bytes(BytesN::from_array(env, &be))
+}
+
+/// Build the canonical zero `Fr`.
+pub(crate) fn fr_zero(env: &Env) -> Fr {
+    Fr::from_bytes(BytesN::from_array(env, &[0u8; FR_LEN]))
+}
+
+/// Build the canonical one `Fr` (BE: high bytes zero, low byte = 1).
+pub(crate) fn fr_one(env: &Env) -> Fr {
+    let mut bytes = [0u8; FR_LEN];
+    bytes[FR_LEN - 1] = 0x01;
+    Fr::from_bytes(BytesN::from_array(env, &bytes))
+}
+
+/// Parse a 96-byte arkworks-uncompressed G1 into a Soroban `G1Affine`.
+///
+/// **Not validation.** Soroban's `from_bytes` accepts any 96-byte
+/// blob; on-curve / subgroup checks happen later when the bases are
+/// fed into `g1_msm` / `pairing_check` host primitives. Off-curve
+/// inputs trap inside the host call (consensus-safe — trap rejects
+/// the proof — but the trap surfaces as a contract failure rather
+/// than a `Result::Err`).
+pub(crate) fn g1_from_bytes(env: &Env, bytes: &[u8; G1_LEN]) -> G1Affine {
+    G1Affine::from_bytes(BytesN::from_array(env, bytes))
+}
+
+/// Parse a 192-byte arkworks-uncompressed G2 into a Soroban
+/// `G2Affine`. Same not-validation semantics as
+/// [`g1_from_bytes`].
+pub(crate) fn g2_from_bytes(env: &Env, bytes: &[u8; G2_LEN]) -> G2Affine {
+    G2Affine::from_bytes(BytesN::from_array(env, bytes))
+}
+
+/// Decode a fixed-size array of arkworks-LE Fr byte slots into a
+/// `[Fr; N]`. Used in `verifier_aggregate` and `verifier` where the
+/// proof's `wires_evals` / `wire_sigma_evals` come back as
+/// `[[u8; FR_LEN]; N]`.
+pub(crate) fn decode_fr_array<const N: usize>(
+    env: &Env,
+    arrays: &[[u8; FR_LEN]; N],
+) -> [Fr; N] {
+    core::array::from_fn(|i| fr_from_le_bytes(env, &arrays[i]))
+}
+
+/// Decode a fixed-size array of arkworks-uncompressed G1 byte slots
+/// into a `[G1Affine; N]`. Same not-validation semantics as
+/// [`g1_from_bytes`].
+pub(crate) fn decode_g1_array<const N: usize>(
+    env: &Env,
+    arrays: &[[u8; G1_LEN]; N],
+) -> [G1Affine; N] {
+    core::array::from_fn(|i| g1_from_bytes(env, &arrays[i]))
+}

--- a/contracts/plonk-verifier/src/lib.rs
+++ b/contracts/plonk-verifier/src/lib.rs
@@ -20,13 +20,17 @@
 //! `verifier::verify(env, vk_bytes, proof_bytes, public_inputs)` from
 //! its `verify_membership` / `verify_update` entrypoints.
 //!
-//! ## No `std`, no `alloc`
+//! ## No `std`
 //!
-//! Soroban contracts run in WASM with no allocator beyond what the
-//! SDK provides via `Env`. This crate is `#![no_std]` and avoids
-//! `alloc::vec::Vec` / `alloc::string::String` — the parsers operate
-//! on byte slices and write to fixed-size arrays, exactly like the
-//! Rust reference.
+//! Soroban contracts run in WASM. This crate is `#![no_std]`. The
+//! parsers and arithmetic helpers operate on byte slices + fixed-size
+//! arrays, matching the off-chain Rust reference shape-for-shape.
+//!
+//! `alloc` is enabled via `extern crate alloc` so a small interim
+//! `alloc::vec::Vec<Fr>` can shuttle public inputs into
+//! `verifier_polys::evaluate_pi_poly` (which takes `&[Fr]`).
+//! soroban-sdk pulls `alloc` in transitively for its own
+//! infrastructure, so the contract build size is unaffected.
 //!
 //! ## Byte layouts
 //!
@@ -35,23 +39,22 @@
 //! crate. If a layout constant ever drifts here, the test in
 //! `vk_format::tests::pinned_offsets_match_layout_table` (or its
 //! proof-side analogue) will fail before any verifier code is exercised.
-//!
-//! For now this crate ships only the byte-format parsers (Phase C
-//! foundation). Subsequent PRs add the transcript module, challenge
-//! derivation, polynomial helpers, and ultimately the top-level
-//! `verifier::verify` entrypoint that contracts call.
 
 #![no_std]
 
+extern crate alloc;
+
 pub mod proof_format;
 pub mod transcript;
-pub mod verifier_challenges;
 pub mod verifier;
 pub mod verifier_aggregate;
 pub mod verifier_aggregate_evals;
+pub mod verifier_challenges;
 pub mod verifier_lin_poly;
 pub mod verifier_polys;
 pub mod vk_format;
+
+pub(crate) mod byte_helpers;
 
 #[cfg(test)]
 mod test_fixtures;

--- a/contracts/plonk-verifier/src/lib.rs
+++ b/contracts/plonk-verifier/src/lib.rs
@@ -46,6 +46,7 @@
 pub mod proof_format;
 pub mod transcript;
 pub mod verifier_challenges;
+pub mod verifier;
 pub mod verifier_aggregate;
 pub mod verifier_aggregate_evals;
 pub mod verifier_lin_poly;

--- a/contracts/plonk-verifier/src/verifier.rs
+++ b/contracts/plonk-verifier/src/verifier.rs
@@ -41,7 +41,8 @@
 use soroban_sdk::crypto::bls12_381::{Fr, G1Affine, G2Affine};
 use soroban_sdk::{BytesN, Env, Vec};
 
-use crate::proof_format::{ParsedProof, FR_LEN, G1_LEN, NUM_WIRE_SIGMA_EVALS, NUM_WIRE_TYPES};
+use crate::byte_helpers::{decode_fr_array, fr_from_le_bytes, g1_from_bytes, g2_from_bytes};
+use crate::proof_format::{ParsedProof, FR_LEN, NUM_WIRE_SIGMA_EVALS, NUM_WIRE_TYPES};
 use crate::verifier_aggregate::{aggregate_poly_commitments, ChallengesFr};
 use crate::verifier_aggregate_evals::aggregate_evaluations;
 use crate::verifier_challenges::compute_challenges;
@@ -49,12 +50,24 @@ use crate::verifier_lin_poly::compute_lin_poly_constant_term;
 use crate::verifier_polys::{
     evaluate_pi_poly, evaluate_vanishing_poly, first_and_last_lagrange_coeffs, DomainParams,
 };
-use crate::vk_format::{ParsedVerifyingKey, G2_COMPRESSED_LEN, G2_LEN};
+use crate::vk_format::{ParsedVerifyingKey, G2_COMPRESSED_LEN};
 
 /// Errors `verify` can raise. `PairingMismatch` is the verifier's
 /// "rejected the proof" outcome; the others reflect malformed-input
 /// conditions that should not happen if the contract entry point
 /// has run the upstream byte parsers.
+///
+/// **Note on adversarial inputs**: this enum does *not* cover off-
+/// curve / non-canonical G1 / G2 / Fr bytes. The byte parsers
+/// (`parse_proof_bytes`, `parse_vk_bytes`) only validate structural
+/// shape; cryptographic validation happens deep inside Soroban's
+/// `g1_msm` / `pairing_check` host primitives, which **trap** on
+/// invalid inputs rather than returning errors. A trap inside a
+/// contract entry point is consensus-safe — it rejects the proof
+/// the same way `Err(PairingMismatch)` does — but the caller sees
+/// a contract failure, not a `Result::Err`. The contract surface
+/// should treat both as "verification rejected" and not depend on
+/// distinguishing them.
 #[derive(Debug, PartialEq, Eq)]
 pub enum VerifyError {
     /// Public-input count doesn't match what the VK expects.
@@ -171,6 +184,12 @@ fn final_pairing_check(
     let shifted_opening = g1_from_bytes(env, &proof.shifted_opening_proof);
     let g_1 = g1_from_bytes(env, &vk.open_key_g);
     let h = g2_from_bytes(env, &vk.open_key_h);
+    // `beta_h` here is the KZG SRS element `[τ]_2` — the second G2
+    // generator, classically denoted `[β]_2` in KZG papers (jf-plonk's
+    // VerifyingKey.open_key.beta_h follows that convention). It is
+    // **not** related to `challenges.beta`, the PLONK Fiat-Shamir β
+    // squeezed earlier in the transcript. Two distinct β's; only the
+    // KZG one shows up in the pairing.
     let beta_h = g2_from_bytes(env, &vk.open_key_beta_h);
 
     let zeta = challenges.zeta.clone();
@@ -202,37 +221,9 @@ fn final_pairing_check(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers (private duplicates of `verifier_aggregate`'s helpers
-// to avoid a public-API surface widening just for cross-module access).
-// ---------------------------------------------------------------------------
-
-fn fr_from_le_bytes(env: &Env, le: &[u8; FR_LEN]) -> Fr {
-    let mut be = [0u8; FR_LEN];
-    for (o, &b) in be.iter_mut().zip(le.iter().rev()) {
-        *o = b;
-    }
-    Fr::from_bytes(BytesN::from_array(env, &be))
-}
-
-fn g1_from_bytes(env: &Env, bytes: &[u8; G1_LEN]) -> G1Affine {
-    G1Affine::from_bytes(BytesN::from_array(env, bytes))
-}
-
-fn g2_from_bytes(env: &Env, bytes: &[u8; G2_LEN]) -> G2Affine {
-    G2Affine::from_bytes(BytesN::from_array(env, bytes))
-}
-
-fn decode_fr_array<const N: usize>(env: &Env, arrays: &[[u8; FR_LEN]; N]) -> [Fr; N] {
-    core::array::from_fn(|i| fr_from_le_bytes(env, &arrays[i]))
-}
-
-// `verify` builds an interim `alloc::vec::Vec<Fr>` to hand to
-// `evaluate_pi_poly` (which takes `&[Fr]`). `alloc` is enabled
-// transitively by soroban-sdk for unit tests; production contract
-// builds also have `alloc` available since the SDK pulls in
-// `alloc` for its own `Vec` infrastructure.
-extern crate alloc;
+// Internal Fr/G1/G2 byte conversion helpers live in
+// `crate::byte_helpers`. `extern crate alloc;` is at the crate root
+// (`lib.rs`).
 
 #[cfg(test)]
 mod tests {

--- a/contracts/plonk-verifier/src/verifier.rs
+++ b/contracts/plonk-verifier/src/verifier.rs
@@ -1,0 +1,335 @@
+//! Top-level Soroban PLONK verifier — closes the Phase C.2 prereq loop.
+//!
+//! Wires together every module in this crate built across PRs
+//! #185–#191 and runs the final pairing equation via
+//! `env.crypto().bls12_381().pairing_check`. Mirrors the off-chain
+//! reference at `sep-xxxx-circuits::circuit::plonk::verifier`
+//! (PR #184).
+//!
+//! For our no-Plookup, single-instance case the verification
+//! equation reduces to:
+//!
+//! ```text
+//!   A = opening_proof + u · shifted_opening_proof
+//!   B = [D]_1
+//!     + ζ · opening_proof
+//!     + u · ζ·g · shifted_opening_proof
+//!     − [E]_1 · g_1                       (g_1 = vk.open_key.g)
+//!
+//!   accept iff e(A, [τ]_2) = e(B, [1]_2)
+//! ```
+//!
+//! Implemented as the multi-pairing check
+//! `e(A, [τ]_2) · e(−B, [1]_2) = 1`, fed through
+//! `env.crypto().bls12_381().pairing_check(&[(A, βh), (−B, h)])` —
+//! one host call.
+//!
+//! `[D]_1` comes from PR #190's `aggregate_poly_commitments`
+//! (MSM-folded here); `[E]_1` from PR #191's `aggregate_evaluations`.
+//!
+//! ## `srs_g2_compressed` contract
+//!
+//! Soroban's BLS12-381 host primitives don't expose a "compress this
+//! G2 point" operation, so we can't derive the transcript's
+//! `srs_g2_compressed` (96 B BE) on-chain from the parsed VK's
+//! `open_key_powers_of_h[1]` (192 B uncompressed). The contract
+//! embeds **both** forms — the uncompressed VK via
+//! `include_bytes!("…vk.bin")` and the pre-computed compressed G2
+//! via `include_bytes!("…srs-g2.bin")` — both produced together by
+//! the bake-vk pipeline.
+
+use soroban_sdk::crypto::bls12_381::{Fr, G1Affine, G2Affine};
+use soroban_sdk::{BytesN, Env, Vec};
+
+use crate::proof_format::{ParsedProof, FR_LEN, G1_LEN, NUM_WIRE_SIGMA_EVALS, NUM_WIRE_TYPES};
+use crate::verifier_aggregate::{aggregate_poly_commitments, ChallengesFr};
+use crate::verifier_aggregate_evals::aggregate_evaluations;
+use crate::verifier_challenges::compute_challenges;
+use crate::verifier_lin_poly::compute_lin_poly_constant_term;
+use crate::verifier_polys::{
+    evaluate_pi_poly, evaluate_vanishing_poly, first_and_last_lagrange_coeffs, DomainParams,
+};
+use crate::vk_format::{ParsedVerifyingKey, G2_COMPRESSED_LEN, G2_LEN};
+
+/// Errors `verify` can raise. `PairingMismatch` is the verifier's
+/// "rejected the proof" outcome; the others reflect malformed-input
+/// conditions that should not happen if the contract entry point
+/// has run the upstream byte parsers.
+#[derive(Debug, PartialEq, Eq)]
+pub enum VerifyError {
+    /// Public-input count doesn't match what the VK expects.
+    BadPublicInputCount { expected: u64, actual: u32 },
+    /// Pairing equation failed — proof rejected.
+    PairingMismatch,
+}
+
+/// Verify a TurboPlonk proof for a circuit using the no-Plookup,
+/// single-instance flow. Returns `Ok(())` to accept,
+/// `Err(_)` to reject.
+///
+/// Inputs are byte-form via the parsed-VK / parsed-proof structures
+/// and a pre-compressed SRS G2 element. The contract entry point
+/// embeds the VK + compressed G2 via `include_bytes!` and parses on
+/// the proof bytes the user submitted.
+pub fn verify(
+    env: &Env,
+    vk: &ParsedVerifyingKey,
+    srs_g2_compressed: &[u8; G2_COMPRESSED_LEN],
+    proof: &ParsedProof,
+    public_inputs_be: &[[u8; FR_LEN]],
+) -> Result<(), VerifyError> {
+    // --- 0. Public-input count must match the VK header. ----------
+    if public_inputs_be.len() as u64 != vk.num_inputs {
+        return Err(VerifyError::BadPublicInputCount {
+            expected: vk.num_inputs,
+            actual: public_inputs_be.len() as u32,
+        });
+    }
+
+    // --- 1. Drive the transcript and reduce the 6 challenges. -----
+    let raw = compute_challenges(env, vk, srs_g2_compressed, public_inputs_be, proof);
+    let challenges = ChallengesFr {
+        beta: Fr::from_bytes(BytesN::from_array(env, &raw.beta)),
+        gamma: Fr::from_bytes(BytesN::from_array(env, &raw.gamma)),
+        alpha: Fr::from_bytes(BytesN::from_array(env, &raw.alpha)),
+        zeta: Fr::from_bytes(BytesN::from_array(env, &raw.zeta)),
+        v: Fr::from_bytes(BytesN::from_array(env, &raw.v)),
+        u: Fr::from_bytes(BytesN::from_array(env, &raw.u)),
+    };
+
+    // --- 2. Domain-derived polynomial evaluations at ζ. -----------
+    let params = DomainParams::for_size(env, vk.domain_size);
+    let vanish_eval = evaluate_vanishing_poly(&challenges.zeta, &params);
+    let (lagrange_1_eval, _lagrange_n_eval) =
+        first_and_last_lagrange_coeffs(&challenges.zeta, &vanish_eval, &params);
+
+    // --- 3. Public-input polynomial evaluation. -------------------
+    // Reduce public inputs BE→Fr.
+    let mut public_inputs_fr: alloc::vec::Vec<Fr> =
+        alloc::vec::Vec::with_capacity(public_inputs_be.len());
+    for be in public_inputs_be.iter() {
+        public_inputs_fr.push(Fr::from_bytes(BytesN::from_array(env, be)));
+    }
+    let pi_eval = evaluate_pi_poly(
+        &public_inputs_fr,
+        &challenges.zeta,
+        &vanish_eval,
+        &params,
+    );
+
+    // --- 4. Linearisation-polynomial constant term r_0. -----------
+    let w_evals: [Fr; NUM_WIRE_TYPES] =
+        decode_fr_array(env, &proof.wires_evals);
+    let sigma_evals: [Fr; NUM_WIRE_SIGMA_EVALS] =
+        decode_fr_array(env, &proof.wire_sigma_evals);
+    let perm_next_eval = fr_from_le_bytes(env, &proof.perm_next_eval);
+    let lin_poly_constant = compute_lin_poly_constant_term(
+        challenges.alpha.clone(),
+        challenges.beta.clone(),
+        challenges.gamma.clone(),
+        pi_eval,
+        lagrange_1_eval.clone(),
+        &w_evals,
+        &sigma_evals,
+        perm_next_eval,
+    );
+
+    // --- 5. Aggregate poly commitments → MSM-able [D]_1. ----------
+    let agg = aggregate_poly_commitments(
+        env,
+        &challenges,
+        vanish_eval,
+        lagrange_1_eval,
+        vk,
+        proof,
+    );
+    let d_1 = agg.multi_scalar_multiply(env);
+
+    // --- 6. Aggregate evaluations → scalar [E]_1. -----------------
+    let aggregate_eval = aggregate_evaluations(env, lin_poly_constant, proof, &agg.v_uv_buffer);
+
+    // --- 7. Final pairing check. ----------------------------------
+    final_pairing_check(env, vk, proof, &challenges, &params, d_1, aggregate_eval)
+}
+
+/// Run the final pairing equation
+/// `e(A, [τ]_2) ?= e(B, [1]_2)` in the form
+/// `e(A, [τ]_2) · e(−B, [1]_2) = 1`.
+///
+/// `A = opening_proof + u·shifted_opening_proof`
+/// `B = [D]_1 + ζ·opening_proof + u·ζ·g·shifted_opening_proof − [E]_1·g_1`
+fn final_pairing_check(
+    env: &Env,
+    vk: &ParsedVerifyingKey,
+    proof: &ParsedProof,
+    challenges: &ChallengesFr,
+    params: &DomainParams,
+    d_1: G1Affine,
+    aggregate_eval: Fr,
+) -> Result<(), VerifyError> {
+    let opening = g1_from_bytes(env, &proof.opening_proof);
+    let shifted_opening = g1_from_bytes(env, &proof.shifted_opening_proof);
+    let g_1 = g1_from_bytes(env, &vk.open_key_g);
+    let h = g2_from_bytes(env, &vk.open_key_h);
+    let beta_h = g2_from_bytes(env, &vk.open_key_beta_h);
+
+    let zeta = challenges.zeta.clone();
+    let u = challenges.u.clone();
+    let zeta_g = zeta.clone() * params.group_gen.clone();
+
+    // A = opening + u · shifted_opening
+    let a = opening.clone() + (shifted_opening.clone() * u.clone());
+    // B = [D]_1 + ζ·opening + u·ζ·g·shifted_opening − [E]_1·g_1
+    let zeta_opening = opening * zeta;
+    let uzg_shifted = shifted_opening * (u * zeta_g);
+    let e_g_1 = g_1 * aggregate_eval;
+    // Subtract via add-with-negate (Soroban G1 has Neg but no Sub).
+    let b = d_1 + zeta_opening + uzg_shifted + (-e_g_1);
+
+    // pairing_check([(A, βh), (−B, h)]) returns true iff product is 1.
+    let mut g1_vec: Vec<G1Affine> = Vec::new(env);
+    g1_vec.push_back(a);
+    g1_vec.push_back(-b);
+    let mut g2_vec: Vec<G2Affine> = Vec::new(env);
+    g2_vec.push_back(beta_h);
+    g2_vec.push_back(h);
+
+    let ok = env.crypto().bls12_381().pairing_check(g1_vec, g2_vec);
+    if ok {
+        Ok(())
+    } else {
+        Err(VerifyError::PairingMismatch)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (private duplicates of `verifier_aggregate`'s helpers
+// to avoid a public-API surface widening just for cross-module access).
+// ---------------------------------------------------------------------------
+
+fn fr_from_le_bytes(env: &Env, le: &[u8; FR_LEN]) -> Fr {
+    let mut be = [0u8; FR_LEN];
+    for (o, &b) in be.iter_mut().zip(le.iter().rev()) {
+        *o = b;
+    }
+    Fr::from_bytes(BytesN::from_array(env, &be))
+}
+
+fn g1_from_bytes(env: &Env, bytes: &[u8; G1_LEN]) -> G1Affine {
+    G1Affine::from_bytes(BytesN::from_array(env, bytes))
+}
+
+fn g2_from_bytes(env: &Env, bytes: &[u8; G2_LEN]) -> G2Affine {
+    G2Affine::from_bytes(BytesN::from_array(env, bytes))
+}
+
+fn decode_fr_array<const N: usize>(env: &Env, arrays: &[[u8; FR_LEN]; N]) -> [Fr; N] {
+    core::array::from_fn(|i| fr_from_le_bytes(env, &arrays[i]))
+}
+
+// `verify` builds an interim `alloc::vec::Vec<Fr>` to hand to
+// `evaluate_pi_poly` (which takes `&[Fr]`). `alloc` is enabled
+// transitively by soroban-sdk for unit tests; production contract
+// builds also have `alloc` available since the SDK pulls in
+// `alloc` for its own `Vec` infrastructure.
+extern crate alloc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_format::parse_proof_bytes;
+    use crate::test_fixtures::{build_synthetic_proof_bytes, build_synthetic_vk_bytes};
+    use crate::vk_format::parse_vk_bytes;
+
+    fn synthetic_srs_g2_compressed() -> [u8; G2_COMPRESSED_LEN] {
+        let mut a = [0u8; G2_COMPRESSED_LEN];
+        a[0] = 0xDE;
+        a[1] = 0xAD;
+        a
+    }
+
+    fn synthetic_public_inputs() -> [[u8; FR_LEN]; 2] {
+        let mut p = [[0u8; FR_LEN]; 2];
+        p[0][0] = 0x70;
+        p[1][0] = 0x71;
+        p
+    }
+
+    /// Wrong public-input count short-circuits with
+    /// `BadPublicInputCount` before any crypto work. Pure
+    /// shape-validation; doesn't need on-curve G1 bytes.
+    #[test]
+    fn rejects_wrong_public_input_count() {
+        let env = Env::default();
+        let vk_bytes = build_synthetic_vk_bytes(8192, 2);
+        let proof_bytes = build_synthetic_proof_bytes();
+        let parsed_vk = parse_vk_bytes(&vk_bytes).expect("parse vk");
+        let parsed_proof = parse_proof_bytes(&proof_bytes).expect("parse proof");
+        let srs_g2 = synthetic_srs_g2_compressed();
+
+        // VK declares num_inputs=2; pass only 1.
+        let too_few: [[u8; FR_LEN]; 1] = [[0x70; FR_LEN]];
+        let result = verify(&env, &parsed_vk, &srs_g2, &parsed_proof, &too_few);
+        assert_eq!(
+            result,
+            Err(VerifyError::BadPublicInputCount {
+                expected: 2,
+                actual: 1,
+            }),
+        );
+
+        // Three is also wrong.
+        let too_many: [[u8; FR_LEN]; 3] = [[0u8; FR_LEN]; 3];
+        let result =
+            verify(&env, &parsed_vk, &srs_g2, &parsed_proof, &too_many);
+        assert_eq!(
+            result,
+            Err(VerifyError::BadPublicInputCount {
+                expected: 2,
+                actual: 3,
+            }),
+        );
+
+        // The correct count (2) doesn't short-circuit here — it
+        // proceeds into the crypto path which fails on synthetic
+        // (off-curve) G1 bytes. We don't assert success; the
+        // `accepts_canonical_proof_for_all_tiers` test in the
+        // fixture-bundling follow-up exercises the accept path.
+    }
+
+    /// **Load-bearing — but `#[ignore]`'d in this PR.** Builds a real
+    /// proof + VK off-chain, parses them, calls `verify(...)`, and
+    /// asserts `Ok(())`. This is the test the entire C.2 prereq
+    /// stack has been building toward — it ties every module
+    /// together end-to-end on real cryptographic inputs.
+    ///
+    /// Currently `#[ignore]`'d because the `plonk-verifier` crate
+    /// is `no_std` + `soroban-sdk` only; pulling in the prover-side
+    /// `sep-xxxx-circuits` (which has arkworks) as a test dep blows
+    /// up the build. The test will land in the fixture-bundling
+    /// follow-up that introduces a `tests/fixtures/*.bin` directory
+    /// generated by the prover and consumed via `include_bytes!`.
+    ///
+    /// Until then, the off-chain reference's
+    /// `accepts_canonical_proof_for_all_tiers` (PR #184) exercises
+    /// the same algorithm end-to-end against real proofs; this
+    /// crate's modules are byte-equivalent ports of those, and
+    /// every component-level test pins the byte layout.
+    #[test]
+    #[ignore = "needs real on-curve G1 / G2 bytes from a baked VK + canonical proof; \
+                fixture-bundling follow-up"]
+    fn accepts_canonical_proof() {
+        // Placeholder. The real test will look like:
+        //
+        //   let env = Env::default();
+        //   let vk_bytes: &[u8; 3002] = include_bytes!("fixtures/vk-d11.vk.bin");
+        //   let srs_g2: &[u8; 96] = include_bytes!("fixtures/srs-g2.bin");
+        //   let proof_bytes: &[u8; 1601] = include_bytes!("fixtures/proof-d11.proof.bin");
+        //   let public_inputs: [[u8; 32]; 2] = include!("fixtures/pi-d11.in");
+        //
+        //   let parsed_vk = parse_vk_bytes(vk_bytes).unwrap();
+        //   let parsed_proof = parse_proof_bytes(proof_bytes).unwrap();
+        //   let result = verify(&env, &parsed_vk, srs_g2, &parsed_proof, &public_inputs);
+        //   assert_eq!(result, Ok(()));
+    }
+}

--- a/contracts/plonk-verifier/src/verifier_aggregate.rs
+++ b/contracts/plonk-verifier/src/verifier_aggregate.rs
@@ -29,8 +29,11 @@
 //! `env.crypto().bls12_381().g1_msm(...)`.
 
 use soroban_sdk::crypto::bls12_381::{Fr, G1Affine};
-use soroban_sdk::{BytesN, Env, Vec};
+use soroban_sdk::{Env, Vec};
 
+use crate::byte_helpers::{
+    decode_fr_array, decode_g1_array, fr_from_le_bytes, fr_one, fr_zero, g1_from_bytes,
+};
 use crate::proof_format::{ParsedProof, NUM_WIRE_SIGMA_EVALS, NUM_WIRE_TYPES};
 use crate::vk_format::{ParsedVerifyingKey, NUM_SELECTOR_COMMS, NUM_SIGMA_COMMS};
 
@@ -236,50 +239,8 @@ pub fn aggregate_poly_commitments(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-fn fr_one(env: &Env) -> Fr {
-    let mut bytes = [0u8; 32];
-    bytes[31] = 0x01;
-    Fr::from_bytes(BytesN::from_array(env, &bytes))
-}
-
-fn fr_zero(env: &Env) -> Fr {
-    Fr::from_bytes(BytesN::from_array(env, &[0u8; 32]))
-}
-
-/// Convert arkworks-LE Fr bytes into a Soroban `Fr`. The transcript
-/// module already does this for its own purposes; this helper
-/// duplicates the small inline logic so `verifier_aggregate` doesn't
-/// drag a `transcript` dependency.
-fn fr_from_le_bytes(env: &Env, le: &[u8; 32]) -> Fr {
-    let mut be = [0u8; 32];
-    for (o, &b) in be.iter_mut().zip(le.iter().rev()) {
-        *o = b;
-    }
-    Fr::from_bytes(BytesN::from_array(env, &be))
-}
-
-/// Parse a 96-byte arkworks-uncompressed G1 into a Soroban `G1Affine`.
-/// Soroban's `from_bytes` doesn't validate; on-curve / subgroup
-/// checks happen later when the bases are fed into `g1_msm` /
-/// `pairing_check`.
-fn g1_from_bytes(env: &Env, bytes: &[u8; 96]) -> G1Affine {
-    G1Affine::from_bytes(BytesN::from_array(env, bytes))
-}
-
-fn decode_fr_array<const N: usize>(env: &Env, arrays: &[[u8; 32]; N]) -> [Fr; N] {
-    core::array::from_fn(|i| fr_from_le_bytes(env, &arrays[i]))
-}
-
-fn decode_g1_array<const N: usize>(
-    env: &Env,
-    arrays: &[[u8; 96]; N],
-) -> [G1Affine; N] {
-    core::array::from_fn(|i| g1_from_bytes(env, &arrays[i]))
-}
+// Internal Fr/G1 byte conversion helpers live in `crate::byte_helpers`
+// to avoid the duplication this module previously carried.
 
 #[cfg(test)]
 mod tests {
@@ -287,7 +248,7 @@ mod tests {
     use crate::proof_format::parse_proof_bytes;
     use crate::test_fixtures::{build_synthetic_proof_bytes, build_synthetic_vk_bytes};
     use crate::vk_format::parse_vk_bytes;
-    use soroban_sdk::Env;
+    use soroban_sdk::{BytesN, Env};
 
     /// Helper: build a deterministic Fr from a u64 (BE-encoded).
     fn fr(env: &Env, value: u64) -> Fr {
@@ -307,7 +268,7 @@ mod tests {
         }
     }
 
-    fn synthetic_fixture(env: &Env) -> (ParsedVerifyingKey, ParsedProof) {
+    fn synthetic_fixture(_env: &Env) -> (ParsedVerifyingKey, ParsedProof) {
         let vk_bytes = build_synthetic_vk_bytes(8192, 2);
         let proof_bytes = build_synthetic_proof_bytes();
         let parsed_vk = parse_vk_bytes(&vk_bytes).expect("parse vk");

--- a/contracts/plonk-verifier/src/verifier_aggregate_evals.rs
+++ b/contracts/plonk-verifier/src/verifier_aggregate_evals.rs
@@ -19,8 +19,9 @@
 //! [`super::verifier_lin_poly::compute_lin_poly_constant_term`].
 
 use soroban_sdk::crypto::bls12_381::Fr;
-use soroban_sdk::{BytesN, Env, Vec};
+use soroban_sdk::{Env, Vec};
 
+use crate::byte_helpers::{fr_from_le_bytes, fr_zero};
 use crate::proof_format::{ParsedProof, NUM_WIRE_SIGMA_EVALS, NUM_WIRE_TYPES};
 
 /// Total v_uv_buffer length: 5 wires + 4 sigmas + 1 perm_next.
@@ -82,25 +83,12 @@ pub fn aggregate_evaluations(
     result + last_coeff * perm_next_eval
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-fn fr_zero(env: &Env) -> Fr {
-    Fr::from_bytes(BytesN::from_array(env, &[0u8; 32]))
-}
-
-fn fr_from_le_bytes(env: &Env, le: &[u8; 32]) -> Fr {
-    let mut be = [0u8; 32];
-    for (o, &b) in be.iter_mut().zip(le.iter().rev()) {
-        *o = b;
-    }
-    Fr::from_bytes(BytesN::from_array(env, &be))
-}
+// Fr byte conversion helpers live in `crate::byte_helpers`.
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use soroban_sdk::BytesN;
 
     /// Helper: build an Fr from a u64 (BE-encoded into a 32-byte
     /// slot's tail).


### PR DESCRIPTION
## Summary

🎉 **The Soroban-portable PLONK verifier crate is functionally complete.** Every off-chain reference module from PRs #174 / #177–184 has a byte-equivalent on-chain port; this PR ties them into a single `verify(...)` entry point that runs the final pairing equation via `env.crypto().bls12_381().pairing_check`.

For our no-Plookup, single-instance case:

```
A = opening_proof + u · shifted_opening_proof
B = [D]_1
  + ζ · opening_proof
  + u · ζ·g · shifted_opening_proof
  − [E]_1 · g_1                       (g_1 = vk.open_key.g)

accept iff e(A, [τ]_2) = e(B, [1]_2)
```

Implemented as the multi-pairing check `e(A, [τ]_2) · e(−B, [1]_2) = 1` — a single `pairing_check([(A, βh), (−B, h)])` host call.

## API

```rust
pub fn verify(
    env: &Env,
    vk: &ParsedVerifyingKey,
    srs_g2_compressed: &[u8; 96],
    proof: &ParsedProof,
    public_inputs_be: &[[u8; 32]],
) -> Result<(), VerifyError>;

pub enum VerifyError {
    BadPublicInputCount { expected: u64, actual: u32 },
    PairingMismatch,
}
```

`srs_g2_compressed` is passed separately because Soroban's host doesn't expose G2 compression; the bake-vk pipeline ships both forms.

## Tests (1 + 1 ignored)

- `rejects_wrong_public_input_count` — pure shape validation, passes 1 and 3 inputs against a VK declaring 2, asserts both reject with `BadPublicInputCount` before any crypto.
- **`accepts_canonical_proof`** — `#[ignore]`'d. The load-bearing end-to-end test, sketched in the docstring. Currently can't land because the verifier crate is `no_std`+`soroban-sdk`-only; pulling the prover-side as a test dep blows up the build. Lands with the fixture-bundling follow-up that adds `tests/fixtures/*.bin` (generated by the prover, consumed via `include_bytes!`).

  Until then, the off-chain reference's `accepts_canonical_proof_for_all_tiers` (PR #184) exercises the same algorithm end-to-end; this crate's modules are byte-equivalent ports.

**58 / 58** plonk-verifier tests pass + 2 ignored. Default-features build for the prover crate is unaffected.

## End of C.2 verifier-crate prereqs

| Component                          | PR (off-chain) | PR (Soroban)   |
|------------------------------------|----------------|----------------|
| proof byte parser                  | #174           | #185           |
| VK byte parser                     | #177           | #185           |
| transcript module                  | #178           | #186           |
| challenge derivation               | #179           | #187           |
| polynomial helpers                 | #180           | #188           |
| lin-poly constant                  | #181           | #189           |
| aggregate_poly_commitments         | #182           | #190           |
| aggregate_evaluations              | #183           | #191           |
| **top-level verify + pairing**     | **#184**       | **this PR**    |

## What's next

1. **Per-contract Phase C.2.{a..e} rewrites**: each Soroban contract (sep-anarchy, sep-democracy, sep-oligarchy, sep-oneonone, sep-tyranny) imports this crate, embeds its baked VK + compressed-SRS-G2 via `include_bytes!`, swaps the verify entrypoint to call `plonk_verifier::verifier::verify(...)`, and drops the legacy `update_vk` admin path + per-tier VK constructor args.
2. **Fixture-bundling follow-up**: adds `tests/fixtures/` to the verifier crate (real on-curve G1/G2 bytes from a baked VK + canonical proof) and lights up the currently-`#[ignore]`'d `accepts_canonical_proof` and `msm_is_deterministic` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)