### PR TITLE
bench-gas: one-line JSONL, match v26 CLI output, drop update_commitment from V1

### DIFF
--- a/scripts/bench-gas/README.md
+++ b/scripts/bench-gas/README.md
@@ -45,21 +45,23 @@ Outputs land under `scripts/bench-gas/results.{txt,jsonl}`.
 | Contract       | deploy | create_* | verify_membership | update_commitment | admin ops |
 |----------------|:------:|:--------:|:-----------------:|:-----------------:|:---------:|
 | sep-oneonone   | ✓      | ✓        | (V2)              | n/a               | ✓         |
-| sep-oligarchy  | ✓      | ✓        | ✓ (revert-mode)   | ✓ (revert-mode)   | ✓         |
+| sep-oligarchy  | ✓      | ✓        | ✓ (revert-mode)   | (V2)              | ✓         |
 | sep-anarchy    | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
 | sep-democracy  | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
 | sep-tyranny    | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
 
 ### Bench mechanics
 
-* **`verify_membership`** returns `Ok(false)` on `InvalidProof`, so
-  the captured fee equals the success-path cost — the verifier runs
-  the full PLONK pairing check identically in both arms.
+* **`verify_membership`** returns `Ok(false)` on `InvalidProof` (no
+  revert), so we can submit a well-formed non-verifying proof, the
+  verifier runs the full PLONK pairing check, the function returns
+  `Ok(false)`, and the captured fee equals the real success-path
+  cost.
 * **`update_commitment`** errors out on `InvalidProof`, so the tx
-  reverts after the verifier. The captured fee misses the
-  post-verify storage writes (history archive + new entry + TTL
-  bumps), which PR #206 measured at ~75K CPU / ~75KB mem (≈1% of
-  total). The release notes flag this caveat.
+  would revert. Soroban-CLI runs simulation pre-flight and refuses
+  to submit reverting txs — so a non-verifying proof can't capture
+  a fee for this entrypoint. Deferred to V2 (real verifying proofs
+  via `gen-update-proof`).
 
 ## V2 follow-up
 

--- a/scripts/bench-gas/contracts/sep-oligarchy.sh
+++ b/scripts/bench-gas/contracts/sep-oligarchy.sh
@@ -4,17 +4,19 @@
 # Coverage (V1):
 #   deploy, create_oligarchy_group (committed fixture, tier 0),
 #   verify_membership (revert-mode against post-create state),
-#   update_commitment (revert-mode against post-create state),
 #   set_restricted_mode, bump_group_ttl.
 #
 # Bench mechanics:
 #   * verify_membership returns Ok(false) on InvalidProof (no revert),
 #     so the captured fee equals the real success-path cost — the
 #     verifier runs the full pairing check identically in both arms.
-#   * update_commitment errors out on InvalidProof, so the tx reverts
-#     after the verifier. The fee misses the post-verify storage
-#     writes (history archive + new entry + TTL bumps), which PR #206
-#     measured at ~75K CPU / ~75KB mem (≈1% of total).
+#
+# Out of scope (V2):
+#   update_commitment — first run showed Soroban-CLI runs simulation
+#   pre-flight and refuses to submit txs that revert, so revert-mode
+#   bench can't capture a fee for ops whose contract path returns
+#   Err. Need real verifying proofs from gen-update-proof; tracked
+#   alongside the V2 anarchy/democracy/tyranny work.
 
 set -euo pipefail
 
@@ -41,14 +43,6 @@ GROUP_ID_HEX="$(printf '07%.0s' $(seq 1 32))"
 
 # verify-membership PI (revert-mode): [state.commitment, be32(0)]
 VERIFY_PI_JSON="[\"${CREATE_COMMITMENT_HEX}\",\"${ZERO32_HEX}\"]"
-
-# update_commitment PI (revert-mode): [c_old, be32(0), c_new, occ_old,
-#     occ_new, be32(threshold=1)]. c_new + occ_new are arbitrary
-#     canonical Fr (32-byte scalars, last byte ≠ 0).
-ONE32_HEX="${ZERO32_HEX:0:62}01"
-TWO32_HEX="${ZERO32_HEX:0:62}02"
-THRESHOLD_HEX="${ZERO32_HEX:0:62}01"
-UPDATE_PI_JSON="[\"${CREATE_COMMITMENT_HEX}\",\"${ZERO32_HEX}\",\"${ONE32_HEX}\",\"${CREATE_OCC_HEX}\",\"${TWO32_HEX}\",\"${THRESHOLD_HEX}\"]"
 
 echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
 CID="$(bench_deploy \
@@ -79,11 +73,9 @@ bench_invoke "$CID" "verify_membership" "0" "verify_membership" \
     --proof "$CREATE_PROOF_HEX" \
     --public-inputs "$VERIFY_PI_JSON"
 
-echo "==> [$BENCH_CURRENT_CONTRACT] update_commitment(revert-mode)"
-bench_invoke "$CID" "update_commitment" "0" "update_commitment" \
-    --group-id "$GROUP_ID_HEX" \
-    --proof "$CREATE_PROOF_HEX" \
-    --public-inputs "$UPDATE_PI_JSON"
+# update_commitment is V2 — see header. Soroban-CLI rejects
+# simulation-failing txs before submission, so a "well-formed but
+# non-verifying proof" path doesn't capture a fee.
 
 echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
 bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \

--- a/scripts/bench-gas/lib.sh
+++ b/scripts/bench-gas/lib.sh
@@ -68,17 +68,22 @@ ZERO32_HEX="$(printf '%064d' 0)"
 # ---------- invocation + fee capture ----------
 
 # capture_tx_hashes <stderr_logfile>
