### PR TITLE
release-testnet-gas: override rust-toolchain.toml pin

### DIFF
--- a/.github/workflows/release-testnet-gas.yml
+++ b/.github/workflows/release-testnet-gas.yml
@@ -23,6 +23,14 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      # The repo's rust-toolchain.toml pins 1.88.0 (the version every
+      # mobile bundle and FFI surface compiles against), but
+      # `stellar contract build` pulls in soroban-sdk@26.0.0-rc.1
+      # which requires rustc 1.91.0. RUSTUP_TOOLCHAIN takes precedence
+      # over rust-toolchain.toml, so we override just for this job
+      # without touching the file every other CI path depends on.
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

First testnet-gas-bench run (https://github.com/rinat-enikeev/stellar-mls/actions/runs/25210503663) failed at \`stellar contract build\` because:

\`\`\`
error: rustc 1.88.0 is not supported by the following packages:
  soroban-sdk@26.0.0-rc.1 requires rustc 1.91.0
\`\`\`

The repo's \`rust-toolchain.toml\` pins 1.88.0 (every mobile bundle / FFI surface compiles against that). \`soroban-sdk@26.0.0-rc.1\` (a transitive dep of every contract crate) needs 1.91.0.

Set \`RUSTUP_TOOLCHAIN: stable\` at the bench-job scope — that takes precedence over \`rust-toolchain.toml\`, so this job uses stable while every other CI path keeps compiling against 1.88.0. Same pattern as the F-Droid metadata fix flagged in the project notes.

## Test plan

- [ ] Land + re-trigger \`gh workflow run "Release testnet gas benchmarks" -f tag=v1.10.90\`
- [ ] Confirm \`stellar contract build\` passes
- [ ] Continue iterating from the next failure point

🤖 Generated with [Claude Code](https://claude.com/claude-code)