### PR TITLE
Phase C.4: oligarchy K-of-N quorum + count-delta + admin-tree membership

### DIFF
--- a/src/circuit/plonk/oligarchy.rs
+++ b/src/circuit/plonk/oligarchy.rs
@@ -1,29 +1,50 @@
-//! Oligarchy `Create` and `Update` circuits — simplified initial port.
+//! Oligarchy `Create` and `Update` circuits.
 //!
-//! ## Status
+//! ## Create — `synthesize_oligarchy_create`
 //!
-//! This is a **simplified initial port** of the Oligarchy verify
-//! circuits. The original Groth16 reference (not in this repo —
-//! pinned via VK bytes only) enforced:
+//! Verbose binding per design §4.8: c binds member_root, admin_root,
+//! salt_initial, occupancy_commitment, and epoch=0 in a single
+//! Poseidon chain.
 //!
-//!   * Member-root + admin-root binding to the on-chain commitment
-//!     (verbose anti-mismatch binding at create).
-//!   * K-of-N admin quorum on update.
-//!   * Single-leaf delta on the member root.
+//! ## Update — two circuits
 //!
-//! The PLONK ports below preserve the **public-input shape and
-//! transcript binding** of the originals, but in-circuit they reduce
-//! to a "witness produces this commitment" relation:
+//! - `synthesize_oligarchy_update_quorum` (this PR, issue #202) —
+//!   enforces K-of-N admin quorum + count delta + admin-tree
+//!   membership, with the commitment chain reconciled to match
+//!   create's `Poseidon(occ, admin_root)` mix.
+//! - `synthesize_oligarchy_update` (kept verbatim from PR #200's
+//!   simplified port) — Poseidon-only commitment chain that does
+//!   **not** include `admin_root`, so it's not lineage-compatible
+//!   with `synthesize_oligarchy_create`. Retained as a migration
+//!   fallback / reference; production VKs should bake the quorum
+//!   variant.
 //!
-//!   create: c = Poseidon(Poseidon(Poseidon(member_root, 0), salt),
-//!                        Poseidon(occupancy_commitment, admin_root))
-//!   update: c_old / c_new derivations as per democracy update,
-//!          bound to occupancy_commitment_{old,new} and threshold.
+//! ## Quorum + delta semantics (issue #202)
 //!
-//! Documented loudly so a follow-up can land the full quorum + admin
-//! semantics without reshaping the contract surface.
+//! `synthesize_oligarchy_update_quorum` enforces:
 //!
-//! ## Public inputs
+//!   1. **K-of-N admin quorum** — `OLIGARCHY_K_MAX = 2` admin signer
+//!      slots; each `(sk, merkle_path, leaf_idx, active)` against
+//!      `admin_root_old` at depth 5. Active slots form a strict
+//!      prefix; pairwise-distinct `leaf_idx` for active slots
+//!      (anti-double-count); `K = Σ active` and `K ≥ threshold`
+//!      with both range-checked into 2 bits.
+//!   2. **Member count delta** — `occupancy_commitment_X =
+//!      Poseidon(member_count_X, salt_oc_X)` with
+//!      `|count_new - count_old| ≤ 1`. Same caveats as democracy:
+//!      tree-level delta (the new root differs by exactly one leaf)
+//!      is **not** enforced — `member_root_new` is a free witness
+//!      bounded only by the count.
+//!   3. **Commitment chain reconciliation** — c_old / c_new use the
+//!      same chain as create:
+//!      `c_X = Poseidon(Poseidon(Poseidon(member_root_X, epoch_X),
+//!                               salt_X),
+//!                      Poseidon(occ_X, admin_root_X))`.
+//!      The simplified-port update was lineage-incompatible with
+//!      create (omitted `admin_root` from the third hash), so this
+//!      is a **soundness fix** in addition to the quorum upgrade.
+//!
+//! ## Public inputs (unchanged across both update variants)
 //!
 //! **Create** (6, fixed order):
 //!   1. `commitment`
@@ -45,9 +66,27 @@
 
 use ark_bls12_381_v05::Fr;
 use ark_ff_v05::PrimeField;
-use jf_relation::{Circuit, CircuitError, PlonkCircuit};
+use jf_relation::{BoolVar, Circuit, CircuitError, PlonkCircuit, Variable};
 