-# Echoes every transaction hash the stellar CLI logged, one per line,
-# in the order they were submitted. Anchored on the `Transaction hash
-# is <hex>` prefix to avoid matching wasm hashes, contract IDs, or
-# error blobs that happen to contain a 64-char hex run.
+# Echoes every successfully-submitted transaction hash the stellar
+# CLI logged, one per line, in submission order. Anchored on the
+# stellar.expert URL line, which v26 prints only after the network
+# accepts the tx — so simulation-failed ops that never hit chain are
+# correctly skipped.
 #
 # `stellar contract deploy` submits two txs (upload_contract_wasm +
 # create_contract); a normal invoke submits one. Callers pick by
 # index.
+#
+# v26 sample lines this matches (one per accepted tx):
+#   🔗 https://stellar.expert/explorer/testnet/tx/<64-hex>
 capture_tx_hashes() {
     local err="$1"
-    grep -oE 'Transaction hash is [0-9a-f]{64}' "$err" | awk '{print $4}'
+    grep -oE 'stellar\.expert/explorer/[a-z]+/tx/[0-9a-f]{64}' "$err" \
+        | grep -oE '[0-9a-f]{64}'
 }
 
 # capture_tx_hash <stderr_logfile>
@@ -127,7 +132,7 @@ emit_contract_address() {
     if [ -z "$address" ]; then
         return 0
     fi
-    jq -n \
+    jq -nc \
         --arg row_type "contract" \
         --arg contract "$contract" \
         --arg address "$address" \
@@ -149,7 +154,7 @@ emit_row() {
         # CLI rejected it at simulation time, or it's a read-only
         # entrypoint that short-circuits to local sim). Emit a row
         # with null fee fields so the renderer can flag it.
-        jq -n \
+        jq -nc \
             --arg row_type "op" \
             --arg contract "$contract" \
             --arg op "$op" \
@@ -162,7 +167,7 @@ emit_row() {
 
     local raw
     raw="$(fetch_fee_full "$hash" || echo '{}')"
-    jq -n \
+    jq -nc \
         --arg row_type "op" \
         --arg contract "$contract" \
         --arg op "$op" \

--- a/scripts/bench-gas/render.py
+++ b/scripts/bench-gas/render.py
@@ -191,12 +191,13 @@ def main() -> int:
         "",
         "- Stroops are testnet stroops; 1 XLM = 10,000,000 stroops.",
         "- `verify_membership` rows are captured in revert-mode (well-formed proof, "
-        "non-matching PI) where applicable; the verifier runs the full PLONK pairing "
-        "check identically in success and failure paths, so the fee equals the "
-        "success-path cost.",
-        "- `update_commitment` revert-mode rows underestimate the true cost by ~1% — "
-        "the post-verify storage writes (history archive + new entry + TTL bumps) "
-        "are skipped on revert.",
+        "non-matching PI) where applicable; the verifier returns `Ok(false)` on "
+        "`InvalidProof` (no revert), so the verifier runs the full PLONK pairing "
+        "check and the fee equals the success-path cost.",
+        "- `update_commitment` is deferred to V2 — Soroban-CLI runs simulation "
+        "pre-flight and won't submit txs that revert, so a non-verifying proof "
+        "can't capture a fee. V2 will use `gen-update-proof` to produce real "
+        "verifying proofs.",
         "- sep-anarchy / sep-democracy / sep-tyranny verifier ops are deferred to a "
         "follow-up release (require runtime proof gen).",
     ]


### PR DESCRIPTION
## What v1.10.92 surfaced

Workflow ran clean, but the [release body](https://github.com/rinat-enikeev/stellar-mls/releases/tag/v1.10.92) showed **0 op rows / 0 contracts**. Pulling the workflow artifact JSONL revealed the data WAS being emitted — 22 op rows + 5 contract rows — but every row had `fee_stroops: null` and `hash: null`, and each row was pretty-printed across 7-9 lines.

## Root causes

### 1. JSONL was multi-line
`jq -n` pretty-prints by default → renderer's "one JSON per line" parser skipped every row. Switch to `jq -nc`.

### 2. Hash regex didn't match CLI v26 output
v26 doesn't print \`Transaction hash is <hex>\`. It prints:

\`\`\`
ℹ️  Signing transaction: <hex>
🌎 Sending transaction…
✅ Transaction submitted successfully!
🔗 https://stellar.expert/explorer/testnet/tx/<hex>
\`\`\`

Switched to grepping the \`stellar.expert/.../tx/<hex>\` URL — it's only emitted *after* the network accepts the tx, so simulation-failed ops that never reach chain are correctly skipped.

### 3. \`update_commitment\` revert-mode is unreachable
Soroban-CLI runs simulation pre-flight and refuses to submit txs that revert. A non-verifying proof reverts at simulation → CLI never submits → no on-chain tx → no fee. Drop the entrypoint from V1.

\`verify_membership\` stays — it returns \`Ok(false)\` on \`InvalidProof\` (no revert), so simulation succeeds, the verifier runs the full PLONK pairing check, and the captured fee equals the success-path cost.

## On the user's \`Error(Contract, #12)\` question

That was \`ProofReplay\`. The driver re-used \`oligarchy-create-proof.bin\` for both create and update, and create's \`record_proof\` made it a replay for update. Self-inflicted, but moot once update_commitment is out of V1 scope.

## Test plan

- [ ] Land + retrigger
- [ ] Confirm \`fee_stroops\` populated for deploy_upload / deploy_create / create_group / create_oligarchy_group / verify_membership / set_restricted_mode / bump_group_ttl
- [ ] Confirm release body has the contract address + gas tables populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)