### PR TITLE
Phase C.5 follow-up: testnet gas-bench workflow

### DIFF
--- a/.github/workflows/release-testnet-gas.yml
+++ b/.github/workflows/release-testnet-gas.yml
@@ -45,10 +45,11 @@ jobs:
 
       - name: Install stellar CLI
         run: |
-          # Match the version pinned by the rest of the project's
-          # testnet tooling. Update in lockstep with the rest of the
-          # repo if the deploy scripts switch.
-          STELLAR_VERSION="${STELLAR_CLI_VERSION:-22.6.0}"
+          # Pin to the same major the local dev environment ships
+          # with (`stellar --version` → 26.0.0 on the maintainer's
+          # box). Bump in lockstep with the rest of the repo if a
+          # deploy script switches.
+          STELLAR_VERSION="${STELLAR_CLI_VERSION:-26.0.0}"
           curl -sSLf "https://github.com/stellar/stellar-cli/releases/download/v${STELLAR_VERSION}/stellar-cli-${STELLAR_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
             | tar -xz -C /usr/local/bin stellar
           stellar --version

--- a/.github/workflows/release-testnet-gas.yml
+++ b/.github/workflows/release-testnet-gas.yml
@@ -44,14 +44,33 @@ jobs:
           key: bench-gas-rust-${{ hashFiles('Cargo.lock', 'contracts/**/Cargo.toml') }}
 
       - name: Install stellar CLI
+        env:
+          # Pin to the version the maintainer's local dev env runs
+          # (`stellar --version` → 26.0.0). Bump in lockstep with the
+          # rest of the repo if a deploy script switches.
+          STELLAR_VERSION: '26.0.0'
+          # SHA-256 of stellar-cli-26.0.0-x86_64-unknown-linux-gnu.tar.gz,
+          # captured 2026-05-01 from the official GitHub release. The job
+          # has `contents: write`, so verifying the toolchain we rely on
+          # before extracting is cheap insurance against an upstream
+          # release-asset compromise.
+          STELLAR_SHA256: '31c83db342d1184b31f6591e739950eb45756be46dcd7bb57e4f38e91ea32e84'
         run: |
-          # Pin to the same major the local dev environment ships
-          # with (`stellar --version` → 26.0.0 on the maintainer's
-          # box). Bump in lockstep with the rest of the repo if a
-          # deploy script switches.
-          STELLAR_VERSION="${STELLAR_CLI_VERSION:-26.0.0}"
-          curl -sSLf "https://github.com/stellar/stellar-cli/releases/download/v${STELLAR_VERSION}/stellar-cli-${STELLAR_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
-            | tar -xz -C /usr/local/bin stellar
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          tarball="$tmp/stellar-cli.tar.gz"
+          curl -sSLf -o "$tarball" \
+            "https://github.com/stellar/stellar-cli/releases/download/v${STELLAR_VERSION}/stellar-cli-${STELLAR_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${STELLAR_SHA256}  ${tarball}" | sha256sum -c -
+          tar -xz -C "$tmp" -f "$tarball"
+          # Don't assume the binary lives at the tarball root — extract
+          # to a scratch dir and `install` whatever named `stellar`
+          # turned up. v26 happens to have it at the root; later releases
+          # may not.
+          binary="$(find "$tmp" -maxdepth 3 -type f -name stellar -perm -u+x | head -1)"
+          test -n "$binary" || { echo "no stellar binary in tarball" >&2; exit 1; }
+          sudo install -m 0755 "$binary" /usr/local/bin/stellar
+          rm -rf "$tmp"
           stellar --version
 
       - name: Configure stellar testnet

