### PR TITLE
bench-gas V2: real verifier rows for sep-anarchy + sep-democracy

### DIFF
--- a/scripts/bench-gas/README.md
+++ b/scripts/bench-gas/README.md
@@ -40,48 +40,66 @@ Requirements: `stellar` CLI, `cargo`, `jq`, `xxd`, `python3`.
 
 Outputs land under `scripts/bench-gas/results.{txt,jsonl}`.
 
-## Coverage matrix (V1)
+## Coverage matrix (V2)
 
 | Contract       | deploy | create_* | verify_membership | update_commitment | admin ops |
 |----------------|:------:|:--------:|:-----------------:|:-----------------:|:---------:|
-| sep-oneonone   | ✓      | ✓        | (V2)              | n/a               | ✓         |
-| sep-oligarchy  | ✓      | ✓        | ✓ (revert-mode)   | (V2)              | ✓         |
-| sep-anarchy    | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
-| sep-democracy  | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
-| sep-tyranny    | ✓      | (V2)     | (V2)              | (V2)              | ✓         |
+| sep-oneonone   | ✓      | ✓        | (V3)              | n/a               | ✓         |
+| sep-oligarchy  | ✓      | ✓        | ✓ (revert-mode)   | (V3)              | ✓         |
+| sep-anarchy    | ✓      | ✓ × 3    | ✓ × 3             | ✓ × 3             | ✓         |
+| sep-democracy  | ✓      | ✓ × 3    | ✓ × 3             | (V3)              | ✓         |
+| sep-tyranny    | ✓      | (V3)     | (V3)              | (V3)              | ✓         |
+
+`× 3` = covered at all three tiers (d=5, d=8, d=11).
 
 ### Bench mechanics
 
-* **`verify_membership`** returns `Ok(false)` on `InvalidProof` (no
-  revert), so we can submit a well-formed non-verifying proof, the
-  verifier runs the full PLONK pairing check, the function returns
-  `Ok(false)`, and the captured fee equals the real success-path
-  cost.
-* **`update_commitment`** errors out on `InvalidProof`, so the tx
-  would revert. Soroban-CLI runs simulation pre-flight and refuses
-  to submit reverting txs — so a non-verifying proof can't capture
-  a fee for this entrypoint. Deferred to V2 (real verifying proofs
-  via `gen-update-proof`).
+* **V1 contracts (`sep-oneonone`, `sep-oligarchy`)** use committed
+  fixtures from `contracts/plonk-verifier/tests/fixtures/`. Their
+  `create_*` paths use contract-specific create circuits we don't
+  have generators for, so V2 doesn't extend them.
+* **V2 contracts (`sep-anarchy`, `sep-democracy`)** generate fresh
+  PLONK proofs at runtime via `gen-membership-proof` /
+  `gen-update-proof`. Both contracts use `MEMBERSHIP_VK` for create
+  (so a membership proof IS a create proof), and `sep-anarchy`'s
+  update circuit matches `gen-update-proof`'s circuit shape.
+* **`verify_membership` revert-mode caveat (oligarchy only)**: the
+  verifier returns `Ok(false)` on `InvalidProof` without reverting,
+  so the captured fee equals the success-path cost — the verifier
+  runs the full PLONK pairing check identically in both arms. V2
+  rows for anarchy/democracy use real verifying proofs and capture
+  the genuine `Ok(true)` fee.
+* **VK shape-only invariant**: for any depth-`d` circuit the baked
+  VK depends on circuit topology, not witness values. So a witness
+  generated from `(secret_keys, prover_index, salt)` of our choice
+  produces a proof that verifies under the on-chain VK regardless
+  of what the contract's bake-time witness was.
 
-## V2 follow-up
+## V3 follow-up
 
-The contracts deferred above use `MEMBERSHIP_VK` for create
-(anarchy/democracy) or per-tier `VK_CREATE_D{5,8,11}` (tyranny).
-None has a fixture-only path that produces a successful
-`create_group` from a fresh deploy without runtime proof generation.
+V2 unlocks the contracts whose verifier circuits match the
+existing `gen-membership-proof` / `gen-update-proof` shapes. V3
+needs contract-specific gen tools to extend coverage further:
 