-use super::poseidon::poseidon_hash_two_gadget;
+use super::merkle::compute_merkle_root_gadget;
+use super::poseidon::{poseidon_hash_one_gadget, poseidon_hash_two_gadget};
+
+/// Quorum cap for the oligarchy admin tree. Mirrors democracy's
+/// `K_MAX = 2`: 2 admin signer slots, each producing a Merkle opening
+/// against `admin_root_old`. Raising past 3 requires widening the
+/// slack + threshold 2-bit range gates in lockstep.
+pub const OLIGARCHY_K_MAX: usize = 2;
+
+/// Admin tree depth. Per design §4.6 the admin tier is fixed at Small
+/// across all member tiers: 32 slots, depth 5. Constant rather than
+/// witness-driven so `synthesize_oligarchy_update_quorum`'s circuit
+/// shape is fixed (single-tier VK across all member tiers).
+pub const OLIGARCHY_ADMIN_DEPTH: usize = 5;
+
+const _: () = assert!(
+    OLIGARCHY_K_MAX <= 3,
+    "widen slack + threshold ranges before raising OLIGARCHY_K_MAX past 3"
+);
 
 pub struct OligarchyCreateWitness {
     pub commitment: Fr,
@@ -122,6 +161,247 @@ pub fn synthesize_oligarchy_update(
     let inner_new = poseidon_hash_two_gadget(circuit, member_root_new_var, epoch_new_var)?;
     let mid_new = poseidon_hash_two_gadget(circuit, inner_new, salt_new_var)?;
     let computed_c_new = poseidon_hash_two_gadget(circuit, mid_new, occ_new_var)?;
+    circuit.enforce_equal(computed_c_new, c_new_var)?;
+
+    Ok(())
+}
+
+// ================================================================
+// Quorum + delta + admin-membership update circuit (issue #202).
+// ================================================================
+
+/// One admin signer's witness bundle. Mirrors `DemocracySigner` but
+/// the path opens against the **admin tree** at fixed depth
+/// `OLIGARCHY_ADMIN_DEPTH = 5`.
+#[derive(Clone)]
+pub struct OligarchyAdminSigner {
+    pub secret_key: Fr,
+    pub merkle_path: Vec<Fr>,
+    pub leaf_index: usize,
+    pub active: bool,
+}
+
+/// Witness for the K-of-N quorum + count-delta update circuit.
+pub struct OligarchyUpdateQuorumWitness {
+    // Public inputs (6, fixed order — unchanged from the simplified
+    // port).
+    pub c_old: Fr,
+    pub epoch_old: u64,
+    pub c_new: Fr,
+    pub occupancy_commitment_old: Fr,
+    pub occupancy_commitment_new: Fr,
+    pub admin_threshold_numerator: u64,
+
+    // K-of-N admin signers. Active slots must form a strict prefix.
+    pub admin_signers: [OligarchyAdminSigner; OLIGARCHY_K_MAX],
+
+    // Tree roots — both pairs are private witnesses. `admin_root_old`
+    // is the root the K signers open against; the new admin/member
+    // roots are bound only via the commitment chain.
+    pub member_root_old: Fr,
+    pub member_root_new: Fr,
+    pub admin_root_old: Fr,
+    pub admin_root_new: Fr,
+
+    // Member counts + occupancy salts (occupancy commitment = Poseidon
+    // of these). Matches democracy's pattern — count-only single-leaf
+    // delta, **not** tree-level. Tree-level delta on the member tree
+    // is a future follow-up.
+    pub member_count_old: u64,
+    pub member_count_new: u64,
+    pub salt_oc_old: Fr,
+    pub salt_oc_new: Fr,
+
+    // Commitment-chain salts.
+    pub salt_old: Fr,
+    pub salt_new: Fr,
+}
+
+/// K-of-N admin quorum + count-delta + admin-tree-membership oligarchy
+/// update circuit. Public-input shape and order are byte-identical to
+/// `synthesize_oligarchy_update`, so the Soroban contract surface is
+/// unchanged when production VKs are rebaked against this circuit.
+pub fn synthesize_oligarchy_update_quorum(
+    circuit: &mut PlonkCircuit<Fr>,
+    witness: &OligarchyUpdateQuorumWitness,
+) -> Result<(), CircuitError> {
+    for (i, signer) in witness.admin_signers.iter().enumerate() {
+        if signer.merkle_path.len() != OLIGARCHY_ADMIN_DEPTH {
+            return Err(CircuitError::ParameterError(format!(
+                "admin_signers[{i}].merkle_path length {} != OLIGARCHY_ADMIN_DEPTH {}",
+                signer.merkle_path.len(),
+                OLIGARCHY_ADMIN_DEPTH,
+            )));
+        }
+        if signer.leaf_index >= (1usize << OLIGARCHY_ADMIN_DEPTH) {
+            return Err(CircuitError::ParameterError(format!(
+                "admin_signers[{i}].leaf_index {} out of range",
+                signer.leaf_index,
+            )));
+        }
+    }
+
+    // ---- Public inputs (fixed order, identical to simplified) ----
+    let c_old_var = circuit.create_public_variable(witness.c_old)?;
+    let epoch_old_var = circuit.create_public_variable(Fr::from(witness.epoch_old))?;
+    let c_new_var = circuit.create_public_variable(witness.c_new)?;
+    let occ_old_var = circuit.create_public_variable(witness.occupancy_commitment_old)?;
+    let occ_new_var = circuit.create_public_variable(witness.occupancy_commitment_new)?;
+    let threshold_var =
+        circuit.create_public_variable(Fr::from(witness.admin_threshold_numerator))?;
+
+    // ---- Private witnesses ----
+    let member_root_old_var = circuit.create_variable(witness.member_root_old)?;
+    let member_root_new_var = circuit.create_variable(witness.member_root_new)?;
+    let admin_root_old_var = circuit.create_variable(witness.admin_root_old)?;
+    let admin_root_new_var = circuit.create_variable(witness.admin_root_new)?;
+    let count_old_var = circuit.create_variable(Fr::from(witness.member_count_old))?;
+    let count_new_var = circuit.create_variable(Fr::from(witness.member_count_new))?;
+    let salt_oc_old_var = circuit.create_variable(witness.salt_oc_old)?;
+    let salt_oc_new_var = circuit.create_variable(witness.salt_oc_new)?;
+    let salt_old_var = circuit.create_variable(witness.salt_old)?;
+    let salt_new_var = circuit.create_variable(witness.salt_new)?;
+
+    // ---- 1. K-of-N admin quorum ----
+    let mut active_vars: Vec<BoolVar> = Vec::with_capacity(OLIGARCHY_K_MAX);
+    for signer in witness.admin_signers.iter() {
+        active_vars.push(circuit.create_boolean_variable(signer.active)?);
+    }
+
+    // Prefix constraint: active_i ⇒ active_{i-1} for i ≥ 1.
+    let one_var = circuit.create_constant_variable(Fr::from(1u64))?;
+    for i in 1..OLIGARCHY_K_MAX {
+        let prev_var: Variable = active_vars[i - 1].into();
+        let neg_prev = circuit.sub(one_var, prev_var)?;
+        let cur_var: Variable = active_vars[i].into();
+        let prod = circuit.mul(cur_var, neg_prev)?;
+        circuit.enforce_constant(prod, Fr::from(0u64))?;
+    }
+
+    // Active-conditional admin-tree membership + leaf-index decomp.
+    let mut leaf_idx_field_vars: Vec<Variable> = Vec::with_capacity(OLIGARCHY_K_MAX);
+    for (i, signer) in witness.admin_signers.iter().enumerate() {
+        let sk_var = circuit.create_variable(signer.secret_key)?;
+        let path_vars: Vec<Variable> = signer
+            .merkle_path
+            .iter()
+            .map(|p| circuit.create_variable(*p))
+            .collect::<Result<_, _>>()?;
+        let bit_vars: Vec<BoolVar> = (0..OLIGARCHY_ADMIN_DEPTH)
+            .map(|j| circuit.create_boolean_variable(((signer.leaf_index >> j) & 1) == 1))
+            .collect::<Result<_, _>>()?;
+
+        // leaf_idx_var = Σ_j bit_j · 2^j.
+        let leaf_idx_var = circuit.create_variable(Fr::from(signer.leaf_index as u64))?;
+        let mut acc = circuit.zero();
+        let two = Fr::from(2u64);
+        let mut pow = Fr::from(1u64);
+        for bit in &bit_vars {
+            let bit_v: Variable = (*bit).into();
+            let pow_const = circuit.create_constant_variable(pow)?;
+            let term = circuit.mul(bit_v, pow_const)?;
+            acc = circuit.add(acc, term)?;
+            pow *= two;
+        }
+        circuit.enforce_equal(acc, leaf_idx_var)?;
+        leaf_idx_field_vars.push(leaf_idx_var);
+
+        let leaf_var = poseidon_hash_one_gadget(circuit, sk_var)?;
+        let computed_root =
+            compute_merkle_root_gadget(circuit, leaf_var, &path_vars, &bit_vars)?;
+
+        // active=1 ⇒ computed_root == admin_root_old.
+        let diff = circuit.sub(computed_root, admin_root_old_var)?;
+        let active_var: Variable = active_vars[i].into();
+        let prod = circuit.mul(active_var, diff)?;
+        circuit.enforce_constant(prod, Fr::from(0u64))?;
+    }
+
+    // Anti-double-count: pairwise leaf_idx distinctness across active
+    // slots. Distinctness is on `leaf_idx`, not `Poseidon(sk)` — relies
+    // on admin-tree uniqueness (the off-circuit tree builder
+    // deduplicates secret keys before populating leaves).
+    for i in 1..OLIGARCHY_K_MAX {
+        for j in 0..i {
+            let eq = circuit.is_equal(leaf_idx_field_vars[j], leaf_idx_field_vars[i])?;
+            let prev_a: Variable = active_vars[j].into();
+            let cur_a: Variable = active_vars[i].into();
+            let both_active = circuit.mul(prev_a, cur_a)?;
+            let eq_var: Variable = eq.into();
+            let bad = circuit.mul(both_active, eq_var)?;
+            circuit.enforce_constant(bad, Fr::from(0u64))?;
+        }
+    }
+
+    // K = Σ active_i.
+    let zero_var = circuit.zero();
+    let mut k_var = zero_var;
+    for av in active_vars.iter() {
+        let av_var: Variable = (*av).into();
+        k_var = circuit.add(k_var, av_var)?;
+    }
+
+    // K ≥ threshold encoded as `K = threshold + slack` with both sides
+    // 2-bit-range-checked (covers `[0, 3]`, sufficient for K_MAX = 2).
+    // The threshold range gate closes the underflow path: without it,
+    // an attacker could pick `threshold ≡ -slack (mod p)` and pass
+    // `K = 0`. Mirrors the soundness fix from PR #201's review round 2
+    // for democracy.
+    let two_var = circuit.create_constant_variable(Fr::from(2u64))?;
+
+    let thresh_bit0 =
+        circuit.create_boolean_variable((witness.admin_threshold_numerator & 1) == 1)?;
+    let thresh_bit1 = circuit
+        .create_boolean_variable(((witness.admin_threshold_numerator >> 1) & 1) == 1)?;
+    let thresh_b0_var: Variable = thresh_bit0.into();
+    let thresh_b1_var: Variable = thresh_bit1.into();
+    let thresh_b1_scaled = circuit.mul(thresh_b1_var, two_var)?;
+    let thresh_decomp = circuit.add(thresh_b0_var, thresh_b1_scaled)?;
+    circuit.enforce_equal(thresh_decomp, threshold_var)?;
+
+    let slack_value = (witness.admin_signers.iter().filter(|s| s.active).count() as u64)
+        .saturating_sub(witness.admin_threshold_numerator);
+    let slack_bit0 = circuit.create_boolean_variable((slack_value & 1) == 1)?;
+    let slack_bit1 = circuit.create_boolean_variable(((slack_value >> 1) & 1) == 1)?;
+    let slack_b0_var: Variable = slack_bit0.into();
+    let slack_b1_var: Variable = slack_bit1.into();
+    let slack_b1_scaled = circuit.mul(slack_b1_var, two_var)?;
+    let slack_var = circuit.add(slack_b0_var, slack_b1_scaled)?;
+    let lhs = circuit.add(threshold_var, slack_var)?;
+    circuit.enforce_equal(lhs, k_var)?;
+
+    // ---- 2. Member count + occupancy binding (count-only delta) ----
+    let computed_occ_old =
+        poseidon_hash_two_gadget(circuit, count_old_var, salt_oc_old_var)?;
+    circuit.enforce_equal(computed_occ_old, occ_old_var)?;
+    let computed_occ_new =
+        poseidon_hash_two_gadget(circuit, count_new_var, salt_oc_new_var)?;
+    circuit.enforce_equal(computed_occ_new, occ_new_var)?;
+
+    // |count_new - count_old| ≤ 1 ⇔ (diff)(diff-1)(diff+1) = 0
+    let diff = circuit.sub(count_new_var, count_old_var)?;
+    let diff_minus1 = circuit.add_constant(diff, &(-Fr::from(1u64)))?;
+    let diff_plus1 = circuit.add_constant(diff, &Fr::from(1u64))?;
+    let prod1 = circuit.mul(diff, diff_minus1)?;
+    let prod2 = circuit.mul(prod1, diff_plus1)?;
+    circuit.enforce_constant(prod2, Fr::from(0u64))?;
+
+    // ---- 3. Commitment chain (matches synthesize_oligarchy_create) ----
+    // c_X = Poseidon(Poseidon(Poseidon(member_root_X, epoch_X), salt_X),
+    //               Poseidon(occ_X, admin_root_X))
+    let inner_old = poseidon_hash_two_gadget(circuit, member_root_old_var, epoch_old_var)?;
+    let mid_old = poseidon_hash_two_gadget(circuit, inner_old, salt_old_var)?;
+    let admin_mix_old =
+        poseidon_hash_two_gadget(circuit, occ_old_var, admin_root_old_var)?;
+    let computed_c_old = poseidon_hash_two_gadget(circuit, mid_old, admin_mix_old)?;
+    circuit.enforce_equal(computed_c_old, c_old_var)?;
+
+    let epoch_new_var = circuit.add_constant(epoch_old_var, &Fr::from(1u64))?;
+    let inner_new = poseidon_hash_two_gadget(circuit, member_root_new_var, epoch_new_var)?;
+    let mid_new = poseidon_hash_two_gadget(circuit, inner_new, salt_new_var)?;
+    let admin_mix_new =
+        poseidon_hash_two_gadget(circuit, occ_new_var, admin_root_new_var)?;
+    let computed_c_new = poseidon_hash_two_gadget(circuit, mid_new, admin_mix_new)?;
     circuit.enforce_equal(computed_c_new, c_new_var)?;
 
     Ok(())
@@ -277,5 +557,384 @@ mod tests {
             Fr::from(threshold),
         ];
         crate::prover::plonk::verify(&keys.vk, &pi, &proof).unwrap();
+    }
+
+    // ============================================================
+    // Quorum + delta + admin-membership update circuit (issue #202)
+    // ============================================================
+
+    use crate::circuit::plonk::poseidon::poseidon_hash_one_v05;
+
+    /// Build a complete admin tree from `secret_keys` and return the
+    /// root + every leaf's Merkle path. Mirrors `democracy.rs`'s
+    /// helper but with a fixed depth.
+    fn build_admin_tree(secret_keys: &[Fr], depth: usize) -> (Fr, Vec<Vec<Fr>>) {
+        let leaves: Vec<Fr> = secret_keys.iter().map(poseidon_hash_one_v05).collect();
+        let num_leaves = 1usize << depth;
+        let mut nodes = vec![Fr::from(0u64); 2 * num_leaves];
+        for (i, leaf) in leaves.iter().enumerate() {
+            nodes[num_leaves + i] = *leaf;
+        }
+        for i in (1..num_leaves).rev() {
+            nodes[i] = poseidon_hash_two_v05(&nodes[2 * i], &nodes[2 * i + 1]);
+        }
+        let root = nodes[1];
+        let mut paths: Vec<Vec<Fr>> = Vec::with_capacity(secret_keys.len());
+        for prover_index in 0..secret_keys.len() {
+            let mut path = Vec::with_capacity(depth);
+            let mut cur = num_leaves + prover_index;
+            for _ in 0..depth {
+                let sib = if cur % 2 == 0 { cur + 1 } else { cur - 1 };
+                path.push(nodes[sib]);
+                cur /= 2;
+            }
+            paths.push(path);
+        }
+        (root, paths)
+    }
+
+    /// Native equivalent of the quorum circuit's commitment chain —
+    /// matches `synthesize_oligarchy_create` so create→update lineage
+    /// is consistent.
+    fn native_quorum_c(
+        member_root: Fr,
+        epoch: u64,
+        salt: Fr,
+        occ: Fr,
+        admin_root: Fr,
+    ) -> Fr {
+        let inner = poseidon_hash_two_v05(&member_root, &Fr::from(epoch));
+        let mid = poseidon_hash_two_v05(&inner, &salt);
+        let admin_mix = poseidon_hash_two_v05(&occ, &admin_root);
+        poseidon_hash_two_v05(&mid, &admin_mix)
+    }
+
+    /// Build a deterministic K-active quorum witness. `admin_count`
+    /// determines how many slots are flagged active (must be
+    /// `<= OLIGARCHY_K_MAX`). Inactive slots get dummy values.
+    fn build_quorum_witness(
+        admin_secret_keys: &[Fr],
+        admin_count: usize,
+        threshold: u64,
+        epoch_old: u64,
+        member_count_old: u64,
+        member_count_new: u64,
+    ) -> OligarchyUpdateQuorumWitness {
+        assert!(admin_count <= OLIGARCHY_K_MAX);
+        assert!(admin_count <= admin_secret_keys.len());
+        let (admin_root, paths) = build_admin_tree(admin_secret_keys, OLIGARCHY_ADMIN_DEPTH);
+        let member_root = Fr::from(0xCAFEu64);
+        let salt_old = Fr::from(0xEEEEu64);
+        let salt_new = Fr::from(0xFFFFu64);
+        let salt_oc_old = Fr::from(0x55u64);
+        let salt_oc_new = Fr::from(0x66u64);
+        let occ_old =
+            poseidon_hash_two_v05(&Fr::from(member_count_old), &salt_oc_old);
+        let occ_new =
+            poseidon_hash_two_v05(&Fr::from(member_count_new), &salt_oc_new);
+        let c_old = native_quorum_c(member_root, epoch_old, salt_old, occ_old, admin_root);
+        let c_new =
+            native_quorum_c(member_root, epoch_old + 1, salt_new, occ_new, admin_root);
+
+        let dummy_path = vec![Fr::from(0u64); OLIGARCHY_ADMIN_DEPTH];
+        let admin_signers: [OligarchyAdminSigner; OLIGARCHY_K_MAX] =
+            core::array::from_fn(|i| {
+                if i < admin_count {
+                    OligarchyAdminSigner {
+                        secret_key: admin_secret_keys[i],
+                        merkle_path: paths[i].clone(),
+                        leaf_index: i,
+                        active: true,
+                    }
+                } else {
+                    OligarchyAdminSigner {
+                        secret_key: Fr::from(0u64),
+                        merkle_path: dummy_path.clone(),
+                        leaf_index: 0,
+                        active: false,
+                    }
+                }
+            });
+
+        OligarchyUpdateQuorumWitness {
+            c_old,
+            epoch_old,
+            c_new,
+            occupancy_commitment_old: occ_old,
+            occupancy_commitment_new: occ_new,
+            admin_threshold_numerator: threshold,
+            admin_signers,
+            member_root_old: member_root,
+            member_root_new: member_root,
+            admin_root_old: admin_root,
+            admin_root_new: admin_root,
+            member_count_old,
+            member_count_new,
+            salt_oc_old,
+            salt_oc_new,
+            salt_old,
+            salt_new,
+        }
+    }
+
+    fn pi_quorum(w: &OligarchyUpdateQuorumWitness) -> Vec<Fr> {
+        vec![
+            w.c_old,
+            Fr::from(w.epoch_old),
+            w.c_new,
+            w.occupancy_commitment_old,
+            w.occupancy_commitment_new,
+            Fr::from(w.admin_threshold_numerator),
+        ]
+    }
+
+    #[test]
+    fn quorum_satisfies_with_full_quorum() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        c.check_circuit_satisfiability(&pi_quorum(&w)).unwrap();
+    }
+
+    #[test]
+    fn quorum_satisfies_with_quorum_above_threshold() {
+        // K = K_MAX, threshold = 1 → slack = 1 fits 2 bits.
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, 1, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        c.check_circuit_satisfiability(&pi_quorum(&w)).unwrap();
+    }
+
+    /// Positive baseline for `quorum_rejects_out_of_range_threshold_pi`.
+    #[test]
+    fn quorum_satisfies_zero_quorum_zero_threshold() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, 0, 0, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        c.check_circuit_satisfiability(&pi_quorum(&w)).unwrap();
+    }
+
+    #[test]
+    fn quorum_satisfies_count_delta_plus_one() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 6);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        c.check_circuit_satisfiability(&pi_quorum(&w)).unwrap();
+    }
+
+    /// Member-removal path: count_new = count_old - 1.
+    #[test]
+    fn quorum_satisfies_count_delta_minus_one() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 4);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        c.check_circuit_satisfiability(&pi_quorum(&w)).unwrap();
+    }
+
+    #[test]
+    fn quorum_rejects_k_below_threshold() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let mut w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        w.admin_signers[OLIGARCHY_K_MAX - 1].active = false;
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        assert!(c.check_circuit_satisfiability(&pi_quorum(&w)).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_count_delta_too_large() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 7);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        assert!(c.check_circuit_satisfiability(&pi_quorum(&w)).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_active_prefix_violation() {
+        // active = [false, true] — prefix violated.
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let mut w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, 1, 42, 5, 5);
+        w.admin_signers[0].active = false;
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        assert!(c.check_circuit_satisfiability(&pi_quorum(&w)).is_err());
+    }
+
+    /// An inactive slot can hold a perfectly valid Merkle opening to
+    /// some *other* admin tree — the active-conditional gate must
+    /// mask it. Verifies the gating, not just dummy zeros.
+    #[test]
+    fn quorum_inactive_slot_with_valid_different_admin_root_passes() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let mut w = build_quorum_witness(&sks, 1, 1, 42, 5, 5);
+        let other_sks: Vec<Fr> = (100u64..104).map(Fr::from).collect();
+        let (_other_root, other_paths) =
+            build_admin_tree(&other_sks, OLIGARCHY_ADMIN_DEPTH);
+        w.admin_signers[1] = OligarchyAdminSigner {
+            secret_key: other_sks[0],
+            merkle_path: other_paths[0].clone(),
+            leaf_index: 7,
+            active: false,
+        };
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        c.check_circuit_satisfiability(&pi_quorum(&w)).unwrap();
+    }
+
+    #[test]
+    fn quorum_rejects_duplicate_leaf_double_count() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let mut w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        w.admin_signers[1] = w.admin_signers[0].clone();
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        assert!(c.check_circuit_satisfiability(&pi_quorum(&w)).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_tampered_active_merkle_path() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let mut w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        w.admin_signers[0].merkle_path[1] += Fr::from(1u64);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        assert!(c.check_circuit_satisfiability(&pi_quorum(&w)).is_err());
+    }
+
+    /// Tampering `admin_root_old` (private witness) must break the
+    /// active-conditional Merkle gate even though it isn't a public
+    /// input. Pins the signer→`admin_root_old` binding.
+    #[test]
+    fn quorum_rejects_tampered_admin_root_old() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let mut w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        w.admin_root_old += Fr::from(1u64);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        assert!(c.check_circuit_satisfiability(&pi_quorum(&w)).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_tampered_c_old_pi() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        let mut bad_pi = pi_quorum(&w);
+        bad_pi[0] += Fr::from(1u64);
+        assert!(c.check_circuit_satisfiability(&bad_pi).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_tampered_epoch_old_pi() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        let mut bad_pi = pi_quorum(&w);
+        bad_pi[1] += Fr::from(1u64);
+        assert!(c.check_circuit_satisfiability(&bad_pi).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_tampered_c_new_pi() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        let mut bad_pi = pi_quorum(&w);
+        bad_pi[2] += Fr::from(1u64);
+        assert!(c.check_circuit_satisfiability(&bad_pi).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_tampered_occ_old_pi() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        let mut bad_pi = pi_quorum(&w);
+        bad_pi[3] += Fr::from(1u64);
+        assert!(c.check_circuit_satisfiability(&bad_pi).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_tampered_occ_new_pi() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        let mut bad_pi = pi_quorum(&w);
+        bad_pi[4] += Fr::from(1u64);
+        assert!(c.check_circuit_satisfiability(&bad_pi).is_err());
+    }
+
+    /// `threshold ≡ -3 (mod p)` would let an attacker pass `K = 0`
+    /// without the threshold range gate. Companion:
+    /// `quorum_satisfies_zero_quorum_zero_threshold` confirms the
+    /// unpatched PI baseline is satisfiable.
+    #[test]
+    fn quorum_rejects_out_of_range_threshold_pi() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, 0, 0, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        let mut bad_pi = pi_quorum(&w);
+        bad_pi[5] = -Fr::from(3u64);
+        assert!(c.check_circuit_satisfiability(&bad_pi).is_err());
+    }
+
+    /// `threshold = 3` is in-range for the 2-bit threshold gate but
+    /// unsatisfiable with `K_MAX = 2`: slack underflows. Pins the
+    /// slack range check.
+    #[test]
+    fn quorum_rejects_threshold_above_k_max() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, 3, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        assert!(c.check_circuit_satisfiability(&pi_quorum(&w)).is_err());
+    }
+
+    /// Gate-count guard: the quorum circuit must fit n=32768 SRS for
+    /// the on-chain verifier to accept it. Admin tree depth is fixed
+    /// at 5 across all member tiers, so the circuit shape (and gate
+    /// count) is independent of member tier.
+    #[test]
+    fn quorum_gate_count_under_srs_ceiling() {
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 42, 5, 5);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        c.finalize_for_arithmetization().unwrap();
+        eprintln!(
+            "[gate-count] oligarchy_update_quorum K={OLIGARCHY_K_MAX} admin_depth={OLIGARCHY_ADMIN_DEPTH}: {} gates",
+            c.num_gates()
+        );
+        assert!(
+            c.num_gates() < 32768,
+            "oligarchy quorum ({} gates) over SRS ceiling",
+            c.num_gates(),
+        );
+    }
+
+    #[test]
+    fn quorum_round_trip() {
+        use rand_chacha::rand_core::SeedableRng;
+        let sks: Vec<Fr> = (1u64..=4).map(Fr::from).collect();
+        let w = build_quorum_witness(&sks, OLIGARCHY_K_MAX, OLIGARCHY_K_MAX as u64, 1234, 5, 6);
+        let mut c = PlonkCircuit::<Fr>::new_turbo_plonk();
+        synthesize_oligarchy_update_quorum(&mut c, &w).unwrap();
+        c.finalize_for_arithmetization().unwrap();
+        let mut rng = rand_chacha::ChaCha20Rng::from_seed([0u8; 32]);
+        let keys = crate::prover::plonk::preprocess(&c).unwrap();
+        let proof = crate::prover::plonk::prove(&mut rng, &keys.pk, &c).unwrap();
+        crate::prover::plonk::verify(&keys.vk, &pi_quorum(&w), &proof).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Closes #202. Adds `synthesize_oligarchy_update_quorum` alongside the simplified `synthesize_oligarchy_update` (kept verbatim as a migration fallback, mirroring democracy's d=11 pattern).

This PR is the **circuit-side** half — same split as PR #201 → PR #203 for democracy. Baker wiring + production VK rebake comes in a follow-up after this lands.

## What's enforced

The simplified port flagged in PR #200 had three soundness gaps the v0.1.4 design (`docs/oligarchy-update-testnet-design.md` §4.7.3 + §4.7.6) calls for. All three now in-circuit:

1. **K-of-N admin quorum** — `OLIGARCHY_K_MAX = 2` admin signer slots. Each `(sk, merkle_path, leaf_idx, active)` opens against `admin_root_old` at fixed `OLIGARCHY_ADMIN_DEPTH = 5` (admin tier pinned to Small per design §4.6, regardless of member tier). Same structure as democracy's quorum: prefix gate, anti-double-count by leaf_idx, slack + threshold range-checked into 2 bits, `K = threshold + slack` equality, `const _: () = assert!(K_MAX <= 3)` guard.
2. **Member count delta** — `occupancy_commitment_X = Poseidon(member_count_X, salt_oc_X)` with `|count_new − count_old| ≤ 1` enforced as `(diff)(diff−1)(diff+1) = 0`. Count-only — tree-level "new root differs by one leaf" is deferred (matches democracy's scope; documented).
3. **Commitment chain reconciliation** — c_old / c_new now use the same chain as `synthesize_oligarchy_create`:
   ```
   c_X = Poseidon(Poseidon(Poseidon(member_root_X, epoch_X), salt_X),
                  Poseidon(occ_X, admin_root_X))
   ```
   The simplified update was lineage-incompatible with create (omitted `admin_root` from the third hash), so a freshly-created group could **not** produce a valid update proof. **Fixes a pre-existing soundness bug** in addition to the quorum upgrade.

## Public-input shape

Unchanged. The 6 PI fields are byte-identical to the simplified port:
1. `c_old`
2. `epoch_old`
3. `c_new`
4. `occupancy_commitment_old`
5. `occupancy_commitment_new`
6. `admin_threshold_numerator`

When production VKs are rebaked against the quorum circuit (follow-up PR), the on-chain Soroban contract surface is unchanged — `admin_threshold_numerator` is still contract-supplied from storage at verify time.

## Gate count

`16384` (exactly 2^14) — single-tier circuit fits n=32768 SRS with a full power-of-2 of headroom. Admin tree depth is fixed at 5 across all member tiers, so circuit shape is independent of member-tier and the VK is shared.

## Tests

19 new + 6 existing = **25/25 pass** in 109s:
- Positive baselines: full quorum, K=K_MAX/threshold=1, K=0/threshold=0, count-delta ±1.
- Negative paths: K-below-threshold, count-delta-too-large, active-prefix violation, duplicate-leaf double-count, tampered active Merkle path, tampered `admin_root_old` (private witness), all 5 PI tamper paths, threshold-out-of-range (`-3 mod p`), threshold above K_MAX (slack underflow).
- Inactive-slot-with-valid-different-admin-root — pins the active-conditional gating against dummy-zero false positives.
- Gate-count guard: `assert!(num_gates() < 32768)`.
- Round-trip: prove+verify against jf-plonk through the canonical witness.

## Out of scope (follow-ups)

- **Baker wiring** — rebake `oligarchy-update-vk.bin`, `proof.bin`, `pi.bin` against the quorum circuit. Same shape as PR #203 for democracy.
- **Tree-level single-leaf delta** on the member tree — documented under "Deviations / TODOs" in democracy.rs and same applies here.

## Test plan

- [x] `cargo test --features plonk --lib circuit::plonk::oligarchy` — 25/25 pass.
- [x] Gate count printed: `[gate-count] oligarchy_update_quorum K=2 admin_depth=5: 16384 gates`.
- [ ] CI verifies the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)