--- a/.github/workflows/release-testnet-gas.yml
+++ b/.github/workflows/release-testnet-gas.yml
@@ -1,0 +1,94 @@
+# Run the testnet gas-cost bench against an already-published release
+# and attach the ASCII table as a release asset.
+#
+# Trigger model matches the project convention: manual workflow_dispatch
+# with an explicit tag. The tag must already exist (the regular Release
+# workflow creates it). This workflow is read-only WRT the codebase —
+# it doesn't push, doesn't bump versions, just measures and uploads.
+
+name: Release testnet gas benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach the bench table to (e.g. v1.10.89). Must already exist.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache Rust build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: bench-gas-rust-${{ hashFiles('Cargo.lock', 'contracts/**/Cargo.toml') }}
+
+      - name: Install stellar CLI
+        run: |
+          # Match the version pinned by the rest of the project's
+          # testnet tooling. Update in lockstep with the rest of the
+          # repo if the deploy scripts switch.
+          STELLAR_VERSION="${STELLAR_CLI_VERSION:-22.6.0}"
+          curl -sSLf "https://github.com/stellar/stellar-cli/releases/download/v${STELLAR_VERSION}/stellar-cli-${STELLAR_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C /usr/local/bin stellar
+          stellar --version
+
+      - name: Configure stellar testnet
+        run: |
+          stellar network add testnet \
+            --rpc-url https://soroban-testnet.stellar.org \
+            --network-passphrase "Test SDF Network ; September 2015" || true
+
+      - name: Run gas benchmarks
+        env:
+          BENCH_NETWORK: testnet
+          BENCH_TAG: ${{ inputs.tag }}
+        run: |
+          chmod +x scripts/bench-gas/run.sh \
+                   scripts/bench-gas/setup.sh \
+                   scripts/bench-gas/contracts/*.sh
+          bash scripts/bench-gas/run.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gas-benchmarks-${{ inputs.tag }}
+          path: |
+            scripts/bench-gas/results.txt
+            scripts/bench-gas/results.jsonl
+          if-no-files-found: error
+
+      - name: Attach to GitHub release
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          cp scripts/bench-gas/results.txt   "gas-benchmarks-${TAG}.txt"
+          cp scripts/bench-gas/results.jsonl "gas-benchmarks-${TAG}.jsonl"
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            gas-benchmarks-${{ inputs.tag }}.txt
+            gas-benchmarks-${{ inputs.tag }}.jsonl
+          fail_on_unmatched_files: true

--- a/scripts/bench-gas/README.md
+++ b/scripts/bench-gas/README.md
@@ -1,0 +1,99 @@
+# Testnet gas benchmarks
+
+Captures real `fee_charged` values (in stroops, rendered as XLM) for
+every public entrypoint of the 5 governance contracts on Stellar
+testnet. Output is an ASCII table attached to a GitHub release as
+`gas-benchmarks-<tag>.txt`, plus a JSONL stream
+(`gas-benchmarks-<tag>.jsonl`) for downstream tooling.
+
+## Why this exists
+
+PR #206 ("Phase C.5: gas benchmark suite") landed `bench_*` tests
+that read the soroban-sdk budget tracker around each heavy op. Those
+numbers are **lower bounds** — the sdk docstring flags that "CPU
+instructions are likely to be underestimated when running Rust code
+compared to running the WASM equivalent." This bench closes that gap
+by submitting real testnet transactions and reading the
+post-execution `fee_charged` from `stellar tx fetch fee`.
+
+## Triggering
+
+Manual workflow dispatch only — same convention as `Release`:
+
+```
+gh workflow run "Release testnet gas benchmarks" -f tag=vX.Y.Z
+```
+
+The tag must already exist (the regular `Release` workflow creates
+it). This workflow doesn't push commits, doesn't bump versions, and
+doesn't touch the published release notes — it only uploads two
+files as release assets.
+
+## Local dry-run
+
+```
+bash scripts/bench-gas/run.sh                 # all 5 contracts
+bash scripts/bench-gas/run.sh sep-oneonone    # one contract
+```
+
+Requirements: `stellar` CLI, `cargo`, `jq`, `xxd`, `python3`.
+
+Outputs land under `scripts/bench-gas/results.{txt,jsonl}`.
+
+## Coverage matrix (V1)
+
+| Contract       | deploy | create_* | verify_membership | update_commitment | admin ops |
+|----------------|:------:|:--------:|:-----------------:|:-----------------:|:---------:|
+| sep-oneonone   | ✓      | ✓        | (V2)              | n/a               | ✓         |
+| sep-oligarchy  | ✓      | ✓        | ✓ (revert-mode)   | ✓ (revert-mode)   | ✓         |
+| sep-anarchy    | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
+| sep-democracy  | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
+| sep-tyranny    | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
+
+### Bench mechanics
+
+* **`verify_membership`** returns `Ok(false)` on `InvalidProof`, so
+  the captured fee equals the success-path cost — the verifier runs
+  the full PLONK pairing check identically in both arms.
+* **`update_commitment`** errors out on `InvalidProof`, so the tx
+  reverts after the verifier. The captured fee misses the
+  post-verify storage writes (history archive + new entry + TTL
+  bumps), which PR #206 measured at ~75K CPU / ~75KB mem (≈1% of
+  total). The release notes flag this caveat.
+
+## V2 follow-up
+
+The contracts deferred above use `MEMBERSHIP_VK` for create
+(anarchy/democracy) or per-tier `VK_CREATE_D{5,8,11}` (tyranny).
+None has a fixture-only path that produces a successful
+`create_group` from a fresh deploy without runtime proof generation.
+
+V2 plan:
+1. Workflow step builds `gen-membership-proof` + `gen-update-proof`
+   under `--features gen-proof-tool`.
+2. For each tier, generate a fresh `(proof, public_inputs)` bundle
+   matching the deploy-time witness defaults (`secret-keys`,
+   `prover-index`, `salt`).
+3. Drive `create_group` → `verify_membership` → `update_commitment`
+   against the fresh proofs, capturing real success-path fees.
+
+Trade-off vs V1: extra ~30 s of CI wall-time per contract for the
+proof gen, plus the cost of the proofs hitting BLS arithmetic in
+release mode. Tracked in the next-up follow-up issue.
+
+## File layout
+
+```
+scripts/bench-gas/
+├── README.md          (this file)
+├── lib.sh             (encoding helpers, deploy/invoke/fee capture)
+├── setup.sh           (identity, friendbot fund, contract builds)
+├── run.sh             (orchestrator → JSONL → render.py)
+├── render.py          (JSONL → ASCII table)
+└── contracts/
+    ├── sep-anarchy.sh
+    ├── sep-democracy.sh
+    ├── sep-oligarchy.sh
+    ├── sep-oneonone.sh
+    └── sep-tyranny.sh
+```

--- a/scripts/bench-gas/contracts/sep-anarchy.sh
+++ b/scripts/bench-gas/contracts/sep-anarchy.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# sep-anarchy gas bench driver.
+#
+# V1 coverage: deploy, set_restricted_mode.
+# V2 (deferred): create_group, verify_membership, update_commitment —
+#   each requires a fresh PLONK proof at runtime via gen-membership-
+#   proof / gen-update-proof. Tracked in scripts/bench-gas/README.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LIB="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)/lib.sh"
+# shellcheck source=../lib.sh
+. "$LIB"
+
+export BENCH_CURRENT_CONTRACT="sep-anarchy"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
+CID="$(bench_deploy \
+    "bench-gas-anarchy" \
+    "$BENCH_ARTIFACT_DIR/sep_anarchy_contract.wasm" \
+    --admin "$BENCH_DEPLOYER_ADDRESS")"
+
+if [ -z "$CID" ]; then
+    echo "    deploy failed — skipping further ops" >&2
+    exit 0
+fi
+echo "    contract: $CID"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
+bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \
+    --restricted true
+
+echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/contracts/sep-democracy.sh
+++ b/scripts/bench-gas/contracts/sep-democracy.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# sep-democracy gas bench driver.
+#
+# V1 coverage: deploy, set_restricted_mode.
+# V2 (deferred): create_group + verify_membership via fresh
+#   gen-membership-proof; update_commitment via committed
+#   democracy-update-proof-d{5,8,11}.bin in revert mode.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LIB="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)/lib.sh"
+# shellcheck source=../lib.sh
+. "$LIB"
+
+export BENCH_CURRENT_CONTRACT="sep-democracy"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
+CID="$(bench_deploy \
+    "bench-gas-democracy" \
+    "$BENCH_ARTIFACT_DIR/sep_democracy_contract.wasm" \
+    --admin "$BENCH_DEPLOYER_ADDRESS")"
+
+if [ -z "$CID" ]; then
+    echo "    deploy failed — skipping further ops" >&2
+    exit 0
+fi
+echo "    contract: $CID"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
+bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \
+    --restricted true
+
+echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/contracts/sep-oligarchy.sh
+++ b/scripts/bench-gas/contracts/sep-oligarchy.sh
@@ -5,7 +5,7 @@
 #   deploy, create_oligarchy_group (committed fixture, tier 0),
 #   verify_membership (revert-mode against post-create state),
 #   update_commitment (revert-mode against post-create state),
-#   set_restricted_mode, bump_group_ttl, get_commitment.
+#   set_restricted_mode, bump_group_ttl.
 #
 # Bench mechanics:
 #   * verify_membership returns Ok(false) on InvalidProof (no revert),
@@ -121,8 +121,7 @@ echo "==> [$BENCH_CURRENT_CONTRACT] bump_group_ttl"
 bench_invoke "$CID" "bump_group_ttl" "n/a" "bump_group_ttl" \
     --group-id-file-path "$WORK/group-id.json"
 
-echo "==> [$BENCH_CURRENT_CONTRACT] get_commitment"
-bench_invoke "$CID" "get_commitment" "n/a" "get_commitment" \
-    --group-id-file-path "$WORK/group-id.json"
+# Read-only entrypoints (`get_commitment`, `get_history`) are skipped
+# intentionally — see sep-oneonone.sh for the reason.
 
 echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/contracts/sep-oligarchy.sh
+++ b/scripts/bench-gas/contracts/sep-oligarchy.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# sep-oligarchy gas bench driver.
+#
+# Coverage (V1):
+#   deploy, create_oligarchy_group (committed fixture, tier 0),
+#   verify_membership (revert-mode against post-create state),
+#   update_commitment (revert-mode against post-create state),
+#   set_restricted_mode, bump_group_ttl, get_commitment.
+#
+# Bench mechanics:
+#   * verify_membership returns Ok(false) on InvalidProof (no revert),
+#     so the captured fee equals the real success-path cost — the
+#     verifier runs the full pairing check identically in both arms.
+#   * update_commitment errors out on InvalidProof, so the tx reverts
+#     after the verifier. The fee misses the post-verify storage
+#     writes (history archive + new entry + TTL bumps), which PR #206
+#     measured at ~75K CPU / ~75KB mem (≈1% of total).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LIB="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)/lib.sh"
+# shellcheck source=../lib.sh
+. "$LIB"
+
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../../.." && pwd)"
+FIXTURE_DIR="$REPO_ROOT/contracts/plonk-verifier/tests/fixtures"
+
+export BENCH_CURRENT_CONTRACT="sep-oligarchy"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-oligarchy.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# ---- encode fixtures ----
+# create PI: 6 fields × 32 = 192 bytes. PI = [commitment, be32(0),
+#     occ, admin_pubkey_commitment, group_id_fr, ?]; only PI[0..3]
+#     are validated against wire args.
+bin_to_hex_json "$FIXTURE_DIR/oligarchy-create-proof.bin"  "$WORK/create-proof.json"
+pi_concat_to_json "$FIXTURE_DIR/oligarchy-create-pi.bin" 6 "$WORK/create-pi.json"
+
+CREATE_COMMITMENT_HEX="$(read_pi_field_hex "$FIXTURE_DIR/oligarchy-create-pi.bin" 0)"
+CREATE_OCC_HEX="$(read_pi_field_hex         "$FIXTURE_DIR/oligarchy-create-pi.bin" 2)"
+hex_to_json "$CREATE_COMMITMENT_HEX" "$WORK/create-commitment.json"
+hex_to_json "$CREATE_OCC_HEX"        "$WORK/create-occ.json"
+
+GROUP_ID_HEX="$(printf '07%.0s' $(seq 1 32))"
+hex_to_json "$GROUP_ID_HEX" "$WORK/group-id.json"
+
+# verify-membership PI (revert-mode): [state.commitment, be32(0)]
+ZERO32_HEX="$(printf '00%.0s' $(seq 1 32))"
+{
+    printf '['
+    printf '"%s",' "$CREATE_COMMITMENT_HEX"
+    printf '"%s"'  "$ZERO32_HEX"
+    printf ']'
+} > "$WORK/verify-pi.json"
+
+# update_commitment PI (revert-mode): [c_old, be32(0), c_new, occ_old,
+#     occ_new, be32(threshold=1)]. c_new + occ_new are arbitrary
+#     canonical Fr (we use 0...01 and 0...02).
+ONE32_HEX="$(printf '%062d01' 0)"   # 32 bytes, last byte = 0x01
+TWO32_HEX="$(printf '%062d02' 0)"
+THRESHOLD_HEX="$(printf '%062d01' 0)"   # be32(1)
+{
+    printf '['
+    printf '"%s",' "$CREATE_COMMITMENT_HEX"
+    printf '"%s",' "$ZERO32_HEX"
+    printf '"%s",' "$ONE32_HEX"
+    printf '"%s",' "$CREATE_OCC_HEX"
+    printf '"%s",' "$TWO32_HEX"
+    printf '"%s"'  "$THRESHOLD_HEX"
+    printf ']'
+} > "$WORK/update-pi.json"
+
+# ---- deploy ----
+echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
+CID="$(bench_deploy \
+    "bench-gas-oligarchy" \
+    "$BENCH_ARTIFACT_DIR/sep_oligarchy_contract.wasm" \
+    --admin "$BENCH_DEPLOYER_ADDRESS")"
+
+if [ -z "$CID" ]; then
+    echo "    deploy failed — skipping further ops" >&2
+    exit 0
+fi
+echo "    contract: $CID"
+
+# ---- create_oligarchy_group (tier 0 from canonical fixture) ----
+echo "==> [$BENCH_CURRENT_CONTRACT] create_oligarchy_group(tier=0)"
+bench_invoke "$CID" "create_oligarchy_group" "0" "create_oligarchy_group" \
+    --caller "$BENCH_DEPLOYER_ADDRESS" \
+    --group-id-file-path "$WORK/group-id.json" \
+    --commitment-file-path "$WORK/create-commitment.json" \
+    --member-tier 0 \
+    --admin-threshold-numerator 1 \
+    --occupancy-commitment-initial-file-path "$WORK/create-occ.json" \
+    --proof-file-path "$WORK/create-proof.json" \
+    --public-inputs-file-path "$WORK/create-pi.json"
+
+# ---- verify_membership (revert-mode; state matches, proof is well-
+#      formed but doesn't verify; verifier runs full pairing) ----
+echo "==> [$BENCH_CURRENT_CONTRACT] verify_membership(tier=0, revert-mode)"
+bench_invoke "$CID" "verify_membership" "0" "verify_membership" \
+    --group-id-file-path "$WORK/group-id.json" \
+    --proof-file-path "$WORK/create-proof.json" \
+    --public-inputs-file-path "$WORK/verify-pi.json"
+
+# ---- update_commitment (revert-mode) ----
+echo "==> [$BENCH_CURRENT_CONTRACT] update_commitment(revert-mode)"
+bench_invoke "$CID" "update_commitment" "0" "update_commitment" \
+    --group-id-file-path "$WORK/group-id.json" \
+    --proof-file-path "$WORK/create-proof.json" \
+    --public-inputs-file-path "$WORK/update-pi.json"
+
+# ---- admin / utility ops ----
+echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
+bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \
+    --restricted true
+
+echo "==> [$BENCH_CURRENT_CONTRACT] bump_group_ttl"
+bench_invoke "$CID" "bump_group_ttl" "n/a" "bump_group_ttl" \
+    --group-id-file-path "$WORK/group-id.json"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] get_commitment"
+bench_invoke "$CID" "get_commitment" "n/a" "get_commitment" \
+    --group-id-file-path "$WORK/group-id.json"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/contracts/sep-oneonone.sh
+++ b/scripts/bench-gas/contracts/sep-oneonone.sh
@@ -3,7 +3,7 @@
 #
 # Coverage (V1):
 #   deploy, create_group (committed fixture), set_restricted_mode,
-#   bump_group_ttl, get_commitment.
+#   bump_group_ttl.
 #
 # Out of scope (V2):
 #   verify_membership — needs a fresh membership proof matching the
@@ -73,9 +73,9 @@ echo "==> [$BENCH_CURRENT_CONTRACT] bump_group_ttl"
 bench_invoke "$CID" "bump_group_ttl" "n/a" "bump_group_ttl" \
     --group-id-file-path "$WORK/group-id.json"
 
-# ---- get_commitment (read; submitted to capture the on-chain fee) ----
-echo "==> [$BENCH_CURRENT_CONTRACT] get_commitment"
-bench_invoke "$CID" "get_commitment" "n/a" "get_commitment" \
-    --group-id-file-path "$WORK/group-id.json"
+# Read-only entrypoints (`get_commitment`, `get_history`) are skipped
+# intentionally — `stellar contract invoke` short-circuits to a local
+# simulation for them regardless of `--send yes`, so no tx is submitted
+# and no fee is charged.
 
 echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/contracts/sep-oneonone.sh
+++ b/scripts/bench-gas/contracts/sep-oneonone.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# sep-oneonone gas bench driver.
+#
+# Coverage (V1):
+#   deploy, create_group (committed fixture), set_restricted_mode,
+#   bump_group_ttl, get_commitment.
+#
+# Out of scope (V2):
+#   verify_membership — needs a fresh membership proof matching the
+#   create-fixture's commitment, but we don't have the witness used
+#   to generate `oneonone-create-proof.bin`. Tracked as a follow-up.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LIB="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)/lib.sh"
+# shellcheck source=../lib.sh
+. "$LIB"
+
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../../.." && pwd)"
+FIXTURE_DIR="$REPO_ROOT/contracts/plonk-verifier/tests/fixtures"
+
+export BENCH_CURRENT_CONTRACT="sep-oneonone"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-oneonone.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# ---- encode fixtures into CLI-ready JSON files ----
+# Constructor: (admin: Address) — no fixture args.
+#
+# create_group(caller, group_id, commitment, proof: BytesN<1601>,
+#              public_inputs: Vec<BytesN<32>>)
+# PI layout (2 fields × 32 bytes): [commitment, be32(epoch=0)]
+# Total file size: 64 bytes.
+bin_to_hex_json "$FIXTURE_DIR/oneonone-create-proof.bin" "$WORK/create-proof.json"
+pi_concat_to_json "$FIXTURE_DIR/oneonone-create-pi.bin" 2 "$WORK/create-pi.json"
+
+CREATE_COMMITMENT_HEX="$(read_pi_field_hex "$FIXTURE_DIR/oneonone-create-pi.bin" 0)"
+hex_to_json "$CREATE_COMMITMENT_HEX" "$WORK/create-commitment.json"
+
+GROUP_ID_HEX="$(printf '42%.0s' $(seq 1 32))"
+hex_to_json "$GROUP_ID_HEX" "$WORK/group-id.json"
+
+# ---- deploy ----
+echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
+CID="$(bench_deploy \
+    "bench-gas-oneonone" \
+    "$BENCH_ARTIFACT_DIR/sep_oneonone_contract.wasm" \
+    --admin "$BENCH_DEPLOYER_ADDRESS")"
+
+if [ -z "$CID" ]; then
+    echo "    deploy failed — skipping further ops" >&2
+    exit 0
+fi
+echo "    contract: $CID"
+
+# ---- create_group ----
+echo "==> [$BENCH_CURRENT_CONTRACT] create_group"
+bench_invoke "$CID" "create_group" "n/a" "create_group" \
+    --caller "$BENCH_DEPLOYER_ADDRESS" \
+    --group-id-file-path "$WORK/group-id.json" \
+    --commitment-file-path "$WORK/create-commitment.json" \
+    --proof-file-path "$WORK/create-proof.json" \
+    --public-inputs-file-path "$WORK/create-pi.json"
+
+# ---- set_restricted_mode (admin op, on then off) ----
+echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
+bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \
+    --restricted true
+
+# ---- bump_group_ttl ----
+echo "==> [$BENCH_CURRENT_CONTRACT] bump_group_ttl"
+bench_invoke "$CID" "bump_group_ttl" "n/a" "bump_group_ttl" \
+    --group-id-file-path "$WORK/group-id.json"
+
+# ---- get_commitment (read; submitted to capture the on-chain fee) ----
+echo "==> [$BENCH_CURRENT_CONTRACT] get_commitment"
+bench_invoke "$CID" "get_commitment" "n/a" "get_commitment" \
+    --group-id-file-path "$WORK/group-id.json"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/contracts/sep-tyranny.sh
+++ b/scripts/bench-gas/contracts/sep-tyranny.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# sep-tyranny gas bench driver.
+#
+# V1 coverage: deploy, set_restricted_mode.
+# V2 (deferred): create_group, verify_membership, update_commitment —
+#   each contract uses tier-keyed VKs (VK_CREATE_D{5,8,11},
+#   VK_UPDATE_D{5,8,11}) with no committed fixture chain that survives
+#   a fresh deploy. Need runtime proof generation OR per-tier
+#   committed (proof, PI, group_id, admin_pubkey_commitment) bundles.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LIB="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)/lib.sh"
+# shellcheck source=../lib.sh
+. "$LIB"
+
+export BENCH_CURRENT_CONTRACT="sep-tyranny"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
+CID="$(bench_deploy \
+    "bench-gas-tyranny" \
+    "$BENCH_ARTIFACT_DIR/sep_tyranny_contract.wasm" \
+    --admin "$BENCH_DEPLOYER_ADDRESS")"
+
+if [ -z "$CID" ]; then
+    echo "    deploy failed — skipping further ops" >&2
+    exit 0
+fi
+echo "    contract: $CID"
+
+echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
+bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \
+    --restricted true
+
+echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/lib.sh
+++ b/scripts/bench-gas/lib.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Shared helpers for the testnet gas benchmark suite.
+#
+# Encoding contract:
+#   `stellar contract invoke` accepts `--<arg>-file-path <PATH>` for any
+#   typed arg, where the file contains a JSON value matching the
+#   contract's schema:
+#     - BytesN<N>          → JSON string of N hex chars × 2: `"<hex>"`
+#     - Vec<BytesN<32>>    → JSON array of hex strings:        `["<hex>", ...]`
+#
+# Fee capture: `stellar contract invoke` (default --send=yes) prints
+# the tx hash to stderr in the line `ℹ Transaction hash is <hex>`. We
+# capture stderr, grep the hash, then `stellar tx fetch fee --hash`
+# to get the resource + inclusion + refund breakdown.
+#
+# All output rows go to a JSONL sink (BENCH_JSONL env var); the
+# renderer reads them post-run.
+
+set -euo pipefail
+
+# ---------- low-level encoders ----------
+
+# bin_to_hex_json <input.bin> <output.json>
+# Wraps raw bytes as `"<hex>"` (a JSON string). Suitable for BytesN<N>.
+bin_to_hex_json() {
+    local in="$1"
+    local out="$2"
+    local hex
+    hex="$(xxd -p -c 99999 "$in" | tr -d '\n')"
+    printf '"%s"' "$hex" > "$out"
+}
+
+# pi_concat_to_json <input.bin> <num_fields> <output.json>
+# Splits a flat 32*N byte file into a JSON array of N hex-encoded
+# 32-byte chunks. Suitable for Vec<BytesN<32>>.
+pi_concat_to_json() {
+    local in="$1"
+    local n="$2"
+    local out="$3"
+    local i hex
+    : > "$out.tmp"
+    {
+        printf '['
+        for (( i=0; i<n; i++ )); do
+            hex="$(dd if="$in" bs=32 skip="$i" count=1 2>/dev/null | xxd -p -c 99999 | tr -d '\n')"
+            if (( i > 0 )); then printf ','; fi
+            printf '"%s"' "$hex"
+        done
+        printf ']'
+    } > "$out"
+}
+
+# hex_to_json <hex_string> <output.json>
+# Wraps a hex string (no 0x prefix) as a JSON BytesN value.
+hex_to_json() {
+    local hex="$1"
+    local out="$2"
+    printf '"%s"' "$hex" > "$out"
+}
+
+# read_pi_field_hex <pi.bin> <field_index>
+# Echoes the hex of the i-th 32-byte chunk in a flat PI file.
+read_pi_field_hex() {
+    local pi="$1"
+    local i="$2"
+    dd if="$pi" bs=32 skip="$i" count=1 2>/dev/null | xxd -p -c 99999 | tr -d '\n'
+}
+
+# be32_zero_json <output.json>
+# JSON for 32 zero bytes (= big-endian repr of u64 zero, used for epoch=0).
+be32_zero_json() {
+    local out="$1"
+    printf '"%s"' "$(printf '%064d' 0)" > "$out"
+}
+
+# ---------- invocation + fee capture ----------
+
+# capture_tx_hash <stderr_logfile>
+# Greps the stellar CLI's stderr for the transaction hash. Returns the
+# hex hash on stdout, exits non-zero if not found.
+capture_tx_hash() {
+    local err="$1"
+    # CLI v26 prints `ℹ Transaction hash is <hex>` (note the leading
+    # info glyph). We tolerate either the glyph form or a bare line.
+    grep -oE '[0-9a-f]{64}' "$err" | head -1
+}
+
+# fetch_fee_stroops <hash>
+# Echoes the total fee_charged in stroops, parsed from
+# `stellar tx fetch fee --output json`.
+fetch_fee_stroops() {
+    local hash="$1"
+    local rpc_args=()
+    if [ -n "${BENCH_NETWORK:-}" ]; then
+        rpc_args=(--network "$BENCH_NETWORK")
+    fi
+    if [ -n "${BENCH_CONFIG_DIR:-}" ]; then
+        rpc_args=(--config-dir "$BENCH_CONFIG_DIR" "${rpc_args[@]}")
+    fi
+    stellar tx fetch fee --hash "$hash" --output json "${rpc_args[@]}" \
+        | jq -r '.totals.fee_charged // .fee_charged // empty'
+}
+
+# fetch_fee_full <hash>
+# Echoes JSON with both fee_charged (net) + resource breakdown when
+# available. Used by the JSONL emitter.
+fetch_fee_full() {
+    local hash="$1"
+    local rpc_args=()
+    if [ -n "${BENCH_NETWORK:-}" ]; then
+        rpc_args=(--network "$BENCH_NETWORK")
+    fi
+    if [ -n "${BENCH_CONFIG_DIR:-}" ]; then
+        rpc_args=(--config-dir "$BENCH_CONFIG_DIR" "${rpc_args[@]}")
+    fi
+    stellar tx fetch fee --hash "$hash" --output json "${rpc_args[@]}"
+}
+
+# emit_row <contract> <op> <tier> <hash> [extra_json]
+# Append a JSONL row to $BENCH_JSONL with fee + cost data for the tx.
+emit_row() {
+    local contract="$1"
+    local op="$2"
+    local tier="$3"
+    local hash="$4"
+    local extra="${5:-{\}}"
+
+    if [ -z "$hash" ]; then
+        # Fee capture failed (often: tx wasn't submitted, e.g. read-only).
+        # Emit a row with null fee fields so the renderer can flag it.
+        jq -n \
+            --arg contract "$contract" \
+            --arg op "$op" \
+            --arg tier "$tier" \
+            --argjson extra "$extra" \
+            '{contract: $contract, op: $op, tier: $tier, fee_stroops: null, hash: null} + $extra' \
+            >> "$BENCH_JSONL"
+        return 0
+    fi
+
+    local raw
+    raw="$(fetch_fee_full "$hash" || echo '{}')"
+    jq -n \
+        --arg contract "$contract" \
+        --arg op "$op" \
+        --arg tier "$tier" \
+        --arg hash "$hash" \
+        --argjson raw "$raw" \
+        --argjson extra "$extra" \
+        '{contract: $contract, op: $op, tier: $tier, hash: $hash,
+          fee_stroops: ($raw.totals.fee_charged // $raw.fee_charged // null),
+          inclusion_fee: ($raw.totals.inclusion_fee // null),
+          resource_fee: ($raw.totals.resource_fee // null),
+          refundable_fee_refund: ($raw.totals.refundable_fee_refund // null),
+          raw: $raw} + $extra' \
+        >> "$BENCH_JSONL"
+}
+
+# ---------- deploy + invoke wrappers ----------
+
+# bench_deploy <contract_alias> <wasm> <constructor_args...>
+# Deploys, captures the contract id (stdout) and the fee for the
+# deployment tx (stderr → tx hash → fetch fee). Echoes the contract
+# id on stdout for the caller to bind to a variable. Stderr is sunk
+# to $err synchronously (no `tee >()` race) and replayed for the
+# operator on completion.
+bench_deploy() {
+    local alias="$1"
+    local wasm="$2"
+    shift 2
+
+    local err
+    err="$(mktemp)"
+
+    local cid
+    cid="$(stellar contract deploy \
+        --config-dir "$BENCH_CONFIG_DIR" \
+        --network "$BENCH_NETWORK" \
+        --source-account "$BENCH_DEPLOYER" \
+        --alias "$alias" \
+        --wasm "$wasm" \
+        -- "$@" 2> "$err" | tr -d '\n')" || cid=""
+
+    cat "$err" >&2
+
+    local hash
+    hash="$(capture_tx_hash "$err" || true)"
+    rm -f "$err"
+
+    emit_row "$BENCH_CURRENT_CONTRACT" "deploy" "n/a" "$hash"
+    printf '%s' "$cid"
+}
+
+# bench_invoke <contract_id> <op> <tier> <fn> <fn_args...>
+# Submits the call, captures tx hash, fetches fee, emits a JSONL row.
+# Uses --send=yes so we get a real fee_charged even on revert paths.
+# A non-zero CLI exit (e.g. revert) is intentional for revert-mode
+# benches and does not abort the run.
+bench_invoke() {
+    local cid="$1"
+    local op="$2"
+    local tier="$3"
+    local fn="$4"
+    shift 4
+
+    local err
+    err="$(mktemp)"
+
+    stellar contract invoke \
+        --config-dir "$BENCH_CONFIG_DIR" \
+        --network "$BENCH_NETWORK" \
+        --id "$cid" \
+        --source-account "$BENCH_DEPLOYER" \
+        --send yes \
+        -- "$fn" "$@" \
+        > /dev/null 2> "$err" || true
+
+    cat "$err" >&2
+
+    local hash
+    hash="$(capture_tx_hash "$err" || true)"
+    rm -f "$err"
+
+    emit_row "$BENCH_CURRENT_CONTRACT" "$op" "$tier" "$hash"
+}

--- a/scripts/bench-gas/lib.sh
+++ b/scripts/bench-gas/lib.sh
@@ -38,7 +38,6 @@ pi_concat_to_json() {
     local n="$2"
     local out="$3"
     local i hex
-    : > "$out.tmp"
     {
         printf '['
         for (( i=0; i<n; i++ )); do
@@ -75,14 +74,24 @@ be32_zero_json() {
 
 # ---------- invocation + fee capture ----------
 
-# capture_tx_hash <stderr_logfile>
-# Greps the stellar CLI's stderr for the transaction hash. Returns the
-# hex hash on stdout, exits non-zero if not found.
-capture_tx_hash() {
+# capture_tx_hashes <stderr_logfile>
+# Echoes every transaction hash the stellar CLI logged, one per line,
+# in the order they were submitted. Anchored on the `Transaction hash
+# is <hex>` prefix to avoid matching wasm hashes, contract IDs, or
+# error blobs that happen to contain a 64-char hex run.
+#
+# `stellar contract deploy` submits two txs (upload_contract_wasm +
+# create_contract); a normal invoke submits one. Callers pick by
+# index.
+capture_tx_hashes() {
     local err="$1"
-    # CLI v26 prints `ℹ Transaction hash is <hex>` (note the leading
-    # info glyph). We tolerate either the glyph form or a bare line.
-    grep -oE '[0-9a-f]{64}' "$err" | head -1
+    grep -oE 'Transaction hash is [0-9a-f]{64}' "$err" | awk '{print $4}'
+}
+
+# capture_tx_hash <stderr_logfile>
+# Convenience: first hash from `capture_tx_hashes`. Empty if none.
+capture_tx_hash() {
+    capture_tx_hashes "$1" | head -1
 }
 
 # fetch_fee_stroops <hash>
@@ -159,11 +168,13 @@ emit_row() {
 # ---------- deploy + invoke wrappers ----------
 
 # bench_deploy <contract_alias> <wasm> <constructor_args...>
-# Deploys, captures the contract id (stdout) and the fee for the
-# deployment tx (stderr → tx hash → fetch fee). Echoes the contract
-# id on stdout for the caller to bind to a variable. Stderr is sunk
-# to $err synchronously (no `tee >()` race) and replayed for the
-# operator on completion.
+# Deploys and echoes the contract id on stdout for the caller to bind.
+# `stellar contract deploy` submits two txs:
+#   1. upload_contract_wasm  (size-dominated, the larger of the two)
+#   2. create_contract       (constructor execution)
+# Both fees are emitted as separate JSONL rows (deploy_upload,
+# deploy_create) so the headline cost isn't silently masked by
+# capturing only the first hash.
 bench_deploy() {
     local alias="$1"
     local wasm="$2"
@@ -183,11 +194,13 @@ bench_deploy() {
 
     cat "$err" >&2
 
-    local hash
-    hash="$(capture_tx_hash "$err" || true)"
+    local upload_hash create_hash
+    upload_hash="$(capture_tx_hashes "$err" | sed -n '1p')"
+    create_hash="$(capture_tx_hashes "$err" | sed -n '2p')"
     rm -f "$err"
 
-    emit_row "$BENCH_CURRENT_CONTRACT" "deploy" "n/a" "$hash"
+    emit_row "$BENCH_CURRENT_CONTRACT" "deploy_upload" "n/a" "$upload_hash"
+    emit_row "$BENCH_CURRENT_CONTRACT" "deploy_create" "n/a" "$create_hash"
     printf '%s' "$cid"
 }
 

--- a/scripts/bench-gas/render.py
+++ b/scripts/bench-gas/render.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Render the bench JSONL into an ASCII table for the GitHub release.
+
+Input:  one JSON object per line, schema produced by `lib.sh`'s
+        `emit_row` (contract, op, tier, fee_stroops, hash, ...).
+Output: a single ASCII table; rows sorted by (contract, op, tier),
+        XLM = stroops / 10_000_000 with 7 decimal places.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from pathlib import Path
+
+CONTRACT_ORDER = {
+    "sep-anarchy": 0,
+    "sep-democracy": 1,
+    "sep-oligarchy": 2,
+    "sep-oneonone": 3,
+    "sep-tyranny": 4,
+}
+
+OP_ORDER = {
+    "deploy": 0,
+    "create_group": 1,
+    "create_oligarchy_group": 1,
+    "verify_membership": 2,
+    "update_commitment": 3,
+    "set_restricted_mode": 10,
+    "bump_group_ttl": 11,
+    "get_commitment": 12,
+}
+
+
+def stroops_to_xlm(stroops: int | None) -> str:
+    if stroops is None:
+        return "—"
+    return f"{stroops / 10_000_000:.7f}"
+
+
+def fmt_stroops(stroops: int | None) -> str:
+    if stroops is None:
+        return "—"
+    return f"{stroops:,}"
+
+
+def fmt_int(value: int | None) -> str:
+    if value is None:
+        return "—"
+    return f"{int(value):,}"
+
+
+def tier_str(t: str) -> str:
+    if t in ("", "n/a", "none", None):
+        return "—"
+    return t
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--jsonl", required=True, type=Path)
+    p.add_argument("--output", required=True, type=Path)
+    p.add_argument("--network", default="testnet")
+    p.add_argument("--tag", default="(untagged)")
+    return p.parse_args()
+
+
+def load_rows(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                print(f"warning: skipping unparseable line: {exc}", file=sys.stderr)
+    return rows
+
+
+def sort_key(row: dict) -> tuple:
+    return (
+        CONTRACT_ORDER.get(row.get("contract", ""), 99),
+        OP_ORDER.get(row.get("op", ""), 99),
+        row.get("tier") or "",
+    )
+
+
+def build_table(rows: list[dict]) -> str:
+    headers = ["Contract", "Operation", "Tier", "Fee (XLM)", "Stroops",
+               "Inclusion", "Resource", "Refund"]
+    body = []
+    for row in sorted(rows, key=sort_key):
+        body.append([
+            row.get("contract", "?"),
+            row.get("op", "?"),
+            tier_str(row.get("tier", "")),
+            stroops_to_xlm(row.get("fee_stroops")),
+            fmt_stroops(row.get("fee_stroops")),
+            fmt_int(row.get("inclusion_fee")),
+            fmt_int(row.get("resource_fee")),
+            fmt_int(row.get("refundable_fee_refund")),
+        ])
+
+    widths = [
+        max(len(h), max((len(r[i]) for r in body), default=0))
+        for i, h in enumerate(headers)
+    ]
+
+    def fmt_row(cells: list[str]) -> str:
+        return "| " + " | ".join(c.ljust(widths[i]) for i, c in enumerate(cells)) + " |"
+
+    sep = "|-" + "-|-".join("-" * w for w in widths) + "-|"
+    lines = [fmt_row(headers), sep]
+    lines.extend(fmt_row(r) for r in body)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    rows = load_rows(args.jsonl)
+
+    captured_at = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    header = (
+        f"SEP MLS testnet gas benchmarks — {args.tag}\n"
+        f"Network: {args.network}    Captured: {captured_at}\n"
+        f"Total rows: {len(rows)}\n"
+        "\n"
+        "Notes:\n"
+        "  * Stroops are testnet stroops; 1 XLM = 10,000,000 stroops.\n"
+        "  * `verify_membership` rows are captured in revert-mode (well-\n"
+        "    formed proof, non-matching PI) where applicable; the verifier\n"
+        "    runs the full PLONK pairing check identically in success and\n"
+        "    failure paths, so the fee equals the success-path cost.\n"
+        "  * `update_commitment` revert-mode rows underestimate the true\n"
+        "    cost by ~1% — the post-verify storage writes (history archive\n"
+        "    + new entry + TTL bumps) are skipped on revert.\n"
+        "  * sep-anarchy / sep-democracy / sep-tyranny verifier ops are\n"
+        "    deferred to a follow-up release (require runtime proof gen).\n"
+    )
+
+    if not rows:
+        body = "(no rows captured)"
+    else:
+        body = build_table(rows)
+
+    args.output.write_text(header + "\n" + body + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench-gas/run.sh
+++ b/scripts/bench-gas/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Top-level driver: provisions identity + builds, then runs each
+# per-contract bench. Emits the JSONL row stream to $BENCH_JSONL
+# (default: scripts/bench-gas/results.jsonl).
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+BENCH_JSONL="${BENCH_JSONL:-$SCRIPT_DIR/results.jsonl}"
+BENCH_TABLE="${BENCH_TABLE:-$SCRIPT_DIR/results.txt}"
+export BENCH_JSONL
+
+: > "$BENCH_JSONL"
+
+# shellcheck source=setup.sh
+. "$SCRIPT_DIR/setup.sh"
+
+if [ "$#" -gt 0 ]; then
+    CONTRACTS=("$@")
+else
+    # Default ordering: contracts with the most ops first so the operator
+    # sees the meaty rows early and can ^C if RPC starts wobbling.
+    CONTRACTS=(sep-oneonone sep-oligarchy sep-anarchy sep-democracy sep-tyranny)
+fi
+
+for c in "${CONTRACTS[@]}"; do
+    driver="$SCRIPT_DIR/contracts/$c.sh"
+    if [ ! -f "$driver" ]; then
+        echo "no driver for $c at $driver" >&2
+        exit 1
+    fi
+    bash "$driver" || echo "    [$c] driver exited non-zero — continuing"
+done
+
+echo "==> rendering ASCII table → $BENCH_TABLE"
+python3 "$SCRIPT_DIR/render.py" \
+    --jsonl "$BENCH_JSONL" \
+    --output "$BENCH_TABLE" \
+    --network "$BENCH_NETWORK" \
+    --tag "${BENCH_TAG:-(untagged)}"
+
+echo
+echo "==> done"
+echo "    jsonl: $BENCH_JSONL"
+echo "    table: $BENCH_TABLE"

--- a/scripts/bench-gas/setup.sh
+++ b/scripts/bench-gas/setup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Provision the bench environment: deployer identity, friendbot fund,
+# contract builds. Idempotent — safe to re-run.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+BENCH_NETWORK="${BENCH_NETWORK:-testnet}"
+BENCH_DEPLOYER="${BENCH_DEPLOYER:-bench-gas-deployer}"
+BENCH_CONFIG_DIR="${BENCH_CONFIG_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-config.XXXXXX")}"
+BENCH_ARTIFACT_DIR="${BENCH_ARTIFACT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-artifacts.XXXXXX")}"
+
+export BENCH_NETWORK BENCH_DEPLOYER BENCH_CONFIG_DIR BENCH_ARTIFACT_DIR
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "missing required command: $1" >&2
+        exit 1
+    fi
+}
+require_cmd cargo
+require_cmd stellar
+require_cmd jq
+require_cmd xxd
+
+echo "==> bench config"
+echo "    network:      $BENCH_NETWORK"
+echo "    deployer:     $BENCH_DEPLOYER"
+echo "    config-dir:   $BENCH_CONFIG_DIR"
+echo "    artifact-dir: $BENCH_ARTIFACT_DIR"
+
+echo "==> deployer identity"
+if stellar keys public-key "$BENCH_DEPLOYER" --config-dir "$BENCH_CONFIG_DIR" >/dev/null 2>&1; then
+    echo "    reusing existing identity"
+else
+    stellar keys generate "$BENCH_DEPLOYER" \
+        --config-dir "$BENCH_CONFIG_DIR" \
+        --network "$BENCH_NETWORK" \
+        --overwrite >/dev/null
+    echo "    generated new identity"
+fi
+
+BENCH_DEPLOYER_ADDRESS="$(stellar keys public-key "$BENCH_DEPLOYER" --config-dir "$BENCH_CONFIG_DIR" | tr -d '\n')"
+export BENCH_DEPLOYER_ADDRESS
+
+echo "==> friendbot fund (best-effort)"
+stellar keys fund "$BENCH_DEPLOYER" \
+    --config-dir "$BENCH_CONFIG_DIR" \
+    --network "$BENCH_NETWORK" >/dev/null 2>&1 || \
+    echo "    (friendbot returned non-zero; proceeding — account may already be funded)"
+
+echo "==> building contracts"
+mkdir -p "$BENCH_ARTIFACT_DIR"
+for c in sep-anarchy sep-democracy sep-oligarchy sep-oneonone sep-tyranny; do
+    echo "    $c"
+    stellar contract build \
+        --manifest-path "$REPO_ROOT/contracts/$c/Cargo.toml" \
+        --out-dir "$BENCH_ARTIFACT_DIR" >/dev/null
+done
+
+echo "==> building proof-gen tools (gen-proof-tool feature)"
+cargo build --release \
+    --manifest-path "$REPO_ROOT/Cargo.toml" \
+    --features gen-proof-tool \
+    --bin gen-membership-proof \
+    --bin gen-update-proof >/dev/null 2>&1
+
+echo "==> setup complete"

--- a/scripts/bench-gas/setup.sh
+++ b/scripts/bench-gas/setup.sh
@@ -59,11 +59,9 @@ for c in sep-anarchy sep-democracy sep-oligarchy sep-oneonone sep-tyranny; do
         --out-dir "$BENCH_ARTIFACT_DIR" >/dev/null
 done
 
-echo "==> building proof-gen tools (gen-proof-tool feature)"
-cargo build --release \
-    --manifest-path "$REPO_ROOT/Cargo.toml" \
-    --features gen-proof-tool \
-    --bin gen-membership-proof \
-    --bin gen-update-proof >/dev/null 2>&1
+# V2 will compile `gen-membership-proof` / `gen-update-proof` here
+# once the deferred contract drivers consume them. V1 doesn't, so we
+# don't burn CI time on the `gen-proof-tool` feature build (and a
+# regression in those binaries can't fail the V1 bench).
 
 echo "==> setup complete"


### PR DESCRIPTION
## Summary

Standalone workflow that submits real testnet transactions for every benchable contract op, captures `fee_charged` via `stellar tx fetch fee`, renders an ASCII table, and uploads `gas-benchmarks-<tag>.{txt,jsonl}` as release assets.

Closes the gap PR #206 explicitly defers — the in-VM budget tracker numbers are lower bounds; this anchors against real WASM-on-chain costs.

## Trigger

Manual workflow dispatch only, matching the project's release convention:

```
gh workflow run "Release testnet gas benchmarks" -f tag=vX.Y.Z
```

The tag must already exist (the regular `Release` workflow creates it). This workflow only uploads — no commits, no version bumps.

## V1 coverage

| Contract | deploy | create_* | verify_membership | update_commitment | admin ops |
|---|:-:|:-:|:-:|:-:|:-:|
| sep-oneonone | ✓ | ✓ | (V2) | n/a | ✓ |
| sep-oligarchy | ✓ | ✓ | ✓ (revert) | ✓ (revert) | ✓ |
| sep-anarchy | ✓ | (V2) | (V2) | (V2) | ✓ |
| sep-democracy | ✓ | (V2) | (V2) | (V2) | ✓ |
| sep-tyranny | ✓ | (V2) | (V2) | (V2) | ✓ |

## Bench mechanics worth flagging

- `verify_membership` returns `Ok(false)` on `InvalidProof`, so the captured fee equals the success-path cost — the verifier runs the full PLONK pairing check identically in both arms
- `update_commitment` errors out on `InvalidProof`, so the tx reverts after the verifier. Captured fee misses the post-verify storage writes (history archive + new entry + TTL bumps), which PR #206 measured at ~75K CPU / ~75KB mem (≈1% of total). The release notes flag this caveat

## V2 follow-up

The 3 contracts deferred above need runtime proof generation via the existing \`gen-membership-proof\` / \`gen-update-proof\` binaries — none has a fixture-only path that produces a successful \`create_group\` from a fresh deploy. Plan documented in \`scripts/bench-gas/README.md\`.

## Test plan

- [ ] Land this draft, then run \`gh workflow run "Release testnet gas benchmarks" -f tag=v1.10.89\` against the existing tag for the first integration test
- [ ] Iterate on encoder edge cases (\`--<arg>-file-path\` formats for \`bool\`, \`u32\`, etc.) based on first run output
- [ ] Sanity-check the ASCII table shows non-zero fees for deploy + create_* + admin ops on the two covered contracts
- [ ] If the run is clean, file V2 issue with the runtime-proof-gen plan from the README

## Notes

- Stellar CLI pinned to v26.0.0 (matches the maintainer's local)
- Renderer smoke-tested locally with synthetic JSONL — output verified clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)