-V2 plan:
-1. Workflow step builds `gen-membership-proof` + `gen-update-proof`
-   under `--features gen-proof-tool`.
-2. For each tier, generate a fresh `(proof, public_inputs)` bundle
-   matching the deploy-time witness defaults (`secret-keys`,
-   `prover-index`, `salt`).
-3. Drive `create_group` → `verify_membership` → `update_commitment`
-   against the fresh proofs, capturing real success-path fees.
+* `gen-democracy-update-proof` — for `sep-democracy.update_commitment`
+  (uses `VK_DEMO_UPDATE_D{5,8,11}`; constrains a quorum threshold +
+  occupancy commitment that the generic update circuit doesn't).
+* `gen-oligarchy-create-proof` / `gen-oligarchy-update-proof` —
+  oligarchy already has committed fixtures for these (V1 covers
+  the create path), but `update_commitment` needs a fresh proof
+  matching post-create state and there's no committed fixture
+  that does so.
+* `gen-tyranny-create-proof` / `gen-tyranny-update-proof` — both
+  the create and update circuits are tyranny-specific (admin-tree
+  binding, group_id_fr derivation). No coverage today.
+* `gen-oneonone-create-proof` — the 1v1 create circuit is its own
+  shape; without it, `verify_membership` can't be benched against
+  a known commitment we set via `create_group`.
 
-Trade-off vs V1: extra ~30 s of CI wall-time per contract for the
-proof gen, plus the cost of the proofs hitting BLS arithmetic in
-release mode. Tracked in the next-up follow-up issue.
+For the V2 contracts: generation adds ~30s wall-time per tier in
+CI (heavier at d=11). With three tiers per contract × two contracts
+× two op types (membership + update), the bench job grows from ~4 m
+in V1 to ~10–12 m in V2.
 
 ## File layout
 

--- a/scripts/bench-gas/contracts/sep-anarchy.sh
+++ b/scripts/bench-gas/contracts/sep-anarchy.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env bash
-# sep-anarchy gas bench driver.
+# sep-anarchy gas bench driver (V2).
 #
-# V1 coverage: deploy, set_restricted_mode.
-# V2 (deferred): create_group, verify_membership, update_commitment —
-#   each requires a fresh PLONK proof at runtime via gen-membership-
-#   proof / gen-update-proof. Tracked in scripts/bench-gas/README.md.
+# Coverage:
+#   deploy, set_restricted_mode, plus per-tier (d=5/8/11):
+#     create_group, verify_membership, update_commitment.
+#
+# Per-tier ops use freshly-generated PLONK proofs from the
+# `gen-membership-proof` and `gen-update-proof` binaries. The baked
+# VKs are shape-only (depend on circuit topology, not witness), so
+# any (secret_keys, prover_index, salt) tuple at the same depth
+# produces a proof that verifies under the on-chain VK.
+#
+# State chain per group_id:
+#   1. create_group writes  (commitment=Cm,  epoch=0).
+#   2. verify_membership re-uses the same proof+PI; matches state.
+#   3. update_commitment uses an update proof generated at the same
+#      depth with epoch_old=0, salt_old=salt_membership, salt_new
+#      different. The c_old in update PI matches Cm.
+#
+# One contract hosts all three tiers (different group_id per tier),
+# so the release body shows a single sep-anarchy address row.
 
 set -euo pipefail
 
@@ -15,17 +30,68 @@ LIB="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)/lib.sh"
 
 export BENCH_CURRENT_CONTRACT="sep-anarchy"
 
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-anarchy.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
 echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
 CID="$(bench_deploy \
     "bench-gas-anarchy" \
     "$BENCH_ARTIFACT_DIR/sep_anarchy_contract.wasm" \
     --admin "$BENCH_DEPLOYER_ADDRESS")"
-
 if [ -z "$CID" ]; then
     echo "    deploy failed — skipping further ops" >&2
     exit 0
 fi
-echo "    contract: $CID"
+
+run_tier() {
+    local tier="$1"
+    local depth="$2"
+    # Distinct group_id per tier — high byte = 0x40+tier so the bytes
+    # decode to canonical Fr regardless of tier.
+    local group_id_hex
+    group_id_hex="$(printf '%02x%s' $(( 0x40 + tier )) "$(printf '00%.0s' $(seq 1 31))")"
+
+    echo "==> [$BENCH_CURRENT_CONTRACT] tier=$tier (d=$depth) generating fresh proofs"
+    bench_gen_membership_proof "$depth" "$WORK/mp-d$depth"
+    bench_gen_update_proof     "$depth" "$WORK/up-d$depth"
+
+    local mp_proof_hex mp_pi_json commitment_hex
+    mp_proof_hex="$(bench_gen_proof_hex "$WORK/mp-d$depth")"
+    mp_pi_json="$(bench_gen_pi_json "$WORK/mp-d$depth")"
+    commitment_hex="$(bench_gen_commitment_hex "$WORK/mp-d$depth")"
+
+    local up_proof_hex up_pi_json
+    up_proof_hex="$(bench_gen_proof_hex "$WORK/up-d$depth")"
+    up_pi_json="$(bench_gen_pi_json "$WORK/up-d$depth")"
+
+    echo "==> [$BENCH_CURRENT_CONTRACT] tier=$tier create_group"
+    bench_invoke "$CID" "create_group" "$tier" "create_group" \
+        --caller "$BENCH_DEPLOYER_ADDRESS" \
+        --group-id "$group_id_hex" \
+        --commitment "$commitment_hex" \
+        --tier "$tier" \
+        --member-count 8 \
+        --proof "$mp_proof_hex" \
+        --public-inputs "$mp_pi_json"
+
+    echo "==> [$BENCH_CURRENT_CONTRACT] tier=$tier verify_membership"
+    bench_invoke "$CID" "verify_membership" "$tier" "verify_membership" \
+        --group-id "$group_id_hex" \
+        --proof "$mp_proof_hex" \
+        --public-inputs "$mp_pi_json"
+
+    echo "==> [$BENCH_CURRENT_CONTRACT] tier=$tier update_commitment"
+    bench_invoke "$CID" "update_commitment" "$tier" "update_commitment" \
+        --group-id "$group_id_hex" \
+        --proof "$up_proof_hex" \
+        --public-inputs "$up_pi_json"
+}
+
+run_tier 0 5
+if [ "${BENCH_FULL_TIERS:-1}" = "1" ]; then
+    run_tier 1 8
+    run_tier 2 11
+fi
 
 echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
 bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \

--- a/scripts/bench-gas/contracts/sep-democracy.sh
+++ b/scripts/bench-gas/contracts/sep-democracy.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-# sep-democracy gas bench driver.
+# sep-democracy gas bench driver (V2).
 #
-# V1 coverage: deploy, set_restricted_mode.
-# V2 (deferred): create_group + verify_membership via fresh
-#   gen-membership-proof; update_commitment via committed
-#   democracy-update-proof-d{5,8,11}.bin in revert mode.
+# Coverage:
+#   deploy, set_restricted_mode, plus per-tier (d=5/8/11):
+#     create_group (uses MEMBERSHIP_VK — gen-membership-proof works),
+#     verify_membership (same fresh proof + state).
+#
+# Out of scope (V3):
+#   update_commitment — uses VK_DEMO_UPDATE_D{5,8,11}, a democracy-
+#   specific update circuit. `gen-update-proof` produces proofs for
+#   the generic update circuit (used by sep-anarchy), not for the
+#   democracy variant. Needs a `gen-democracy-update-proof` binary.
 
 set -euo pipefail
 
@@ -15,17 +21,61 @@ LIB="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)/lib.sh"
 
 export BENCH_CURRENT_CONTRACT="sep-democracy"
 
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-democracy.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# A canonical occupancy commitment value (any canonical Fr works —
+# the contract only checks `is_canonical_fr` on this; it's stored,
+# not re-verified by the create proof).
+OCCUPANCY_HEX="${ZERO32_HEX:0:62}01"
+
 echo "==> [$BENCH_CURRENT_CONTRACT] deploy"
 CID="$(bench_deploy \
     "bench-gas-democracy" \
     "$BENCH_ARTIFACT_DIR/sep_democracy_contract.wasm" \
     --admin "$BENCH_DEPLOYER_ADDRESS")"
-
 if [ -z "$CID" ]; then
     echo "    deploy failed — skipping further ops" >&2
     exit 0
 fi
-echo "    contract: $CID"
+
+run_tier() {
+    local tier="$1"
+    local depth="$2"
+    local group_id_hex
+    group_id_hex="$(printf '%02x%s' $(( 0x60 + tier )) "$(printf '00%.0s' $(seq 1 31))")"
+
+    echo "==> [$BENCH_CURRENT_CONTRACT] tier=$tier (d=$depth) generating fresh proof"
+    bench_gen_membership_proof "$depth" "$WORK/mp-d$depth"
+
+    local mp_proof_hex mp_pi_json commitment_hex
+    mp_proof_hex="$(bench_gen_proof_hex "$WORK/mp-d$depth")"
+    mp_pi_json="$(bench_gen_pi_json "$WORK/mp-d$depth")"
+    commitment_hex="$(bench_gen_commitment_hex "$WORK/mp-d$depth")"
+
+    echo "==> [$BENCH_CURRENT_CONTRACT] tier=$tier create_group"
+    bench_invoke "$CID" "create_group" "$tier" "create_group" \
+        --caller "$BENCH_DEPLOYER_ADDRESS" \
+        --group-id "$group_id_hex" \
+        --commitment "$commitment_hex" \
+        --tier "$tier" \
+        --threshold-numerator 60 \
+        --occupancy-commitment-initial "$OCCUPANCY_HEX" \
+        --proof "$mp_proof_hex" \
+        --public-inputs "$mp_pi_json"
+
+    echo "==> [$BENCH_CURRENT_CONTRACT] tier=$tier verify_membership"
+    bench_invoke "$CID" "verify_membership" "$tier" "verify_membership" \
+        --group-id "$group_id_hex" \
+        --proof "$mp_proof_hex" \
+        --public-inputs "$mp_pi_json"
+}
+
+run_tier 0 5
+if [ "${BENCH_FULL_TIERS:-1}" = "1" ]; then
+    run_tier 1 8
+    run_tier 2 11
+fi
 
 echo "==> [$BENCH_CURRENT_CONTRACT] set_restricted_mode(true)"
 bench_invoke "$CID" "set_restricted_mode" "n/a" "set_restricted_mode" \

--- a/scripts/bench-gas/lib.sh
+++ b/scripts/bench-gas/lib.sh
@@ -65,6 +65,65 @@ read_pi_field_hex() {
 # Constants used across drivers.
 ZERO32_HEX="$(printf '%064d' 0)"
 
+# ---------- V2 proof generators ----------
+# Wrappers around the `gen-membership-proof` / `gen-update-proof`
+# binaries (built under `--features gen-proof-tool` by setup.sh).
+# Each call writes `proof.bin`, `proof.hex`, `commitment.hex`,
+# `public_inputs.json`, etc. into a fresh out-dir; callers consume
+# the artifacts via `bench_gen_*_load`.
+#
+# Witness defaults are baked in below — they're shape-only fixtures
+# (the VK is shape-dependent, not witness-dependent), so the same
+# (secret_keys, prover_index) works at every depth.
+
+# 8 canonical secret keys; tree pads beyond that. prover_index=3.
+BENCH_GEN_SECRET_KEYS='0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08'
+BENCH_GEN_PROVER_INDEX='3'
+BENCH_GEN_SALT_OLD='0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+BENCH_GEN_SALT_NEW='0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+
+# bench_gen_membership_proof <depth> <out_dir>
+# Generates a membership proof at the given depth (5/8/11) at epoch 0
+# with the canonical witness. Writes proof.bin / commitment.hex /
+# public_inputs.json into out_dir.
+bench_gen_membership_proof() {
+    local depth="$1"
+    local out_dir="$2"
+    mkdir -p "$out_dir"
+    "${BENCH_REPO_ROOT}/target/release/gen-membership-proof" \
+        --depth "$depth" \
+        --epoch 0 \
+        --salt "$BENCH_GEN_SALT_OLD" \
+        --secret-keys "$BENCH_GEN_SECRET_KEYS" \
+        --prover-index "$BENCH_GEN_PROVER_INDEX" \
+        --out-dir "$out_dir" >&2
+}
+
+# bench_gen_update_proof <depth> <out_dir>
+# Generates an update proof at the given depth: c_old comes from the
+# epoch=0 / salt_old witness (matches `bench_gen_membership_proof`'s
+# commitment), c_new comes from the epoch=1 / salt_new witness.
+# Re-using salt_old here keeps c_old aligned with the post-create
+# state set by the membership-proof's create_group call.
+bench_gen_update_proof() {
+    local depth="$1"
+    local out_dir="$2"
+    mkdir -p "$out_dir"
+    "${BENCH_REPO_ROOT}/target/release/gen-update-proof" \
+        --depth "$depth" \
+        --epoch-old 0 \
+        --salt-old "$BENCH_GEN_SALT_OLD" \
+        --salt-new "$BENCH_GEN_SALT_NEW" \
+        --secret-keys "$BENCH_GEN_SECRET_KEYS" \
+        --prover-index "$BENCH_GEN_PROVER_INDEX" \
+        --out-dir "$out_dir" >&2
+}
+
+# Helpers to read out-dir artifacts back as shell-safe strings.
+bench_gen_proof_hex() { cat "$1/proof.hex"; }
+bench_gen_pi_json()   { cat "$1/public_inputs.json"; }
+bench_gen_commitment_hex() { cat "$1/commitment.hex"; }
+
 # ---------- invocation + fee capture ----------
 
 # capture_tx_hashes <stderr_logfile>

--- a/scripts/bench-gas/render.py
+++ b/scripts/bench-gas/render.py
@@ -194,16 +194,17 @@ def main() -> int:
         "## Notes",
         "",
         "- Stroops are testnet stroops; 1 XLM = 10,000,000 stroops.",
-        "- `verify_membership` rows are captured in revert-mode (well-formed proof, "
-        "non-matching PI) where applicable; the verifier returns `Ok(false)` on "
-        "`InvalidProof` (no revert), so the verifier runs the full PLONK pairing "
-        "check and the fee equals the success-path cost.",
-        "- `update_commitment` is deferred to V2 — Soroban-CLI runs simulation "
-        "pre-flight and won't submit txs that revert, so a non-verifying proof "
-        "can't capture a fee. V2 will use `gen-update-proof` to produce real "
-        "verifying proofs.",
-        "- sep-anarchy / sep-democracy / sep-tyranny verifier ops are deferred to a "
-        "follow-up release (require runtime proof gen).",
+        "- `verify_membership` rows for `sep-oligarchy` are captured in revert-mode "
+        "(well-formed proof, non-matching PI); the verifier returns `Ok(false)` "
+        "on `InvalidProof` without reverting, so the captured fee equals the "
+        "success-path cost. Rows for `sep-anarchy` and `sep-democracy` use real "
+        "verifying proofs (V2).",
+        "- `update_commitment` for `sep-anarchy` uses real proofs via "
+        "`gen-update-proof` and captures the full success-path cost including "
+        "post-verify storage writes.",
+        "- `sep-tyranny` and the `update_commitment` rows for `sep-democracy` / "
+        "`sep-oligarchy` / `sep-oneonone.verify_membership` are deferred to V3 — "
+        "they need contract-specific proof generators that don't exist yet.",
     ]
 
     args.output.write_text("\n".join(body_lines) + "\n")

--- a/scripts/bench-gas/setup.sh
+++ b/scripts/bench-gas/setup.sh
@@ -5,13 +5,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+BENCH_REPO_ROOT="$REPO_ROOT"
 
 BENCH_NETWORK="${BENCH_NETWORK:-testnet}"
 BENCH_DEPLOYER="${BENCH_DEPLOYER:-bench-gas-deployer}"
 BENCH_CONFIG_DIR="${BENCH_CONFIG_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-config.XXXXXX")}"
 BENCH_ARTIFACT_DIR="${BENCH_ARTIFACT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/bench-gas-artifacts.XXXXXX")}"
 
