### PR TITLE
bench-gas: fix BytesN encoding + markdown release body

### DIFF
--- a/.github/workflows/release-testnet-gas.yml
+++ b/.github/workflows/release-testnet-gas.yml
@@ -97,26 +97,22 @@ jobs:
                    scripts/bench-gas/contracts/*.sh
           bash scripts/bench-gas/run.sh
 
-      - name: Upload artifacts
+      - name: Upload workflow artifacts (raw JSONL + rendered body)
         uses: actions/upload-artifact@v4
         with:
           name: gas-benchmarks-${{ inputs.tag }}
           path: |
-            scripts/bench-gas/results.txt
+            scripts/bench-gas/results.md
             scripts/bench-gas/results.jsonl
           if-no-files-found: error
 
-      - name: Attach to GitHub release
-        env:
-          TAG: ${{ inputs.tag }}
-        run: |
-          cp scripts/bench-gas/results.txt   "gas-benchmarks-${TAG}.txt"
-          cp scripts/bench-gas/results.jsonl "gas-benchmarks-${TAG}.jsonl"
-
-      - uses: softprops/action-gh-release@v2
+      - name: Set release body to bench output
+        # Replaces the release body wholesale with the rendered
+        # markdown (table + contract addresses linking to
+        # stellar.expert). The raw JSONL is still attached as a
+        # workflow artifact for downstream tooling but no longer
+        # rides along on the release itself.
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag }}
-          files: |
-            gas-benchmarks-${{ inputs.tag }}.txt
-            gas-benchmarks-${{ inputs.tag }}.jsonl
-          fail_on_unmatched_files: true
+          body_path: scripts/bench-gas/results.md

--- a/scripts/bench-gas/contracts/sep-oligarchy.sh
+++ b/scripts/bench-gas/contracts/sep-oligarchy.sh
@@ -28,51 +28,28 @@ FIXTURE_DIR="$REPO_ROOT/contracts/plonk-verifier/tests/fixtures"
 
 export BENCH_CURRENT_CONTRACT="sep-oligarchy"
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-oligarchy.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT INT TERM
-
-# ---- encode fixtures ----
+# ---- precompute hex encodings ----
 # create PI: 6 fields × 32 = 192 bytes. PI = [commitment, be32(0),
 #     occ, admin_pubkey_commitment, group_id_fr, ?]; only PI[0..3]
 #     are validated against wire args.
-bin_to_hex_json "$FIXTURE_DIR/oligarchy-create-proof.bin"  "$WORK/create-proof.json"
-pi_concat_to_json "$FIXTURE_DIR/oligarchy-create-pi.bin" 6 "$WORK/create-pi.json"
-
+CREATE_PROOF_HEX="$(bin_hex "$FIXTURE_DIR/oligarchy-create-proof.bin")"
+CREATE_PI_JSON="$(pi_concat_json_array "$FIXTURE_DIR/oligarchy-create-pi.bin" 6)"
 CREATE_COMMITMENT_HEX="$(read_pi_field_hex "$FIXTURE_DIR/oligarchy-create-pi.bin" 0)"
-CREATE_OCC_HEX="$(read_pi_field_hex         "$FIXTURE_DIR/oligarchy-create-pi.bin" 2)"
-hex_to_json "$CREATE_COMMITMENT_HEX" "$WORK/create-commitment.json"
-hex_to_json "$CREATE_OCC_HEX"        "$WORK/create-occ.json"
+CREATE_OCC_HEX="$(read_pi_field_hex          "$FIXTURE_DIR/oligarchy-create-pi.bin" 2)"
 
 GROUP_ID_HEX="$(printf '07%.0s' $(seq 1 32))"
-hex_to_json "$GROUP_ID_HEX" "$WORK/group-id.json"
 
 # verify-membership PI (revert-mode): [state.commitment, be32(0)]
-ZERO32_HEX="$(printf '00%.0s' $(seq 1 32))"
-{
-    printf '['
-    printf '"%s",' "$CREATE_COMMITMENT_HEX"
-    printf '"%s"'  "$ZERO32_HEX"
-    printf ']'
-} > "$WORK/verify-pi.json"
+VERIFY_PI_JSON="[\"${CREATE_COMMITMENT_HEX}\",\"${ZERO32_HEX}\"]"
 
 # update_commitment PI (revert-mode): [c_old, be32(0), c_new, occ_old,
 #     occ_new, be32(threshold=1)]. c_new + occ_new are arbitrary
-#     canonical Fr (we use 0...01 and 0...02).
-ONE32_HEX="$(printf '%062d01' 0)"   # 32 bytes, last byte = 0x01
-TWO32_HEX="$(printf '%062d02' 0)"
-THRESHOLD_HEX="$(printf '%062d01' 0)"   # be32(1)
-{
-    printf '['
-    printf '"%s",' "$CREATE_COMMITMENT_HEX"
-    printf '"%s",' "$ZERO32_HEX"
-    printf '"%s",' "$ONE32_HEX"
-    printf '"%s",' "$CREATE_OCC_HEX"
-    printf '"%s",' "$TWO32_HEX"
-    printf '"%s"'  "$THRESHOLD_HEX"
-    printf ']'
-} > "$WORK/update-pi.json"
+#     canonical Fr (32-byte scalars, last byte ≠ 0).
+ONE32_HEX="${ZERO32_HEX:0:62}01"
+TWO32_HEX="${ZERO32_HEX:0:62}02"
+THRESHOLD_HEX="${ZERO32_HEX:0:62}01"
+UPDATE_PI_JSON="[\"${CREATE_COMMITMENT_HEX}\",\"${ZERO32_HEX}\",\"${ONE32_HEX}\",\"${CREATE_OCC_HEX}\",\"${TWO32_HEX}\",\"${THRESHOLD_HEX}\"]"
 
-# ---- deploy ----
 echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
 CID="$(bench_deploy \
     "bench-gas-oligarchy" \
@@ -85,43 +62,35 @@ if [ -z "$CID" ]; then
 fi
 echo "    contract: $CID"
 
-# ---- create_oligarchy_group (tier 0 from canonical fixture) ----
 echo "==> [$BENCH_CURRENT_CONTRACT] create_oligarchy_group(tier=0)"
 bench_invoke "$CID" "create_oligarchy_group" "0" "create_oligarchy_group" \
     --caller "$BENCH_DEPLOYER_ADDRESS" \
-    --group-id-file-path "$WORK/group-id.json" \
-    --commitment-file-path "$WORK/create-commitment.json" \
+    --group-id "$GROUP_ID_HEX" \
+    --commitment "$CREATE_COMMITMENT_HEX" \
     --member-tier 0 \
     --admin-threshold-numerator 1 \
-    --occupancy-commitment-initial-file-path "$WORK/create-occ.json" \
-    --proof-file-path "$WORK/create-proof.json" \
-    --public-inputs-file-path "$WORK/create-pi.json"
+    --occupancy-commitment-initial "$CREATE_OCC_HEX" \
+    --proof "$CREATE_PROOF_HEX" \
+    --public-inputs "$CREATE_PI_JSON"
 
-# ---- verify_membership (revert-mode; state matches, proof is well-
-#      formed but doesn't verify; verifier runs full pairing) ----
 echo "==> [$BENCH_CURRENT_CONTRACT] verify_membership(tier=0, revert-mode)"
 bench_invoke "$CID" "verify_membership" "0" "verify_membership" \
-    --group-id-file-path "$WORK/group-id.json" \
-    --proof-file-path "$WORK/create-proof.json" \
-    --public-inputs-file-path "$WORK/verify-pi.json"
+    --group-id "$GROUP_ID_HEX" \
+    --proof "$CREATE_PROOF_HEX" \
+    --public-inputs "$VERIFY_PI_JSON"
 
-# ---- update_commitment (revert-mode) ----
 echo "==> [$BENCH_CURRENT_CONTRACT] update_commitment(revert-mode)"
 bench_invoke "$CID" "update_commitment" "0" "update_commitment" \
-    --group-id-file-path "$WORK/group-id.json" \
-    --proof-file-path "$WORK/create-proof.json" \
-    --public-inputs-file-path "$WORK/update-pi.json"
+    --group-id "$GROUP_ID_HEX" \
+    --proof "$CREATE_PROOF_HEX" \
+    --public-inputs "$UPDATE_PI_JSON"
 
-# ---- admin / utility ops ----
 echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
 bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \
     --restricted true
 
 echo "==> [$BENCH_CURRENT_CONTRACT] bump_group_ttl"
 bench_invoke "$CID" "bump_group_ttl" "n/a" "bump_group_ttl" \
-    --group-id-file-path "$WORK/group-id.json"
-
-# Read-only entrypoints (`get_commitment`, `get_history`) are skipped
-# intentionally — see sep-oneonone.sh for the reason.
+    --group-id "$GROUP_ID_HEX"
 
 echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/contracts/sep-oneonone.sh
+++ b/scripts/bench-gas/contracts/sep-oneonone.sh
@@ -22,26 +22,12 @@ FIXTURE_DIR="$REPO_ROOT/contracts/plonk-verifier/tests/fixtures"
 
 export BENCH_CURRENT_CONTRACT="sep-oneonone"
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-oneonone.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT INT TERM
-
-# ---- encode fixtures into CLI-ready JSON files ----
-# Constructor: (admin: Address) — no fixture args.
-#
-# create_group(caller, group_id, commitment, proof: BytesN<1601>,
-#              public_inputs: Vec<BytesN<32>>)
-# PI layout (2 fields × 32 bytes): [commitment, be32(epoch=0)]
-# Total file size: 64 bytes.
-bin_to_hex_json "$FIXTURE_DIR/oneonone-create-proof.bin" "$WORK/create-proof.json"
-pi_concat_to_json "$FIXTURE_DIR/oneonone-create-pi.bin" 2 "$WORK/create-pi.json"
-
+# ---- precompute hex encodings (no temp files; CLI takes hex inline) ----
+CREATE_PROOF_HEX="$(bin_hex "$FIXTURE_DIR/oneonone-create-proof.bin")"
+CREATE_PI_JSON="$(pi_concat_json_array "$FIXTURE_DIR/oneonone-create-pi.bin" 2)"
 CREATE_COMMITMENT_HEX="$(read_pi_field_hex "$FIXTURE_DIR/oneonone-create-pi.bin" 0)"
-hex_to_json "$CREATE_COMMITMENT_HEX" "$WORK/create-commitment.json"
-
 GROUP_ID_HEX="$(printf '42%.0s' $(seq 1 32))"
-hex_to_json "$GROUP_ID_HEX" "$WORK/group-id.json"
 
-# ---- deploy ----
 echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
 CID="$(bench_deploy \
     "bench-gas-oneonone" \
@@ -54,28 +40,24 @@ if [ -z "$CID" ]; then
 fi
 echo "    contract: $CID"
 
-# ---- create_group ----
 echo "==> [$BENCH_CURRENT_CONTRACT] create_group"
 bench_invoke "$CID" "create_group" "n/a" "create_group" \
     --caller "$BENCH_DEPLOYER_ADDRESS" \
-    --group-id-file-path "$WORK/group-id.json" \
-    --commitment-file-path "$WORK/create-commitment.json" \
-    --proof-file-path "$WORK/create-proof.json" \
-    --public-inputs-file-path "$WORK/create-pi.json"
+    --group-id "$GROUP_ID_HEX" \
+    --commitment "$CREATE_COMMITMENT_HEX" \
+    --proof "$CREATE_PROOF_HEX" \
+    --public-inputs "$CREATE_PI_JSON"
 
-# ---- set_restricted_mode (admin op, on then off) ----
 echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
 bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \
     --restricted true
 
-# ---- bump_group_ttl ----
 echo "==> [$BENCH_CURRENT_CONTRACT] bump_group_ttl"
 bench_invoke "$CID" "bump_group_ttl" "n/a" "bump_group_ttl" \
-    --group-id-file-path "$WORK/group-id.json"
+    --group-id "$GROUP_ID_HEX"
 
-# Read-only entrypoints (`get_commitment`, `get_history`) are skipped
-# intentionally — `stellar contract invoke` short-circuits to a local
-# simulation for them regardless of `--send yes`, so no tx is submitted
-# and no fee is charged.
+# Read-only entrypoints (`get_commitment`) are skipped — the CLI
+# short-circuits to local simulation regardless of `--send yes`, so
+# no tx is submitted and no fee is charged.
 
 echo "==> [$BENCH_CURRENT_CONTRACT] done"

--- a/scripts/bench-gas/lib.sh
+++ b/scripts/bench-gas/lib.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Shared helpers for the testnet gas benchmark suite.
 #
-# Encoding contract:
-#   `stellar contract invoke` accepts `--<arg>-file-path <PATH>` for any
-#   typed arg, where the file contains a JSON value matching the
-#   contract's schema:
-#     - BytesN<N>          → JSON string of N hex chars × 2: `"<hex>"`
-#     - Vec<BytesN<32>>    → JSON array of hex strings:        `["<hex>", ...]`
+# Encoding contract (corrected after the v1 run on testnet showed the
+# CLI receiving JSON-wrapped hex as raw bytes):
+#   * `--<arg>-file-path <PATH>` reads the file as **raw bytes** and
+#     binds them as the arg value. Useful only for binary-shaped types
+#     when you have a binary file to feed in.
+#   * For `BytesN<N>` we pass `--<arg> <hex>` inline (CLI parses hex
+#     into the typed BytesN). Inline length is fine for proofs at
+#     1601 bytes (~3KB hex on a Linux ARG_MAX of 128KB+).
+#   * For `Vec<BytesN<32>>` we pass `--<arg> '<json_array>'` inline
+#     (CLI parses JSON array of hex strings into the typed Vec).
 #
 # Fee capture: `stellar contract invoke` (default --send=yes) prints
 # the tx hash to stderr in the line `ℹ Transaction hash is <hex>`. We
@@ -19,42 +23,35 @@
 set -euo pipefail
 
 # ---------- low-level encoders ----------
+# All encoders return hex (or JSON arrays of hex) on stdout — callers
+# splice the value into the CLI invocation directly. No more temp
+# files holding JSON-wrapped values; the v1 run proved the CLI's
+# --<arg>-file-path treats the file as raw bytes regardless of
+# extension, so JSON wrappers leaked through to the contract as
+# literal `"<hex>"` byte strings.
 
-# bin_to_hex_json <input.bin> <output.json>
-# Wraps raw bytes as `"<hex>"` (a JSON string). Suitable for BytesN<N>.
-bin_to_hex_json() {
-    local in="$1"
-    local out="$2"
-    local hex
-    hex="$(xxd -p -c 99999 "$in" | tr -d '\n')"
-    printf '"%s"' "$hex" > "$out"
+# bin_hex <input.bin>
+# Echoes raw bytes hex-encoded (no `0x`, no quotes, no newline).
+# Suitable for `--<arg> $(bin_hex …)` where the arg is BytesN<N>.
+bin_hex() {
+    xxd -p -c 99999 "$1" | tr -d '\n'
 }
 
-# pi_concat_to_json <input.bin> <num_fields> <output.json>
-# Splits a flat 32*N byte file into a JSON array of N hex-encoded
-# 32-byte chunks. Suitable for Vec<BytesN<32>>.
-pi_concat_to_json() {
+# pi_concat_json_array <input.bin> <num_fields>
+# Splits a flat 32*N byte file into a JSON array of N hex strings.
+# Suitable for `--<arg> "$(pi_concat_json_array … )"` where the arg is
+# Vec<BytesN<32>>.
+pi_concat_json_array() {
     local in="$1"
     local n="$2"
-    local out="$3"
     local i hex
-    {
-        printf '['
-        for (( i=0; i<n; i++ )); do
-            hex="$(dd if="$in" bs=32 skip="$i" count=1 2>/dev/null | xxd -p -c 99999 | tr -d '\n')"
-            if (( i > 0 )); then printf ','; fi
-            printf '"%s"' "$hex"
-        done
-        printf ']'
-    } > "$out"
-}
-
-# hex_to_json <hex_string> <output.json>
-# Wraps a hex string (no 0x prefix) as a JSON BytesN value.
-hex_to_json() {
-    local hex="$1"
-    local out="$2"
-    printf '"%s"' "$hex" > "$out"
+    printf '['
+    for (( i=0; i<n; i++ )); do
+        hex="$(dd if="$in" bs=32 skip="$i" count=1 2>/dev/null | xxd -p -c 99999 | tr -d '\n')"
+        if (( i > 0 )); then printf ','; fi
+        printf '"%s"' "$hex"
+    done
+    printf ']'
 }
 
 # read_pi_field_hex <pi.bin> <field_index>
@@ -65,12 +62,8 @@ read_pi_field_hex() {
     dd if="$pi" bs=32 skip="$i" count=1 2>/dev/null | xxd -p -c 99999 | tr -d '\n'
 }
 
-# be32_zero_json <output.json>
-# JSON for 32 zero bytes (= big-endian repr of u64 zero, used for epoch=0).
-be32_zero_json() {
-    local out="$1"
-    printf '"%s"' "$(printf '%064d' 0)" > "$out"
-}
+# Constants used across drivers.
+ZERO32_HEX="$(printf '%064d' 0)"
 
 # ---------- invocation + fee capture ----------
 
@@ -125,6 +118,23 @@ fetch_fee_full() {
     stellar tx fetch fee --hash "$hash" --output json "${rpc_args[@]}"
 }
 
+# emit_contract_address <contract> <address>
+# One row per deployed contract — the renderer pulls these into the
+# stellar.expert link table at the top of the release body.
+emit_contract_address() {
+    local contract="$1"
+    local address="$2"
+    if [ -z "$address" ]; then
+        return 0
+    fi
+    jq -n \
+        --arg row_type "contract" \
+        --arg contract "$contract" \
+        --arg address "$address" \
+        '{row_type: $row_type, contract: $contract, address: $address}' \
+        >> "$BENCH_JSONL"
+}
+
 # emit_row <contract> <op> <tier> <hash> [extra_json]
 # Append a JSONL row to $BENCH_JSONL with fee + cost data for the tx.
 emit_row() {
@@ -135,14 +145,17 @@ emit_row() {
     local extra="${5:-{\}}"
 
     if [ -z "$hash" ]; then
-        # Fee capture failed (often: tx wasn't submitted, e.g. read-only).
-        # Emit a row with null fee fields so the renderer can flag it.
+        # Fee capture failed (the tx wasn't submitted — most often the
+        # CLI rejected it at simulation time, or it's a read-only
+        # entrypoint that short-circuits to local sim). Emit a row
+        # with null fee fields so the renderer can flag it.
         jq -n \
+            --arg row_type "op" \
             --arg contract "$contract" \
             --arg op "$op" \
             --arg tier "$tier" \
             --argjson extra "$extra" \
-            '{contract: $contract, op: $op, tier: $tier, fee_stroops: null, hash: null} + $extra' \
+            '{row_type: $row_type, contract: $contract, op: $op, tier: $tier, fee_stroops: null, hash: null} + $extra' \
             >> "$BENCH_JSONL"
         return 0
     fi
@@ -150,13 +163,14 @@ emit_row() {
     local raw
     raw="$(fetch_fee_full "$hash" || echo '{}')"
     jq -n \
+        --arg row_type "op" \
         --arg contract "$contract" \
         --arg op "$op" \
         --arg tier "$tier" \
         --arg hash "$hash" \
         --argjson raw "$raw" \
         --argjson extra "$extra" \
-        '{contract: $contract, op: $op, tier: $tier, hash: $hash,
+        '{row_type: $row_type, contract: $contract, op: $op, tier: $tier, hash: $hash,
           fee_stroops: ($raw.totals.fee_charged // $raw.fee_charged // null),
           inclusion_fee: ($raw.totals.inclusion_fee // null),
           resource_fee: ($raw.totals.resource_fee // null),
@@ -201,6 +215,7 @@ bench_deploy() {
 
     emit_row "$BENCH_CURRENT_CONTRACT" "deploy_upload" "n/a" "$upload_hash"
     emit_row "$BENCH_CURRENT_CONTRACT" "deploy_create" "n/a" "$create_hash"
+    emit_contract_address "$BENCH_CURRENT_CONTRACT" "$cid"
     printf '%s' "$cid"
 }
 

--- a/scripts/bench-gas/render.py
+++ b/scripts/bench-gas/render.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Render the bench JSONL into an ASCII table for the GitHub release.
+"""Render the bench JSONL into a Markdown release body.
 
 Input:  one JSON object per line, schema produced by `lib.sh`'s
-        `emit_row` (contract, op, tier, fee_stroops, hash, ...).
-Output: a single ASCII table; rows sorted by (contract, op, tier),
-        XLM = stroops / 10_000_000 with 7 decimal places.
+        `emit_row` (row_type=op) + `emit_contract_address`
+        (row_type=contract).
+Output: a single Markdown document — contract-address table (with
+        stellar.expert links) above the gas table.
+
+The workflow uses this output directly as the GitHub release body
+(`body_path:` for softprops/action-gh-release@v2), not as an asset.
 """
 from __future__ import annotations
 
@@ -23,14 +27,21 @@ CONTRACT_ORDER = {
 }
 
 OP_ORDER = {
-    "deploy": 0,
-    "create_group": 1,
-    "create_oligarchy_group": 1,
-    "verify_membership": 2,
-    "update_commitment": 3,
+    "deploy_upload": 0,
+    "deploy_create": 1,
+    "deploy": 1,  # legacy single-row path; kept so older JSONL still sorts
+    "create_group": 2,
+    "create_oligarchy_group": 2,
+    "verify_membership": 3,
+    "update_commitment": 4,
     "set_restricted_mode": 10,
     "bump_group_ttl": 11,
-    "get_commitment": 12,
+}
+
+NETWORK_TO_EXPERT = {
+    "testnet": "https://stellar.expert/explorer/testnet",
+    "public": "https://stellar.expert/explorer/public",
+    "mainnet": "https://stellar.expert/explorer/public",
 }
 
 
@@ -67,21 +78,30 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def load_rows(path: Path) -> list[dict]:
-    rows: list[dict] = []
+def load_rows(path: Path) -> tuple[list[dict], list[dict]]:
+    """Returns (op_rows, contract_rows)."""
+    op_rows: list[dict] = []
+    contract_rows: list[dict] = []
     with path.open() as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
             try:
-                rows.append(json.loads(line))
+                row = json.loads(line)
             except json.JSONDecodeError as exc:
                 print(f"warning: skipping unparseable line: {exc}", file=sys.stderr)
-    return rows
+                continue
+            row_type = row.get("row_type")
+            if row_type == "contract":
+                contract_rows.append(row)
+            else:
+                # row_type=op or absent (legacy schema)
+                op_rows.append(row)
+    return op_rows, contract_rows
 
 
-def sort_key(row: dict) -> tuple:
+def sort_op(row: dict) -> tuple:
     return (
         CONTRACT_ORDER.get(row.get("contract", ""), 99),
         OP_ORDER.get(row.get("op", ""), 99),
@@ -89,67 +109,99 @@ def sort_key(row: dict) -> tuple:
     )
 
 
-def build_table(rows: list[dict]) -> str:
-    headers = ["Contract", "Operation", "Tier", "Fee (XLM)", "Stroops",
-               "Inclusion", "Resource", "Refund"]
-    body = []
-    for row in sorted(rows, key=sort_key):
-        body.append([
-            row.get("contract", "?"),
-            row.get("op", "?"),
+def sort_contract(row: dict) -> int:
+    return CONTRACT_ORDER.get(row.get("contract", ""), 99)
+
+
+def truncate_addr(addr: str) -> str:
+    if len(addr) <= 16:
+        return addr
+    return f"{addr[:6]}…{addr[-6:]}"
+
+
+def build_contract_table(contract_rows: list[dict], network: str) -> str:
+    if not contract_rows:
+        return "_(no contracts deployed)_"
+
+    expert = NETWORK_TO_EXPERT.get(network, NETWORK_TO_EXPERT["testnet"])
+    lines = [
+        "| Contract | Address |",
+        "|---|---|",
+    ]
+    for row in sorted(contract_rows, key=sort_contract):
+        addr = row.get("address", "")
+        contract = row.get("contract", "?")
+        if not addr:
+            lines.append(f"| `{contract}` | _(deploy failed)_ |")
+            continue
+        link = f"[`{truncate_addr(addr)}`]({expert}/contract/{addr})"
+        lines.append(f"| `{contract}` | {link} |")
+    return "\n".join(lines)
+
+
+def build_gas_table(op_rows: list[dict]) -> str:
+    if not op_rows:
+        return "_(no transactions submitted)_"
+
+    headers = ["Contract", "Operation", "Tier", "Fee (XLM)",
+               "Stroops", "Inclusion", "Resource", "Refund"]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join("---" for _ in headers) + "|",
+    ]
+    for row in sorted(op_rows, key=sort_op):
+        cells = [
+            f"`{row.get('contract', '?')}`",
+            f"`{row.get('op', '?')}`",
             tier_str(row.get("tier", "")),
             stroops_to_xlm(row.get("fee_stroops")),
             fmt_stroops(row.get("fee_stroops")),
             fmt_int(row.get("inclusion_fee")),
             fmt_int(row.get("resource_fee")),
             fmt_int(row.get("refundable_fee_refund")),
-        ])
-
-    widths = [
-        max(len(h), max((len(r[i]) for r in body), default=0))
-        for i, h in enumerate(headers)
-    ]
-
-    def fmt_row(cells: list[str]) -> str:
-        return "| " + " | ".join(c.ljust(widths[i]) for i, c in enumerate(cells)) + " |"
-
-    sep = "|-" + "-|-".join("-" * w for w in widths) + "-|"
-    lines = [fmt_row(headers), sep]
-    lines.extend(fmt_row(r) for r in body)
+        ]
+        lines.append("| " + " | ".join(cells) + " |")
     return "\n".join(lines)
 
 
 def main() -> int:
     args = parse_args()
-    rows = load_rows(args.jsonl)
+    op_rows, contract_rows = load_rows(args.jsonl)
 
     captured_at = datetime.datetime.now(datetime.timezone.utc).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
-    header = (
-        f"SEP MLS testnet gas benchmarks — {args.tag}\n"
-        f"Network: {args.network}    Captured: {captured_at}\n"
-        f"Total rows: {len(rows)}\n"
-        "\n"
-        "Notes:\n"
-        "  * Stroops are testnet stroops; 1 XLM = 10,000,000 stroops.\n"
-        "  * `verify_membership` rows are captured in revert-mode (well-\n"
-        "    formed proof, non-matching PI) where applicable; the verifier\n"
-        "    runs the full PLONK pairing check identically in success and\n"
-        "    failure paths, so the fee equals the success-path cost.\n"
-        "  * `update_commitment` revert-mode rows underestimate the true\n"
-        "    cost by ~1% — the post-verify storage writes (history archive\n"
-        "    + new entry + TTL bumps) are skipped on revert.\n"
-        "  * sep-anarchy / sep-democracy / sep-tyranny verifier ops are\n"
-        "    deferred to a follow-up release (require runtime proof gen).\n"
-    )
 
-    if not rows:
-        body = "(no rows captured)"
-    else:
-        body = build_table(rows)
+    body_lines = [
+        f"# SEP MLS testnet gas benchmarks — {args.tag}",
+        "",
+        f"- **Network:** {args.network}",
+        f"- **Captured:** {captured_at}",
+        f"- **Op rows:** {len(op_rows)}    **Contracts deployed:** {len(contract_rows)}",
+        "",
+        "## Deployed contracts",
+        "",
+        build_contract_table(contract_rows, args.network),
+        "",
+        "## Per-op gas costs",
+        "",
+        build_gas_table(op_rows),
+        "",
+        "## Notes",
+        "",
+        "- Stroops are testnet stroops; 1 XLM = 10,000,000 stroops.",
+        "- `verify_membership` rows are captured in revert-mode (well-formed proof, "
+        "non-matching PI) where applicable; the verifier runs the full PLONK pairing "
+        "check identically in success and failure paths, so the fee equals the "
+        "success-path cost.",
+        "- `update_commitment` revert-mode rows underestimate the true cost by ~1% — "
+        "the post-verify storage writes (history archive + new entry + TTL bumps) "
+        "are skipped on revert.",
+        "- sep-anarchy / sep-democracy / sep-tyranny verifier ops are deferred to a "
+        "follow-up release (require runtime proof gen).",
+    ]
 
-    args.output.write_text(header + "\n" + body + "\n")
+    args.output.write_text("\n".join(body_lines) + "\n")
     return 0
 
 

--- a/scripts/bench-gas/run.sh
+++ b/scripts/bench-gas/run.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
 BENCH_JSONL="${BENCH_JSONL:-$SCRIPT_DIR/results.jsonl}"
-BENCH_TABLE="${BENCH_TABLE:-$SCRIPT_DIR/results.txt}"
+BENCH_BODY="${BENCH_BODY:-$SCRIPT_DIR/results.md}"
 export BENCH_JSONL
 
 : > "$BENCH_JSONL"
@@ -32,14 +32,14 @@ for c in "${CONTRACTS[@]}"; do
     bash "$driver" || echo "    [$c] driver exited non-zero — continuing"
 done
 
-echo "==> rendering ASCII table → $BENCH_TABLE"
+echo "==> rendering markdown release body → $BENCH_BODY"
 python3 "$SCRIPT_DIR/render.py" \
     --jsonl "$BENCH_JSONL" \
-    --output "$BENCH_TABLE" \
+    --output "$BENCH_BODY" \
     --network "$BENCH_NETWORK" \
     --tag "${BENCH_TAG:-(untagged)}"
 
 echo
 echo "==> done"
 echo "    jsonl: $BENCH_JSONL"
-echo "    table: $BENCH_TABLE"
+echo "    body:  $BENCH_BODY"


### PR DESCRIPTION
## What broke

First testnet run on v1.10.91 (https://github.com/rinat-enikeev/stellar-mls/releases/tag/v1.10.91) deployed all 5 contracts but every op beyond `set_restricted_mode` failed at simulation with `UnreachableCodeReached`. Diagnostic events showed the contract receiving:

```
Bytes(2235626664326636…2231…)   // ASCII: "5bfd2f6...1"
```

— literally the JSON-quoted hex string, not the typed BytesN. I had assumed `stellar contract invoke --<arg>-file-path` took JSON, but it reads the file as raw bytes.

## Fix

- BytesN<N> args: `--<arg> <hex>` inline (CLI parses hex into typed BytesN)
- Vec<BytesN<32>> args: `--<arg> <json_array>` inline
- Dropped all the JSON-wrapper temp files

Inline hex for the 1601-byte proof = ~3KB of arg, well under Linux's 128KB+ ARG_MAX.

## Release body change

Per @rinat-enikeev's feedback: the table + contract addresses go in the release description, not as a `.txt` asset. Renderer now emits markdown with two sections:

1. **Deployed contracts** — each contract row links to its stellar.expert testnet page
2. **Per-op gas costs** — same gas data, markdown-formatted

Workflow uses the rendered markdown as `body_path:` for `softprops/action-gh-release@v2`. Raw JSONL still attached as a workflow artifact for downstream tooling, but doesn't ride along on the release.

## Other clean-ups

- JSONL rows tagged with `row_type` (`contract` vs `op`) for deterministic split
- `bench_deploy` calls `emit_contract_address` after the hashes — the contract address shows up in the release body even if a later op on the same contract fails

## Smoke test

Renderer + new schema verified locally with synthetic JSONL — output renders the contract-address table with proper stellar.expert links and the gas table sorts cleanly.

## Test plan

- [ ] Land + retrigger workflow on the new release tag
- [ ] Confirm op rows now appear (no more `UnreachableCodeReached` at simulation)
- [ ] Confirm release body contains both tables, with stellar.expert links resolving

🤖 Generated with [Claude Code](https://claude.com/claude-code)