### PR TITLE
plonk: move Zero to test scope in verifier_lin_poly

### DIFF
--- a/src/circuit/plonk/verifier_lin_poly.rs
+++ b/src/circuit/plonk/verifier_lin_poly.rs
@@ -39,7 +39,7 @@
 #![cfg(feature = "plonk")]
 
 use ark_bls12_381_v05::Fr;
-use ark_ff_v05::{Field, Zero};
+use ark_ff_v05::Field;
 
 use crate::circuit::plonk::proof_format::{NUM_WIRE_SIGMA_EVALS, NUM_WIRE_TYPES};
 use crate::circuit::plonk::vk_format::NUM_SIGMA_COMMS;
@@ -107,7 +107,7 @@ pub fn compute_lin_poly_constant_term(
 mod tests {
     use super::*;
     use ark_bls12_381_v05::{Bls12_381, Fr};
-    use ark_ff_v05::{BigInteger, One, PrimeField};
+    use ark_ff_v05::{BigInteger, One, PrimeField, Zero};
     use ark_serialize_v05::{CanonicalDeserialize, CanonicalSerialize};
     use ark_std_v05::UniformRand;
     use jf_plonk::proof_system::structs::VerifyingKey;


### PR DESCRIPTION
Cleanup follow-up to PR #215 — the V2 bench workflow log surfaced two `unused_imports` warnings in `sep-xxxx-circuits`. This fixes one; the other turned out to be a false positive.

## Fixed

\`src/circuit/plonk/verifier_lin_poly.rs:42\` — \`Zero\` was imported at the parent-module level but only used inside \`#[cfg(test)] mod tests { ... }\` (for the \`Fr::zero()\` calls in the unit tests). Moved it into the test module's own use list. The non-test code uses only \`Field\`.

## Investigated, not fixed

\`src/circuit/plonk/oligarchy.rs:68 use ark_ff_v05::PrimeField;\` — the workflow log called this unused, but it's genuinely needed at line 524:

\`\`\`rust
let salt_fr = Fr::from_le_bytes_mod_order(&witness.salt);
\`\`\`

\`from_le_bytes_mod_order\` is a method on the \`PrimeField\` trait. Removing the import breaks the build (verified via \`cargo build --release --features gen-proof-tool --bin gen-membership-proof\`):

\`\`\`
error[E0599]: no function or associated item named `from_le_bytes_mod_order` found for struct `Fr` in the current scope
   --> src/circuit/plonk/oligarchy.rs:524:30
help: trait `PrimeField` which provides `from_le_bytes_mod_order` is implemented but not in scope; perhaps you want to import it
\`\`\`

The warning didn't reproduce on a clean local rebuild after \`cargo clean -p sep-xxxx-circuits\` + \`touch\`. Likely a transient cargo cache state during the workflow's first build.

## Test plan

- [x] \`cargo test --no-run --features plonk --lib verifier_lin_poly\` builds clean (test code now imports its own \`Zero\`)
- [x] \`cargo build --release --features gen-proof-tool --bin gen-membership-proof\` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)