-export BENCH_NETWORK BENCH_DEPLOYER BENCH_CONFIG_DIR BENCH_ARTIFACT_DIR
+export BENCH_NETWORK BENCH_DEPLOYER BENCH_CONFIG_DIR BENCH_ARTIFACT_DIR BENCH_REPO_ROOT
 
 require_cmd() {
     if ! command -v "$1" >/dev/null 2>&1; then
@@ -59,9 +60,11 @@ for c in sep-anarchy sep-democracy sep-oligarchy sep-oneonone sep-tyranny; do
         --out-dir "$BENCH_ARTIFACT_DIR" >/dev/null
 done
 
-# V2 will compile `gen-membership-proof` / `gen-update-proof` here
-# once the deferred contract drivers consume them. V1 doesn't, so we
-# don't burn CI time on the `gen-proof-tool` feature build (and a
-# regression in those binaries can't fail the V1 bench).
+echo "==> building gen-proof-tool binaries (V2 drivers consume these)"
+cargo build --release \
+    --manifest-path "$REPO_ROOT/Cargo.toml" \
+    --features gen-proof-tool \
+    --bin gen-membership-proof \
+    --bin gen-update-proof >/dev/null
 
 echo "==> setup complete"


### PR DESCRIPTION
## Background

V1 (released as [v1.10.94](https://github.com/rinat-enikeev/stellar-mls/releases/tag/v1.10.94)) covered deploy + admin ops for all 5 contracts and the full verifier path for `sep-oligarchy` via committed fixtures. The README's coverage matrix flagged sep-anarchy / sep-democracy / sep-tyranny verifier ops as "V2 — needs runtime proof gen". This is V2.

## What ships

The repo already has `gen-membership-proof` and `gen-update-proof` binaries (`src/bin/gen_*.rs`). VKs are shape-only — any witness at the same depth produces a proof that verifies under the on-chain VK regardless of the contract's bake-time witness. Use them.

### Coverage delta

| Contract | Op | V1 | V2 |
|---|---|:-:|:-:|
| sep-anarchy | `create_group` (×3 tiers) | — | ✓ |
| sep-anarchy | `verify_membership` (×3 tiers) | — | ✓ |
| sep-anarchy | `update_commitment` (×3 tiers) | — | ✓ |
| sep-democracy | `create_group` (×3 tiers) | — | ✓ |
| sep-democracy | `verify_membership` (×3 tiers) | — | ✓ |

That's **15 new rows** of real-success-path bench data.

### Mechanics

For each `(contract, tier)`:

1. \`gen-membership-proof --depth d --epoch 0 --salt <X> ...\` writes \`commitment.hex\`, \`proof.bin\`, \`public_inputs.json\` (already in CLI-ready format)
2. \`gen-update-proof --depth d --epoch-old 0 --salt-old <X> --salt-new <Y> ...\` writes the matching update artifacts (c_old in update PI = commitment from step 1)
3. \`create_group\` with the membership proof → state = (commitment, 0)
4. \`verify_membership\` with same proof → state matches → real \`Ok(true)\` cost
5. \`update_commitment\` with the update proof → real success path including post-verify storage writes

One contract per sep-anarchy / sep-democracy hosts all three tiers via different group_ids — keeps the release-body's address table compact.

### V3 (deferred)

Each contract whose verifier circuit isn't covered by the existing generic gen tools needs its own gen binary:
- \`gen-democracy-update-proof\` (VK_DEMO_UPDATE_D{5,8,11} — quorum + occupancy circuit)
- \`gen-oligarchy-update-proof\` (single VK_UPDATE — admin-tree circuit)
- \`gen-tyranny-{create,update}-proof\` (per-tier admin-binding circuits)
- \`gen-oneonone-create-proof\` (1v1-specific create circuit)

Tracked in the README.

## Cost / runtime

Workflow goes from ~4 min (V1) to ~10–12 min (V2): proof generation at d=11 (2048-leaf Merkle tree) is the slowest path. Set \`BENCH_FULL_TIERS=0\` to skip d=8 and d=11 for local iteration.

## Test plan

- [ ] Land + retrigger
- [ ] Confirm new rows appear: sep-anarchy + sep-democracy create / verify / (anarchy-only) update at all 3 tiers
- [ ] Sanity-check that per-tier costs scale roughly with depth (d=11 should be ~similar to d=5/d=8 — PR #206's in-VM benches showed tier-invariant CPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)