### PR TITLE
bench-gas: fix fee schema, collapse deploy to single tx

### DIFF
--- a/scripts/bench-gas/lib.sh
+++ b/scripts/bench-gas/lib.sh
@@ -167,6 +167,14 @@ emit_row() {
 
     local raw
     raw="$(fetch_fee_full "$hash" || echo '{}')"
+    # `stellar tx fetch fee --output json` returns
+    #   { "proposed": {fee, resource_fee, inclusion_fee},
+    #     "charged":  {fee, resource_fee, inclusion_fee,
+    #                  non_refundable_resource_fee, refundable_resource_fee} }
+    # `charged.fee` is the net amount the source account paid; that's
+    # what we surface as the headline `fee_stroops`. `proposed` is what
+    # the simulator pre-allocated — useful diagnostic, kept under
+    # `proposed_fee` for the renderer.
     jq -nc \
         --arg row_type "op" \
         --arg contract "$contract" \
@@ -176,10 +184,12 @@ emit_row() {
         --argjson raw "$raw" \
         --argjson extra "$extra" \
         '{row_type: $row_type, contract: $contract, op: $op, tier: $tier, hash: $hash,
-          fee_stroops: ($raw.totals.fee_charged // $raw.fee_charged // null),
-          inclusion_fee: ($raw.totals.inclusion_fee // null),
-          resource_fee: ($raw.totals.resource_fee // null),
-          refundable_fee_refund: ($raw.totals.refundable_fee_refund // null),
+          fee_stroops: $raw.charged.fee,
+          inclusion_fee: $raw.charged.inclusion_fee,
+          resource_fee: $raw.charged.resource_fee,
+          non_refundable_resource_fee: $raw.charged.non_refundable_resource_fee,
+          refundable_resource_fee: $raw.charged.refundable_resource_fee,
+          proposed_fee: $raw.proposed.fee,
           raw: $raw} + $extra' \
         >> "$BENCH_JSONL"
 }
@@ -187,13 +197,12 @@ emit_row() {
 # ---------- deploy + invoke wrappers ----------
 
 # bench_deploy <contract_alias> <wasm> <constructor_args...>
-# Deploys and echoes the contract id on stdout for the caller to bind.
-# `stellar contract deploy` submits two txs:
-#   1. upload_contract_wasm  (size-dominated, the larger of the two)
-#   2. create_contract       (constructor execution)
-# Both fees are emitted as separate JSONL rows (deploy_upload,
-# deploy_create) so the headline cost isn't silently masked by
-# capturing only the first hash.
+# Deploys and echoes the contract id on stdout. `stellar contract
+# deploy` v26 batches upload + create into a single transaction
+# (one tx hash, one stellar.expert URL printed) — the second 🔗
+# line in the output is the lab.stellar.org **contract** URL, not
+# a tx URL. So we emit a single `deploy` row with the captured
+# fee.
 bench_deploy() {
     local alias="$1"
     local wasm="$2"
@@ -213,13 +222,11 @@ bench_deploy() {
 
     cat "$err" >&2
 
-    local upload_hash create_hash
-    upload_hash="$(capture_tx_hashes "$err" | sed -n '1p')"
-    create_hash="$(capture_tx_hashes "$err" | sed -n '2p')"
+    local hash
+    hash="$(capture_tx_hash "$err" || true)"
     rm -f "$err"
 
-    emit_row "$BENCH_CURRENT_CONTRACT" "deploy_upload" "n/a" "$upload_hash"
-    emit_row "$BENCH_CURRENT_CONTRACT" "deploy_create" "n/a" "$create_hash"
+    emit_row "$BENCH_CURRENT_CONTRACT" "deploy" "n/a" "$hash"
     emit_contract_address "$BENCH_CURRENT_CONTRACT" "$cid"
     printf '%s' "$cid"
 }

--- a/scripts/bench-gas/render.py
+++ b/scripts/bench-gas/render.py
@@ -27,13 +27,11 @@ CONTRACT_ORDER = {
 }
 
 OP_ORDER = {
-    "deploy_upload": 0,
-    "deploy_create": 1,
-    "deploy": 1,  # legacy single-row path; kept so older JSONL still sorts
-    "create_group": 2,
-    "create_oligarchy_group": 2,
-    "verify_membership": 3,
-    "update_commitment": 4,
+    "deploy": 0,
+    "create_group": 1,
+    "create_oligarchy_group": 1,
+    "verify_membership": 2,
+    "update_commitment": 3,
     "set_restricted_mode": 10,
     "bump_group_ttl": 11,
 }
@@ -143,8 +141,13 @@ def build_gas_table(op_rows: list[dict]) -> str:
     if not op_rows:
         return "_(no transactions submitted)_"
 
+    # `Fee (XLM)` and `Stroops` are the same number in different units —
+    # `Resource` + `Inclusion` add up to `Stroops`. `Non-refundable` is
+    # the locked portion of `Resource`; `Refundable` is the rest of
+    # `Resource` (charged up-front, refunded if unused — but already
+    # netted out in the headline `Stroops`).
     headers = ["Contract", "Operation", "Tier", "Fee (XLM)",
-               "Stroops", "Inclusion", "Resource", "Refund"]
+               "Stroops", "Resource", "Non-refundable", "Refundable", "Inclusion"]
     lines = [
         "| " + " | ".join(headers) + " |",
         "|" + "|".join("---" for _ in headers) + "|",
@@ -156,9 +159,10 @@ def build_gas_table(op_rows: list[dict]) -> str:
             tier_str(row.get("tier", "")),
             stroops_to_xlm(row.get("fee_stroops")),
             fmt_stroops(row.get("fee_stroops")),
-            fmt_int(row.get("inclusion_fee")),
             fmt_int(row.get("resource_fee")),
-            fmt_int(row.get("refundable_fee_refund")),
+            fmt_int(row.get("non_refundable_resource_fee")),
+            fmt_int(row.get("refundable_resource_fee")),
+            fmt_int(row.get("inclusion_fee")),
         ]
         lines.append("| " + " | ".join(cells) + " |")
     return "\n".join(lines)


### PR DESCRIPTION
## What v1.10.93 surfaced

The [v1.10.93 release body](https://github.com/rinat-enikeev/stellar-mls/releases/tag/v1.10.93) had 20 op rows with all fees as \`—\`, even though every successful tx captured its hash correctly. Pulling the artifact JSONL revealed the \`raw\` field had the full fee breakdown — the bug was just that my jq extraction was hitting the wrong path.

## Two fixes

### 1. Fee schema mismatch

\`stellar tx fetch fee --output json\` returns:

\`\`\`json
{
  "proposed": {"fee": 41523, "resource_fee": 41423, "inclusion_fee": 100},
  "charged":  {"fee": 28809, "resource_fee": 28709, "inclusion_fee": 100,
               "non_refundable_resource_fee": 8471,
               "refundable_resource_fee": 20238}
}
\`\`\`

I had been pulling \`raw.totals.fee_charged\` (doesn't exist). Switched to \`raw.charged.fee\` for headline + surfaced the resource sub-breakdown in the gas table (resource / non-refundable / refundable / inclusion).

\`raw.proposed\` is the simulator's pre-flight estimate — kept in JSONL for downstream analysis but not in the headline table.

### 2. Deploy is one tx, not two

In v26 \`stellar contract deploy\` batches \`upload_contract_wasm\` + \`create_contract\` into a single transaction with a single tx hash:

\`\`\`
ℹ️  Deploying contract using wasm hash <wasm_hash>
ℹ️  Signing transaction: <tx_hash>
🌎 Sending transaction…
✅ Transaction submitted successfully!
🔗 https://stellar.expert/explorer/testnet/tx/<tx_hash>
🔗 https://lab.stellar.org/r/testnet/contract/<contract_id>   ← contract URL, not tx URL
\`\`\`

The second 🔗 line is a contract URL, not a tx URL — so my previous "split into upload + create rows" approach always got null for the create row. Collapsed to a single \`deploy\` row.

## Local smoke test

Renderer with the real CLI schema produces:

\`\`\`
| Contract       | Operation             | Tier | Fee (XLM) | Stroops | Resource | Non-refundable | Refundable | Inclusion |
| sep-oneonone   | deploy                | —    | 0.0028809 | 28,809  | 28,709   | 8,471          | 20,238     | 100       |
| sep-oneonone   | create_group          | —    | 0.0144322 | 144,322 | 144,222  | 96,044         | 48,178     | 100       |
| sep-oneonone   | set_restricted_mode   | —    | 0.0012338 | 12,338  | 12,238   | 6,963          | 5,275      | 100       |
\`\`\`

Numbers reconcile: resource + inclusion = total stroops. ✓

## Test plan

- [ ] Land + retrigger
- [ ] Confirm release body's per-op gas table has populated XLM/stroops columns
- [ ] Sanity-check column sums (resource + inclusion = total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)