### PR TITLE
test: add Solo User Journey UI tests for iOS and Android

### DIFF
--- a/clients/android/StellarChat/SMOKE_TESTS.md
+++ b/clients/android/StellarChat/SMOKE_TESTS.md
@@ -1,0 +1,430 @@
+# Smoke-тесты Onym Android — pre-release чек
+
+Список сценариев для **ручного** прогона перед каждым релизом. Цель — за 10–15 минут на одном устройстве удостовериться, что критический путь не сломан. Сценарии один-в-один соответствуют стадиям авто-теста `uitests.SoloUserJourneyTest` — если что-то падает в проде, проверь сначала, что делает соответствующая стадия в коде.
+
+> **Как пользоваться:** проставлять `[x]` напротив каждого пункта по мере выполнения. Если хоть один пункт упал — **релиз стопаем**, заводим issue со ссылкой на соответствующую стадию авто-теста.
+
+> **Solo-сессия.** Все сценарии проходят без второго пользователя: группы создаются на этом же устройстве, сообщения отправляются "в пустоту" (статус `SENT`/`FAILED` ловится визуально). Сценарии с двумя устройствами (deeplink invite, реальная доставка, knock-and-let-in) — **вне smoke**, в регрессию.
+
+> **Разрушающие операции.** Smoke создаёт 4 временные группы с суффиксом `… QA` и удаляет их в финале (SM-15). Реальные пользовательские группы и identity не затрагиваются.
+
+---
+
+## 0. Подготовка окружения
+
+**Перед каждым прогоном:**
+
+- [ ] APK свежей сборки установлен на физическое устройство (не эмулятор)
+- [ ] Зафиксированы данные сборки:
+  - Версия (`versionName`): `_____`
+  - VersionCode: `_____`
+  - Flavor: `play` / `fdroid`
+  - Variant: `debug` / `release`
+- [ ] Зафиксировано устройство:
+  - Модель: `_____`
+  - Android: `_____` (API `_____`)
+- [ ] Анимации выключены в Developer Options (Window/Transition/Animator scale = 0)
+- [ ] Wi-Fi включён, есть интернет (Soroban testnet + Nostr-relays нужны для создания групп)
+- [ ] Уведомления и звук отключены
+- [ ] Прогоняющий: `_____`, дата: `_____`
+
+> **НЕ нужно** делать `pm clear chat.onym.android` — smoke пишется так, чтобы не уничтожать пользовательские данные. Онбординг показывается только при первом запуске; если SM-1 не воспроизводится — сначала ставится свежий APK на чистое устройство.
+
+---
+
+## SM-1. Холодный старт + онбординг (страница 1)
+
+> Стадия авто-теста: `stage_01_onboarding_sheet_visible_on_first_launch`
+
+**Цель:** при первом запуске показывается онбординг-bottom sheet с темой шифрования.
+
+### Шаги
+- [ ] 1. Запустить приложение с launcher (или через `adb shell am start -n chat.onym.android/.MainActivity`)
+- [ ] 2. Дождаться появления нижнего ModalBottomSheet (страница 1)
+
+### Ожидаемый результат
+- [ ] Виден sheet с заголовком про шифрование сообщений и метаданных (substring `metadata are encrypted`)
+- [ ] Видна кнопка `Next` снизу
+- [ ] Под sheet просвечивает экран Chats
+
+---
+
+## SM-2. Онбординг — все 4 страницы + Get Started
+
+> Стадия авто-теста: `stage_02_walk_through_onboarding_and_dismiss`
+
+**Цель:** все 4 страницы прокликиваются, последний `Get Started` закрывает sheet и пускает в Chats.
+
+**Предусловие:** SM-1 пройден; sheet на странице 1.
+
+### Шаги
+- [ ] 1. Тапнуть `Next` → страница 2 (виден текст `Private by design`)
+- [ ] 2. Тапнуть `Next` → страница 3 (виден текст `Truly shared ownership`)
+- [ ] 3. Тапнуть `Next` → страница 4 (видны заголовок `What makes this different` и кнопка `Get Started`)
+- [ ] 4. Тапнуть `Get Started` → sheet закрылся
+
+### Ожидаемый результат
+- [ ] Sheet полностью пропал (тэг `groupList.onboardingSheet` не виден)
+- [ ] Активный экран — Chats; видно нижнее меню (`Contacts` / `Chats` / `Search` / `Settings`)
+- [ ] Активный таб — `Chats`
+
+> **Restore from Recovery Phrase** — намеренно не покрывается smoke'ом: тап одновременно навигирует и закрывает sheet (необратимо), а сам Restore переписывает identity. Проверять только в регрессии на отдельном устройстве.
+
+---
+
+## SM-3. Создать группу `Anarchy Crew QA` + первое сообщение
+
+> Стадия авто-теста: `stage_03_create_anarchy_and_send_message`
+
+**Цель:** "анархичный" governance создаётся on-chain, чат открывается, сообщение отправляется.
+
+**Предусловие:** SM-2 завершён, экран Chats.
+
+### Шаги
+- [ ] 1. Тапнуть FAB `+` (правый нижний угол)
+- [ ] 2. В диалоге `Add Group` тапнуть `Create`
+- [ ] 3. На экране `New Group` (Step 1 of 2):
+  - [ ] Ввести имя `Anarchy Crew QA`
+  - [ ] Выбрать governance `Anarchy`
+  - [ ] Тапнуть `Next`
+- [ ] 4. На Step 2 of 2 тапнуть `Create`
+- [ ] 5. Дождаться кнопки `Open` в топбаре (до 2 минут — Soroban testnet ledger close)
+- [ ] 6. Тапнуть `Open` → открылся Chat
+- [ ] 7. Ввести в поле `Hello anarchy` и тапнуть Send
+- [ ] 8. Тапнуть Back → вернуться в Chats
+
+### Ожидаемый результат
+- [ ] На Chat экране сообщение `Hello anarchy` отрисовано
+- [ ] У сообщения виден один из статусов: `Sending` / `Sent` / `Delivered` / `Tap to retry` (любой — главное, что иконка статуса появилась)
+- [ ] В Chats есть строка `Anarchy Crew QA`
+
+---
+
+## SM-4. Создать `Direct Bob QA` (1v1)
+
+> Стадия авто-теста: `stage_04_create_one_on_one_and_send_message`
+
+**Цель:** 1v1-governance работает (это технически другой контракт, чем Anarchy).
+
+### Шаги
+- [ ] 1. FAB `+` → `Create`
+- [ ] 2. Имя `Direct Bob QA`, governance `1v1`, Next → Create
+- [ ] 3. Дождаться `Open`, открыть чат
+- [ ] 4. Отправить `Hi Bob`
+- [ ] 5. Back в Chats
+
+### Ожидаемый результат
+- [ ] Сообщение `Hi Bob` со статусной иконкой
+- [ ] Группа `Direct Bob QA` есть в Chats
+
+---
+
+## SM-5. Создать `Democracy Council QA`
+
+> Стадия авто-теста: `stage_05_create_democracy_and_send_message`
+
+**Цель:** Democracy-governance создаётся.
+
+### Шаги
+- [ ] 1. FAB `+` → `Create`
+- [ ] 2. Имя `Democracy Council QA`, governance `Democracy`, Next → Create
+- [ ] 3. Дождаться `Open`, открыть чат
+- [ ] 4. Отправить `Vote on motion`
+- [ ] 5. Back
+
+### Ожидаемый результат
+- [ ] Сообщение со статусной иконкой
+- [ ] Группа в Chats
+
+---
+
+## SM-6. Создать `Oligarchy Inner QA`
+
+> Стадия авто-теста: `stage_06_create_oligarchy_and_send_message`
+
+**Цель:** Oligarchy-governance создаётся (последний из 4 типов).
+
+### Шаги
+- [ ] 1. FAB `+` → `Create`
+- [ ] 2. Имя `Oligarchy Inner QA`, governance `Oligarchy`, Next → Create
+- [ ] 3. Дождаться `Open`, открыть чат
+- [ ] 4. Отправить `Quorum check`
+- [ ] 5. Back
+
+### Ожидаемый результат
+- [ ] Сообщение со статусной иконкой
+- [ ] Группа в Chats; всего на экране **4 группы** с суффиксом `QA`
+
+---
+
+## SM-7. Открыть GroupInfo из чата + Back
+
+> Стадия авто-теста: `stage_07_open_group_info_from_chat_and_back`
+
+**Цель:** экран Group Info открывается с правильными hero-данными, Back возвращает в чат.
+
+### Шаги
+- [ ] 1. В Chats тапнуть `Anarchy Crew QA` → открылся Chat
+- [ ] 2. Тапнуть на header (имя группы) → открылся Group Info
+- [ ] 3. Тапнуть стрелку Back в TopAppBar
+- [ ] 4. Тапнуть Back ещё раз → вернулись в Chats
+
+### Ожидаемый результат
+- [ ] На Group Info видно: имя группы, чип `End-to-end encrypted`, заголовок секции `MEMBERS`
+- [ ] После двух Back'ов — в Chats; список 4 групп на месте
+
+> Действия `Invite member` / `Leave group` / `Delete group` из этого экрана — **не покрываются** smoke (требуют второго пользователя или необратимо ломают группу).
+
+---
+
+## SM-8. Pin / Unpin группы через context menu
+
+> Стадия авто-теста: `stage_08_pin_group_then_long_press_shows_unpin`
+
+**Цель:** long-press открывает контекстное меню, Pin закрепляет (всплывает наверх + 📌 у имени), повторное открытие меню показывает Unpin.
+
+### Шаги
+- [ ] 1. В Chats long-press по `Anarchy Crew QA`
+- [ ] 2. Открылся AlertDialog с заголовком `Anarchy Crew QA` и пунктами `📌 Pin` / `🗑️ Delete`
+- [ ] 3. Тапнуть `Pin`
+- [ ] 4. Диалог закрылся; группа всплыла в самый верх со значком 📌 рядом с именем
+- [ ] 5. Long-press по `Anarchy Crew QA` ещё раз
+- [ ] 6. Теперь в меню `❌ Unpin` (вместо Pin)
+- [ ] 7. Тапнуть `Unpin`
+- [ ] 8. Диалог закрылся, 📌 пропал, порядок групп вернулся к предыдущему
+
+### Ожидаемый результат
+- [ ] Pin/Unpin срабатывают мгновенно (не дольше 500 мс на каждый шаг)
+- [ ] В Chats всё ещё 4 QA-группы на месте
+
+---
+
+## SM-9. Search — найти группу по имени
+
+> Стадия авто-теста: `stage_09_search_finds_created_group_by_name`
+
+**Цель:** глобальный поиск находит группу по части её имени.
+
+### Шаги
+- [ ] 1. Bottom-nav → таб `Search`
+- [ ] 2. В поле поиска ввести `Anarchy Crew`
+- [ ] 3. Дождаться появления результата
+
+### Ожидаемый результат
+- [ ] В выдаче есть строка `Anarchy Crew QA`
+- [ ] Очистить поле — выдача снова пустая (плейсхолдер `Search across all your chats and messages.`)
+
+---
+
+## SM-10. Settings — Invite Key tab по умолчанию
+
+> Стадия авто-теста: `stage_10_settings_lands_on_invite_tab_by_default`
+
+**Цель:** при первом заходе в Settings активна вкладка Invite Key с QR-кодом и кнопкой `Share link`.
+
+### Шаги
+- [ ] 1. Bottom-nav → таб `Settings`
+- [ ] 2. Видна сегмент-кнопка `Invite Key` / `Preferences` (выделен `Invite Key`)
+- [ ] 3. На экране виден QR-код
+
+### Ожидаемый результат
+- [ ] Кнопка `Share link` отрисована и активна
+
+---
+
+## SM-11. Settings → Preferences: 5 секций видны
+
+> Стадия авто-теста: `stage_11_settings_preferences_shows_all_sections`
+
+**Цель:** на вкладке Preferences отрисованы все 5 заголовков секций.
+
+### Шаги
+- [ ] 1. В Settings переключиться на вкладку `Preferences`
+
+### Ожидаемый результат — видны все 5 заголовков (поскролить, если нужно):
+- [ ] `NETWORK`
+- [ ] `PROTOCOL`
+- [ ] `SECURITY`
+- [ ] `ADVANCED`
+- [ ] `ABOUT`
+
+---
+
+## SM-12. Settings sub-screens: 4 раза открыть и Back
+
+> Стадия авто-теста: `stage_12_settings_sub_screens_open_and_back`
+
+**Цель:** 4 sub-screen'а открываются, у каждого виден узнаваемый якорь, Back возвращает в Settings и **сохраняет вкладку Preferences** (см. фикс `rememberSaveable`).
+
+**Предусловие:** в Settings → Preferences (SM-11).
+
+### Шаги
+- [ ] 1. Тапнуть строку `Relays` → виден заголовок `ADD RELAY` → Back → снова на Preferences (НЕ на Invite!)
+- [ ] 2. Тапнуть `Blossom Servers` → виден `ADD SERVER` → Back → Preferences
+- [ ] 3. Тапнуть `Stellar Contract` → виден `RELAYER (OPTIONAL)` → Back → Preferences
+- [ ] 4. Тапнуть `Advanced` → виден `NOSTR IDENTITY` → Back → Preferences
+
+### Ожидаемый результат
+- [ ] После каждого Back: всё ещё активна вкладка `Preferences`, заголовок `Settings`
+- [ ] Все 4 sub-screen открываются без задержек > 1 сек
+
+> **Содержимое sub-screen'ов** (список реле, кнопки add/remove, статусы) — **вне smoke**: в demo-режиме часть гасится, реальный контент зависит от сети. В smoke проверяется только факт открытия экрана.
+
+---
+
+## SM-13. Recovery Phrase — Intro экран + Cancel
+
+> Стадия авто-теста: `stage_13_settings_recovery_phrase_intro_and_cancel`
+
+**Цель:** заходим в Recovery Phrase wizard, видим intro, отменяем БЕЗ ввода фразы и БЕЗ биометрики.
+
+**Предусловие:** в Settings → Preferences.
+
+### Шаги
+- [ ] 1. Тапнуть строку `Backup Recovery Phrase`
+- [ ] 2. Виден intro-экран с заголовком `Back up keys`
+- [ ] 3. Тапнуть кнопку `Cancel` (текстовая, в навигации)
+
+### Ожидаемый результат
+- [ ] Wizard закрылся, вернулись в Settings (Preferences активна)
+
+> **Дальше intro не идём** — следующий шаг wizard вызывает системный BiometricPrompt, который не управляется через Compose UI Test (и потенциально откроется поверх UI на твоём личном устройстве).
+
+---
+
+## SM-14. Bottom-nav: Contacts таб открывается
+
+> Стадия авто-теста: `stage_14_contacts_tab_renders`
+
+**Цель:** таб Contacts открывается без падений.
+
+### Шаги
+- [ ] 1. Bottom-nav → таб `Contacts`
+
+### Ожидаемый результат
+- [ ] Экран Contacts отрисован (тег `contacts.screen` присутствует)
+- [ ] В зависимости от состояния разрешения READ_CONTACTS видно либо `Sync your phone contacts...`, либо список, либо `No Contacts`
+
+> **Не тапаем кнопку синка контактов** — это запросит системное разрешение. Smoke только проверяет факт рендера экрана.
+
+---
+
+## SM-15. Возврат в Chats и удаление 4 QA-групп
+
+> Стадии авто-теста: `stage_15_returning_to_chats_keeps_all_created_groups` + `@After cleanupCreatedGroups`
+
+**Цель:** все 4 группы на месте после хождения по табам; финал — удалить 4 QA-группы, чтобы устройство вернулось в исходное состояние.
+
+### Шаги
+- [ ] 1. Bottom-nav → таб `Chats`
+- [ ] 2. Видны все 4 группы:
+  - [ ] `Anarchy Crew QA`
+  - [ ] `Direct Bob QA`
+  - [ ] `Democracy Council QA`
+  - [ ] `Oligarchy Inner QA`
+- [ ] 3. Удалить **каждую** через long-press → `🗑️ Delete` → `Delete` в подтверждении:
+  - [ ] `Anarchy Crew QA` снесена
+  - [ ] `Direct Bob QA` снесена
+  - [ ] `Democracy Council QA` снесена
+  - [ ] `Oligarchy Inner QA` снесена
+
+### Ожидаемый результат
+- [ ] В Chats нет ни одной группы с суффиксом `QA`
+- [ ] Реальные пользовательские группы (если были) на месте, нетронутые
+
+---
+
+## Финальная проверка после смоука
+
+- [ ] В системных настройках устройства приложение `chat.onym.android` не висит в "недавних" с краш-диалогом
+- [ ] `adb logcat -d | grep -i 'fatal\|androidruntime'` — пусто или только не-наши крэши
+- [ ] Удалённые QA-группы не вернулись после повторного открытия Chats
+
+---
+
+## Решение по релизу
+
+- [ ] **GO** — все 15 пунктов smoke зелёные → можно публиковать
+- [ ] **NO GO** — хотя бы один пункт упал → релиз заблокирован, заводится issue с привязкой к стадии авто-теста
+
+Подпись: `_____`   Дата: `_____`   Решение: `GO` / `NO GO`
+
+---
+
+## Что НЕ покрывается этим smoke (намеренно)
+
+> Если хочется проверить что-то ниже — это **регрессия**, заводи отдельный чек-лист и отдельный временной слот. По мере того, как фичи будут двигаться к проду, переноси точечно по одному.
+
+**Вне solo-сессии (нужен второй пользователь / устройство):**
+- OnboardLandingScreen (`You're invited`) — открывается только по deeplink-приглашению
+- Реальный приём приглашения и присоединение к группе
+- Multi-user сообщения и доставка через Nostr-relay
+- Membership-операции с валидным charter (knock-and-let-in, kick, role change)
+
+**Вне Compose UI Test (системный UI / разрешения):**
+- Recovery Phrase reveal: после Intro вызывается `BiometricPrompt` — системное окно, не доступно через тест
+- Restore identity happy-path — `replaceKeyManager` необратимо перетирает identity
+- Запрос разрешений: Camera, Contacts, Notifications, Microphone
+- QR-сканирование и `Paste from Clipboard` (Scan просит Camera, Paste — мусор из буфера)
+
+**Деструктивные / необратимые:**
+- Settings → "Generate new identity" (confirm-path) — пересоздаёт BIP39, делает все группы read-only
+- Leave group / Delete group из GroupInfoScreen (есть только удаление через long-press из списка)
+- F-droid-specific сценарии (если smoke запускается на play-флейворе)
+
+**Не реализованные в коде или dead-code:**
+- LegacyIdentityScreen (legacy pre-BIP39 инстанс)
+- FirstGroupScreen / FirstJoinScreen (определены, но без точки входа в `MainActivity`)
+
+**Не глубоко smoke'аем (только факт рендера):**
+- Settings sub-screens — содержимое (список реле, статусы blossom, контракт): зависит от сети, в smoke только заголовок
+- ContactsScreen — список контактов: зависит от системного разрешения
+
+---
+
+## Связанные авто-тесты
+
+Если smoke упал — сначала прогнать соответствующую стадию авто-теста: если она зелёная, проблема скорее всего в окружении/устройстве, а не в коде.
+
+| Smoke | Стадия `uitests.SoloUserJourneyTest` |
+|---|---|
+| SM-1 | `stage_01_onboarding_sheet_visible_on_first_launch` |
+| SM-2 | `stage_02_walk_through_onboarding_and_dismiss` |
+| SM-3 | `stage_03_create_anarchy_and_send_message` |
+| SM-4 | `stage_04_create_one_on_one_and_send_message` |
+| SM-5 | `stage_05_create_democracy_and_send_message` |
+| SM-6 | `stage_06_create_oligarchy_and_send_message` |
+| SM-7 | `stage_07_open_group_info_from_chat_and_back` |
+| SM-8 | `stage_08_pin_group_then_long_press_shows_unpin` |
+| SM-9 | `stage_09_search_finds_created_group_by_name` |
+| SM-10 | `stage_10_settings_lands_on_invite_tab_by_default` |
+| SM-11 | `stage_11_settings_preferences_shows_all_sections` |
+| SM-12 | `stage_12_settings_sub_screens_open_and_back` |
+| SM-13 | `stage_13_settings_recovery_phrase_intro_and_cancel` |
+| SM-14 | `stage_14_contacts_tab_renders` |
+| SM-15 | `stage_15_returning_to_chats_keeps_all_created_groups` + `@After cleanupCreatedGroups` |
+
+### Прогон всего solo-journey авто-теста:
+
+```bash
+cd clients/android/StellarChat
+./scripts/run-solo-journey.sh
+```
+
+Скрипт делает:
+1. Прогоняет `:app:connectedPlayDebugAndroidTest` с фильтром на `uitests.SoloUserJourneyTest`.
+2. После прогона `adb pull`'ит MD-отчёты с устройства в `result_autotest/autotest-reports/`.
+3. На любом исходе (PASS или FAIL) отчёт включает таймлайн стадий + длительность; на FAIL добавляется stack trace + дамп logcat.
+
+Файлы отчётов: `result_autotest/autotest-reports/solo-journey-YYYYMMDD-HHMMSS-{PASS|FAIL}.md`.
+
+### Ручной прогон (без обёртки):
+
+```bash
+cd clients/android/StellarChat
+./gradlew :app:connectedPlayDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=uitests.SoloUserJourneyTest
+
+# Затем достать отчёт вручную:
+adb pull /sdcard/Android/data/chat.onym.android/files/autotest-reports ./result_autotest/
+```

--- a/clients/android/StellarChat/app/build.gradle.kts
+++ b/clients/android/StellarChat/app/build.gradle.kts
@@ -196,6 +196,19 @@ dependencies {
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
+    androidTestImplementation("androidx.test:core-ktx:1.6.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test.espresso:espresso-intents:3.6.1")
+    androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
+
+    // Compose UI testing — pulls test rule, finders and assertions for Compose semantics tree
+    androidTestImplementation(composeBom)
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    // ui-test-manifest registers the host activity used by createComposeRule(); only
+    // needed in debug variants since release strips test-only manifest entries.
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 }
 
 if (file("google-services.json").exists()) {

--- a/clients/android/StellarChat/app/src/androidTest/java/chat/onym/android/Phase3Tests.kt
+++ b/clients/android/StellarChat/app/src/androidTest/java/chat/onym/android/Phase3Tests.kt
@@ -729,4 +729,155 @@ class Phase3Tests {
         val s2 = SEPCommitmentBuilder.generateSalt()
         assertFalse(s1.contentEquals(s2))
     }
+
+    // -----------------------------------------------------------------------
+    // 13. Tier Constants
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun tier_smallHasExpectedConstants() {
+        assertEquals(32, SEPTier.SMALL.maxMembers)
+        assertEquals(5, SEPTier.SMALL.depth)
+        assertEquals(0, SEPTier.SMALL.id)
+    }
+
+    @Test
+    fun tier_mediumHasExpectedConstants() {
+        assertEquals(256, SEPTier.MEDIUM.maxMembers)
+        assertEquals(8, SEPTier.MEDIUM.depth)
+        assertEquals(1, SEPTier.MEDIUM.id)
+    }
+
+    @Test
+    fun tier_largeHasExpectedConstants() {
+        assertEquals(2048, SEPTier.LARGE.maxMembers)
+        assertEquals(11, SEPTier.LARGE.depth)
+        assertEquals(2, SEPTier.LARGE.id)
+    }
+
+    @Test
+    fun tier_fromIdRoundTripsForEveryTier() {
+        for (tier in SEPTier.entries) {
+            assertEquals(tier, SEPTier.fromId(tier.id))
+        }
+    }
+
+    @Test
+    fun tier_capacityIsPowerOfDepth() {
+        for (tier in SEPTier.entries) {
+            assertEquals(1 shl tier.depth, tier.maxMembers)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 14. Deterministic Salt Derivation
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun deriveSalt_isDeterministic() {
+        val previousSalt = ByteArray(32) { 0x42 }
+        val memberKey = ByteArray(48) { 0x07 }
+        val s1 = SEPCommitmentBuilder.deriveSalt(previousSalt, memberKey)
+        val s2 = SEPCommitmentBuilder.deriveSalt(previousSalt, memberKey)
+        assertArrayEquals(s1, s2)
+        assertEquals(32, s1.size)
+    }
+
+    @Test
+    fun deriveSalt_differentMemberKeysProduceDifferentOutputs() {
+        val previousSalt = ByteArray(32) { 0x42 }
+        val memberA = ByteArray(48) { 0x01 }
+        val memberB = ByteArray(48) { 0x02 }
+        val s1 = SEPCommitmentBuilder.deriveSalt(previousSalt, memberA)
+        val s2 = SEPCommitmentBuilder.deriveSalt(previousSalt, memberB)
+        assertFalse(s1.contentEquals(s2))
+    }
+
+    @Test
+    fun deriveSalt_differentPreviousSaltsProduceDifferentOutputs() {
+        val saltA = ByteArray(32) { 0x01 }
+        val saltB = ByteArray(32) { 0x02 }
+        val memberKey = ByteArray(48) { 0x07 }
+        val s1 = SEPCommitmentBuilder.deriveSalt(saltA, memberKey)
+        val s2 = SEPCommitmentBuilder.deriveSalt(saltB, memberKey)
+        assertFalse(s1.contentEquals(s2))
+    }
+
+    // -----------------------------------------------------------------------
+    // 15. AES-256-GCM Encrypt / Decrypt (instrumented — uses android.util.Base64)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun encryptDecrypt_roundTrip_preservesAscii() {
+        val key = ByteArray(32) { 0x42 }
+        val plaintext = "Hello, secure world!"
+        val sealed = chat.onym.android.crypto.GroupCrypto.encrypt(plaintext, key)
+        val decrypted = chat.onym.android.crypto.GroupCrypto.decrypt(sealed, key)
+        assertEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun encryptDecrypt_roundTrip_preservesUnicode() {
+        val key = ByteArray(32) { 0x07 }
+        val plaintext = "Привет 🧗 — это тест"
+        val sealed = chat.onym.android.crypto.GroupCrypto.encrypt(plaintext, key)
+        val decrypted = chat.onym.android.crypto.GroupCrypto.decrypt(sealed, key)
+        assertEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun encryptDecrypt_roundTrip_preservesEmptyString() {
+        val key = ByteArray(32) { 0x99.toByte() }
+        val plaintext = ""
+        val sealed = chat.onym.android.crypto.GroupCrypto.encrypt(plaintext, key)
+        val decrypted = chat.onym.android.crypto.GroupCrypto.decrypt(sealed, key)
+        assertEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun encryptDecrypt_roundTrip_preservesLongPayload() {
+        val key = ByteArray(32) { 0x33 }
+        val plaintext = "lorem ipsum ".repeat(500) // ~6KB
+        val sealed = chat.onym.android.crypto.GroupCrypto.encrypt(plaintext, key)
+        val decrypted = chat.onym.android.crypto.GroupCrypto.decrypt(sealed, key)
+        assertEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun encrypt_producesNewSealedEnvelopeEachTime() {
+        // AES-GCM uses a random 12-byte nonce, so two encryptions of the
+        // same plaintext under the same key MUST produce distinct ciphertexts.
+        val key = ByteArray(32) { 0x42 }
+        val plaintext = "stable input"
+        val sealed1 = chat.onym.android.crypto.GroupCrypto.encrypt(plaintext, key)
+        val sealed2 = chat.onym.android.crypto.GroupCrypto.encrypt(plaintext, key)
+        assertNotEquals(sealed1, sealed2)
+        // Both still decrypt back to the same plaintext.
+        assertEquals(plaintext, chat.onym.android.crypto.GroupCrypto.decrypt(sealed1, key))
+        assertEquals(plaintext, chat.onym.android.crypto.GroupCrypto.decrypt(sealed2, key))
+    }
+
+    @Test
+    fun encryptedEnvelope_isValidJsonWithExpectedScheme() {
+        val key = ByteArray(32) { 0x42 }
+        val sealed = chat.onym.android.crypto.GroupCrypto.encrypt("payload", key)
+        val obj = org.json.JSONObject(sealed)
+        assertEquals(1, obj.getInt("version"))
+        assertEquals("aes-256-gcm-v1", obj.getString("scheme"))
+        assertTrue(obj.getString("nonce").isNotBlank())
+        assertTrue(obj.getString("ciphertext").isNotBlank())
+        assertTrue(obj.getString("authentication_tag").isNotBlank())
+    }
+
+    @Test
+    fun encryptDecrypt_roundTripWithDerivedMessageKey() {
+        // Mirror production: deriveMessageKey is what real chat sends use.
+        val secret = ByteArray(32) { 0x42 }
+        val salt = ByteArray(32) { 0x07 }
+        val key = chat.onym.android.crypto.GroupCrypto.deriveMessageKey(secret, 0, salt)
+        val plaintext = "production-derived key path"
+        val sealed = chat.onym.android.crypto.GroupCrypto.encrypt(plaintext, key)
+        val decrypted = chat.onym.android.crypto.GroupCrypto.decrypt(sealed, key)
+        assertEquals(plaintext, decrypted)
+    }
 }

--- a/clients/android/StellarChat/app/src/androidTest/java/uitests/Compose.kt
+++ b/clients/android/StellarChat/app/src/androidTest/java/uitests/Compose.kt
@@ -1,0 +1,82 @@
+package uitests
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+
+/**
+ * Default timeout for ordinary UI assertions — 5s is comfortable for any
+ * frame-driven Compose state change on a real device.
+ */
+const val DEFAULT_TIMEOUT_MS = 5_000L
+
+/**
+ * Long timeout for assertions that wait on real network / on-chain settlement.
+ * Soroban testnet ledger close ranges from ~5s to ~30s in practice; allow
+ * 2 minutes so transient relay backoff or testnet congestion doesn't ruin
+ * a full-journey run.
+ */
+const val LONG_TIMEOUT_MS = 120_000L
+
+/** Waits for a node with the given testTag to appear, then returns it. */
+fun ComposeTestRule.awaitTag(
+    tag: String,
+    timeoutMs: Long = DEFAULT_TIMEOUT_MS
+): SemanticsNodeInteraction {
+    waitUntil(timeoutMs) {
+        onAllNodes(hasTestTag(tag)).fetchSemanticsNodes().isNotEmpty()
+    }
+    return onNodeWithTag(tag)
+}
+
+/** Waits for a node with the given text to appear, then returns it. */
+fun ComposeTestRule.awaitText(
+    text: String,
+    substring: Boolean = false,
+    timeoutMs: Long = DEFAULT_TIMEOUT_MS
+): SemanticsNodeInteraction {
+    waitUntil(timeoutMs) {
+        onAllNodesWithText(text, substring = substring).fetchSemanticsNodes().isNotEmpty()
+    }
+    return onNodeWithText(text, substring = substring)
+}
+
+/** Long-timeout variant for waits on real-network/on-chain phases. */
+fun ComposeTestRule.awaitTextLong(
+    text: String,
+    substring: Boolean = false
+): SemanticsNodeInteraction = awaitText(text, substring = substring, timeoutMs = LONG_TIMEOUT_MS)
+
+/** Waits until no node with the given testTag exists. */
+fun ComposeTestRule.awaitTagGone(tag: String, timeoutMs: Long = DEFAULT_TIMEOUT_MS) {
+    waitUntil(timeoutMs) {
+        onAllNodes(hasTestTag(tag)).fetchSemanticsNodes().isEmpty()
+    }
+}
+
+/** Waits until no node with the given text exists. */
+fun ComposeTestRule.awaitTextGone(
+    text: String,
+    substring: Boolean = false,
+    timeoutMs: Long = DEFAULT_TIMEOUT_MS
+) {
+    waitUntil(timeoutMs) {
+        onAllNodesWithText(text, substring = substring).fetchSemanticsNodes().isEmpty()
+    }
+}
+
+private fun SemanticsNodeInteractionsProvider.onAllNodesWithText(
+    text: String,
+    substring: Boolean
+) = onAllNodes(
+    androidx.compose.ui.test.hasText(text, substring = substring)
+)
+
+private fun SemanticsNodeInteractionsProvider.onNodeWithText(
+    text: String,
+    substring: Boolean
+) = onNode(
+    androidx.compose.ui.test.hasText(text, substring = substring)
+)

--- a/clients/android/StellarChat/app/src/androidTest/java/uitests/MarkdownReportRule.kt
+++ b/clients/android/StellarChat/app/src/androidTest/java/uitests/MarkdownReportRule.kt
@@ -1,0 +1,148 @@
+package uitests
+
+import android.os.Build
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Captures the journey of a single instrumented test into a Markdown report
+ * written to the app's external files dir. The wrapper script
+ * `scripts/run-solo-journey.sh` `adb pull`s these into
+ * `clients/android/StellarChat/result_autotest/` after the run.
+ *
+ * On success: header + chronological stage list with elapsed-time offsets.
+ * On failure: above + exception class, message, stack trace, and a tail
+ * of `logcat` filtered to test-relevant tags.
+ *
+ * Reports land in: `/sdcard/Android/data/chat.onym.android/files/autotest-reports/`
+ */
+class MarkdownReportRule : TestWatcher() {
+
+    private data class StageEntry(val elapsedMs: Long, val text: String)
+
+    private val stages = mutableListOf<StageEntry>()
+    private var startMs: Long = 0L
+    private var endMs: Long = 0L
+    private var fullName: String = ""
+    private var failure: Throwable? = null
+
+    /** Called by the test on every `log()` invocation; records elapsed time. */
+    fun logStage(stage: String) {
+        val elapsed = if (startMs == 0L) 0L else System.currentTimeMillis() - startMs
+        stages.add(StageEntry(elapsed, stage))
+    }
+
+    override fun starting(description: Description) {
+        stages.clear()
+        failure = null
+        startMs = System.currentTimeMillis()
+        fullName = "${description.className}.${description.methodName}"
+    }
+
+    override fun succeeded(description: Description) {
+        endMs = System.currentTimeMillis()
+        writeReport(passed = true)
+    }
+
+    override fun failed(e: Throwable, description: Description) {
+        endMs = System.currentTimeMillis()
+        failure = e
+        writeReport(passed = false)
+    }
+
+    private fun writeReport(passed: Boolean) {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val outDir = ctx.getExternalFilesDir(REPORT_DIR_NAME)
+        if (outDir == null) {
+            Log.w(TAG, "external files dir unavailable — skipping report")
+            return
+        }
+        outDir.mkdirs()
+
+        val fileTimestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.ROOT).format(Date(startMs))
+        val statusTag = if (passed) "PASS" else "FAIL"
+        val outFile = File(outDir, "solo-journey-$fileTimestamp-$statusTag.md")
+
+        val durationS = (endMs - startMs) / 1000.0
+
+        val md = buildString {
+            appendLine("# SoloUserJourneyTest — $statusTag")
+            appendLine()
+            appendLine("| Field | Value |")
+            appendLine("|---|---|")
+            appendLine("| Test | `$fullName` |")
+            appendLine("| Status | **$statusTag** |")
+            appendLine("| Started | ${isoUtc(startMs)} |")
+            appendLine("| Finished | ${isoUtc(endMs)} |")
+            appendLine("| Duration | ${"%.1f".format(durationS)} s |")
+            appendLine("| Device | ${Build.MANUFACTURER} ${Build.MODEL} |")
+            appendLine("| Android | ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT}) |")
+            appendLine("| Build fingerprint | `${Build.FINGERPRINT}` |")
+            appendLine()
+            appendLine("## Stage timeline (${stages.size} entries)")
+            appendLine()
+            appendLine("```")
+            stages.forEach { e ->
+                appendLine("[+%7.3fs] %s".format(e.elapsedMs / 1000.0, e.text))
+            }
+            appendLine("```")
+
+            if (!passed && failure != null) {
+                appendLine()
+                appendLine("## Failure")
+                appendLine()
+                val lastStage = stages.lastOrNull()?.text ?: "(no stages logged)"
+                appendLine("- **Last stage before failure:** `$lastStage`")
+                appendLine("- **Exception:** `${failure!!.javaClass.name}`")
+                val msg = failure!!.message ?: ""
+                if (msg.isNotEmpty()) {
+                    appendLine("- **Message:** $msg")
+                }
+                appendLine()
+                appendLine("### Stack trace")
+                appendLine()
+                appendLine("```")
+                appendLine(failure!!.stackTraceToString().trim())
+                appendLine("```")
+                appendLine()
+                appendLine("### Logcat tail (filtered)")
+                appendLine()
+                appendLine("```")
+                append(captureLogcat())
+                appendLine("```")
+            }
+        }
+
+        runCatching { outFile.writeText(md) }
+            .onSuccess { Log.i(TAG, "wrote ${outFile.absolutePath}") }
+            .onFailure { Log.e(TAG, "failed to write report: ${it.message}") }
+    }
+
+    private fun captureLogcat(): String = runCatching {
+        val proc = Runtime.getRuntime().exec(
+            arrayOf(
+                "logcat", "-d", "-v", "time", "-t", "5000",
+                "SoloUserJourneyTest:I", "TestRunner:I", "AndroidRuntime:E",
+                "MarkdownReportRule:I", "GroupListVM:I", "*:S"
+            )
+        )
+        proc.inputStream.bufferedReader().use { it.readText() }
+    }.getOrElse { "(failed to capture logcat: ${it.message})\n" }
+
+    private fun isoUtc(ms: Long): String {
+        val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT)
+        fmt.timeZone = java.util.TimeZone.getTimeZone("UTC")
+        return fmt.format(Date(ms))
+    }
+
+    companion object {
+        private const val TAG = "MarkdownReportRule"
+        const val REPORT_DIR_NAME = "autotest-reports"
+    }
+}

--- a/clients/android/StellarChat/app/src/androidTest/java/uitests/Robots.kt
+++ b/clients/android/StellarChat/app/src/androidTest/java/uitests/Robots.kt
@@ -1,0 +1,278 @@
+package uitests
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.performTouchInput
+import chat.onym.android.ui.TestTags
+
+/**
+ * Page-object/robot helpers for the solo-user journey suite.
+ *
+ * Each robot exposes a small, intention-oriented vocabulary for one screen so
+ * tests read top-down and don't need to know which testTag or text label
+ * drives a particular action. Robots are stateless — each method takes the
+ * [ComposeTestRule] in via the constructor.
+ *
+ * This file is the *only* robot definition in the test suite (the older
+ * per-class test files and their robots have been folded into one).
+ */
+
+// ── GroupListScreen ────────────────────────────────────────────────────
+
+class GroupListRobot(private val rule: ComposeTestRule) {
+
+    fun assertOnScreen() = apply {
+        rule.awaitTag(TestTags.GroupList.Screen).assertIsDisplayed()
+    }
+
+    fun assertGroupVisible(name: String) = apply {
+        rule.awaitText(name)
+    }
+
+    fun assertGroupGone(name: String) = apply {
+        rule.awaitTextGone(name)
+    }
+
+    fun openGroup(name: String) = apply {
+        rule.awaitText(name).performClick()
+    }
+
+    fun longPressGroup(name: String) = apply {
+        rule.awaitText(name).performTouchInput { longClick() }
+    }
+
+    fun tapAddFab() = apply {
+        rule.awaitTag(TestTags.GroupList.Fab).performClick()
+    }
+
+    fun assertAddDialogVisible() = apply {
+        rule.awaitText("Add Group")
+        rule.onNodeWithText("Create a new group or join an existing one?").assertIsDisplayed()
+    }
+
+    fun chooseCreateInAddDialog() = apply {
+        rule.onNodeWithText("Create").performClick()
+    }
+
+    // Pin and Unpin share one testTag — only one of the two labels is rendered
+    // at a time depending on group.isPinned, so a single tag is unambiguous and
+    // avoids text-matching against the dialog title (which is the group name).
+    fun choosePinInContextMenu() = apply {
+        rule.awaitTag(TestTags.GroupList.ContextMenuPin).performClick()
+    }
+
+    fun chooseUnpinInContextMenu() = apply {
+        rule.awaitTag(TestTags.GroupList.ContextMenuPin).performClick()
+    }
+
+    fun chooseDeleteInContextMenu() = apply {
+        rule.awaitTag(TestTags.GroupList.ContextMenuDelete).performClick()
+    }
+
+    fun chooseCancelInContextMenu() = apply {
+        rule.awaitTag(TestTags.GroupList.ContextMenuCancel).performClick()
+    }
+
+    /** Confirms the destructive Delete action in the confirm-delete AlertDialog. */
+    fun confirmDeleteAction() = apply {
+        rule.awaitTag(TestTags.GroupList.DeleteDialogConfirm).performClick()
+    }
+}
+
+// ── ChatScreen ────────────────────────────────────────────────────────
+
+class ChatRobot(private val rule: ComposeTestRule) {
+
+    fun assertOnScreen(groupName: String) = apply {
+        rule.awaitTag(TestTags.Chat.Screen).assertIsDisplayed()
+        rule.onNodeWithText(groupName).assertIsDisplayed()
+    }
+
+    fun assertMessageVisible(text: String) = apply {
+        rule.awaitText(text)
+    }
+
+    fun typeAndSend(text: String) = apply {
+        rule.awaitTag(TestTags.Chat.MessageInput).performTextInput(text)
+        rule.awaitTag(TestTags.Chat.SendButton).performClick()
+    }
+
+    fun goBack() = apply {
+        rule.awaitTag(TestTags.Chat.Back).performClick()
+    }
+
+    fun openGroupInfo() = apply {
+        rule.awaitTag(TestTags.Chat.GroupInfo).performClick()
+    }
+
+    /**
+     * Soft check: at least one of {Sending, Sent, Delivered} is visible on
+     * a freshly-sent "me" message. We don't insist on FAILED never appearing
+     * because real public Nostr relays may rate-limit a freshly-keyed test
+     * client; the "Tap to retry" indicator is informational, not a fatal
+     * failure for the journey.
+     */
+    fun assertOutgoingStatusIconVisible() = apply {
+        rule.waitUntil(LONG_TIMEOUT_MS) {
+            val sending = rule.onAllNodesWithContentDescription("Sending").fetchSemanticsNodes()
+            val sent = rule.onAllNodesWithContentDescription("Sent").fetchSemanticsNodes()
+            val delivered = rule.onAllNodesWithContentDescription("Delivered").fetchSemanticsNodes()
+            val failed = rule.onAllNodesWithContentDescription("Tap to retry").fetchSemanticsNodes()
+            sending.isNotEmpty() || sent.isNotEmpty() || delivered.isNotEmpty() || failed.isNotEmpty()
+        }
+    }
+}
+
+// ── CreateGroupScreen ─────────────────────────────────────────────────
+
+class CreateGroupRobot(private val rule: ComposeTestRule) {
+
+    fun assertOnScreen() = apply {
+        rule.awaitTag(TestTags.CreateGroup.Screen).assertIsDisplayed()
+        rule.onNodeWithText("New Group").assertIsDisplayed()
+        rule.onNodeWithText("Step 1 of 2").assertIsDisplayed()
+    }
+
+    fun typeGroupName(name: String) = apply {
+        rule.awaitTag(TestTags.CreateGroup.NameField).performTextInput(name)
+    }
+
+    fun selectGovernance(label: String) = apply {
+        rule.onNodeWithText(label).performScrollTo().performClick()
+    }
+
+    fun tapNext() = apply {
+        rule.awaitTag(TestTags.CreateGroup.NextButton).performClick()
+    }
+
+    fun assertOnPeopleStep() = apply {
+        rule.awaitText("Step 2 of 2")
+        rule.awaitTag(TestTags.CreateGroup.CreateButton).assertIsDisplayed()
+    }
+
+    fun tapCreate() = apply {
+        rule.awaitTag(TestTags.CreateGroup.CreateButton).performClick()
+    }
+
+    /**
+     * Wait for the DONE phase: the topbar action becomes "Open" once the
+     * pipeline (createGroup → addGroup → on-chain publish → invitations →
+     * DONE) completes. With the production network enabled this involves a
+     * real Soroban testnet round-trip, hence the long timeout.
+     */
+    fun awaitDoneStage() = apply {
+        rule.awaitTextLong("Open")
+    }
+
+    fun tapOpen() = apply {
+        rule.onNodeWithText("Open").performClick()
+    }
+
+    fun createAndOpen() = apply {
+        tapCreate()
+        awaitDoneStage()
+        tapOpen()
+    }
+}
+
+// ── SettingsScreen ────────────────────────────────────────────────────
+
+class SettingsRobot(private val rule: ComposeTestRule) {
+
+    fun assertOnScreen() = apply {
+        rule.awaitTag(TestTags.Settings.Screen).assertIsDisplayed()
+    }
+
+    fun selectPreferencesTab() = apply {
+        rule.awaitTag(TestTags.Settings.PreferencesTab).performClick()
+    }
+
+    fun selectInviteTab() = apply {
+        rule.awaitTag(TestTags.Settings.InviteTab).performClick()
+    }
+
+    fun assertNetworkSectionVisible() = apply { rule.awaitText("NETWORK") }
+    fun assertSecuritySectionVisible() = apply { rule.awaitText("SECURITY") }
+    fun assertAboutSectionVisible() = apply { rule.awaitText("ABOUT") }
+    fun assertProtocolSectionVisible() = apply { rule.awaitText("PROTOCOL") }
+    fun assertAdvancedSectionVisible() = apply { rule.awaitText("ADVANCED") }
+    fun assertShareLinkButtonVisible() = apply { rule.awaitText("Share link") }
+
+    fun tapRelaysRow() = apply { rule.awaitText("Relays").performClick() }
+    fun tapBlossomRow() = apply { rule.awaitText("Blossom Servers").performClick() }
+    fun tapStellarContractRow() = apply { rule.awaitText("Stellar Contract").performClick() }
+    fun tapAdvancedRow() = apply { rule.awaitText("Advanced").performClick() }
+    fun tapBackupRecoveryPhraseRow() = apply { rule.awaitText("Backup Recovery Phrase").performClick() }
+}
+
+// ── SearchScreen ──────────────────────────────────────────────────────
+
+class SearchRobot(private val rule: ComposeTestRule) {
+
+    fun assertOnScreen() = apply {
+        rule.awaitTag(TestTags.Search.Screen).assertIsDisplayed()
+    }
+
+    fun typeQuery(text: String) = apply {
+        rule.awaitTag(TestTags.Search.Field).performTextInput(text)
+    }
+
+    fun clearQuery() = apply {
+        rule.awaitTag(TestTags.Search.Field).performTextReplacement("")
+    }
+
+    fun assertResultVisible(text: String) = apply {
+        rule.awaitText(text)
+    }
+}
+
+// ── BottomNav ─────────────────────────────────────────────────────────
+
+class BottomNavRobot(private val rule: ComposeTestRule) {
+    fun openContacts() = apply { rule.awaitTag(TestTags.BottomNav.item("contacts")).performClick() }
+    fun openChats() = apply { rule.awaitTag(TestTags.BottomNav.item("groups")).performClick() }
+    fun openSearch() = apply { rule.awaitTag(TestTags.BottomNav.item("search")).performClick() }
+    fun openSettings() = apply { rule.awaitTag(TestTags.BottomNav.item("settings")).performClick() }
+}
+
+// ── OnboardingSheet ───────────────────────────────────────────────────
+
+class OnboardingSheetRobot(private val rule: ComposeTestRule) {
+
+    fun assertVisible() = apply {
+        rule.awaitTag(TestTags.GroupList.OnboardingSheet).assertIsDisplayed()
+    }
+
+    fun tapPrimary() = apply {
+        rule.awaitTag(TestTags.GroupList.OnboardingPrimaryButton).performClick()
+    }
+
+    fun tapRestoreFromRecoveryPhrase() = apply {
+        rule.awaitText("Restore from Recovery Phrase").performClick()
+    }
+}
+
+// ── Generic helpers ───────────────────────────────────────────────────
+
+/**
+ * Sub-screens (Relays, Blossom, Stellar Contract, Advanced, Recovery Phrase,
+ * Restore Identity, Group Info) all use the standard back-arrow with
+ * contentDescription "Back" for their TopAppBar nav icon. This is the only
+ * "Back" content description in the app, so a single generic helper avoids
+ * a dedicated robot for each one.
+ */
+fun ComposeTestRule.tapBackArrow() {
+    onNode(hasContentDescription("Back")).performClick()
+}

--- a/clients/android/StellarChat/app/src/androidTest/java/uitests/SessionPrefs.kt
+++ b/clients/android/StellarChat/app/src/androidTest/java/uitests/SessionPrefs.kt
@@ -1,0 +1,32 @@
+package uitests
+
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+
+/**
+ * Minimal pre-test reset.
+ *
+ * The previous suite (`Prefs.kt`) wiped *every* SharedPreferences bucket and
+ * forced empty strings into `relay_urls`/`endpoint`/`contract_id`/`relayer_url`,
+ * which severed all real networking. The user wants tests to run with the
+ * **production network** intact (Nostr relays, Soroban contract, relayer),
+ * so we no longer touch those buckets.
+ *
+ * What we still need to clear is the onboarding-seen flag — otherwise on a
+ * device that has already run the app once the welcome bottom sheet won't
+ * render and the journey can't start. The same applies to the in-chat first-
+ * group welcome bubble.
+ *
+ * We do NOT wipe the Room database (`stellar_chat.db`) — the device may be
+ * the user's daily driver and contain real groups. The journey creates
+ * groups with unique names ("Anarchy Crew QA", …) and deletes them at the
+ * end, leaving any pre-existing state untouched.
+ */
+fun clearOnboardingFlags() {
+    val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+    ctx.getSharedPreferences("stellar_chat", Context.MODE_PRIVATE)
+        .edit()
+        .remove("has_seen_onboarding")
+        .remove("has_seen_first_group_welcome")
+        .commit()
+}

--- a/clients/android/StellarChat/app/src/androidTest/java/uitests/SoloUserJourneyTest.kt
+++ b/clients/android/StellarChat/app/src/androidTest/java/uitests/SoloUserJourneyTest.kt
@@ -1,0 +1,393 @@
+package uitests
+
+import android.util.Log
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.MainActivity
+import chat.onym.android.ui.TestTags
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+
+/**
+ * Single-session solo-user journey for the Android client.
+ *
+ * The full suite of UI scenarios (onboarding, creation per governance,
+ * settings, sub-screens, search, contacts, pin) lives inside ONE
+ * `@Test` method. The Activity launches once at rule entry and stays in
+ * the foreground for the whole journey — there are no intermediate
+ * Activity restarts and no white screens between stages. Cleanup
+ * (deleting the four `… QA` groups the journey created) lives in
+ * `@After` so it runs even when an earlier stage throws — otherwise a
+ * failure mid-journey would strand the temp groups on the device.
+ *
+ * **Production network is on.** Earlier iterations of this suite cleared
+ * `relay_urls`, `endpoint`, `contract_id`, and `relayer_url` to make tests
+ * deterministic, which had the side-effect of disabling all real I/O.
+ * The user wants real coverage: groups are published to Soroban testnet
+ * and messages are sent over Nostr. That makes some assertions slower
+ * (`awaitDoneStage` waits up to 2 minutes) and tolerant of transient relay
+ * back-pressure (`assertOutgoingStatusIconVisible` accepts FAILED as a valid
+ * status, just not the absence of any status icon).
+ *
+ * **No demo seeding.** The Activity launches without `demo=true`, so there
+ * are no `Climbing Crew` / `Family` fixtures. Every group the journey
+ * touches is created fresh inside the run with a `… QA` suffix to keep it
+ * distinguishable from the user's real groups (the Room DB is intentionally
+ * not wiped — this device may be a daily driver).
+ *
+ * **Run command:**
+ * ```
+ * ./gradlew :app:connectedPlayDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=uitests.SoloUserJourneyTest
+ * ```
+ */
+@RunWith(AndroidJUnit4::class)
+class SoloUserJourneyTest {
+
+    // Outermost rule — captures stage timeline / failure / logcat into a
+    // Markdown report under the app's external files dir. Must wrap the
+    // compose rule so it sees teardown failures too.
+    @get:Rule(order = 0)
+    val reportRule = MarkdownReportRule()
+
+    @get:Rule(order = 1)
+    val prefsResetRule: TestRule = TestRule { base: Statement, _: Description ->
+        object : Statement() {
+            override fun evaluate() {
+                clearOnboardingFlags()
+                base.evaluate()
+            }
+        }
+    }
+
+    @get:Rule(order = 2)
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    private val onboarding get() = OnboardingSheetRobot(composeTestRule)
+    private val list get() = GroupListRobot(composeTestRule)
+    private val chat get() = ChatRobot(composeTestRule)
+    private val create get() = CreateGroupRobot(composeTestRule)
+    private val nav get() = BottomNavRobot(composeTestRule)
+    private val search get() = SearchRobot(composeTestRule)
+    private val settings get() = SettingsRobot(composeTestRule)
+
+    // Unique group names — the `QA` suffix keeps them out of any real groups
+    // the user already has on the device.
+    private val anarchy = "Anarchy Crew QA"
+    private val oneOnOne = "Direct Bob QA"
+    private val democracy = "Democracy Council QA"
+    private val oligarchy = "Oligarchy Inner QA"
+    private val createdGroups = listOf(anarchy, oneOnOne, democracy, oligarchy)
+
+    @Test
+    fun complete_solo_journey() {
+        stage_01_onboarding_sheet_visible_on_first_launch()
+        stage_02_walk_through_onboarding_and_dismiss()
+        stage_03_create_anarchy_and_send_message()
+        stage_04_create_one_on_one_and_send_message()
+        stage_05_create_democracy_and_send_message()
+        stage_06_create_oligarchy_and_send_message()
+        stage_07_open_group_info_from_chat_and_back()
+        stage_08_pin_group_then_long_press_shows_unpin()
+        stage_09_search_finds_created_group_by_name()
+        stage_10_settings_lands_on_invite_tab_by_default()
+        stage_11_settings_preferences_shows_all_sections()
+        stage_12_settings_sub_screens_open_and_back()
+        stage_13_settings_recovery_phrase_intro_and_cancel()
+        stage_14_contacts_tab_renders()
+        stage_15_returning_to_chats_keeps_all_created_groups()
+        log("✓ all stages passed")
+    }
+
+    /**
+     * Cleanup runs unconditionally — even if any earlier stage threw — so the
+     * device returns to its prior state (the journey created `… QA` groups,
+     * and this is the user's daily-driver phone). After a failure we don't
+     * know which screen we're on, so we try up to 5 back-presses to dismiss
+     * any open dialog/sub-screen, stopping early once the GroupList screen
+     * tag becomes visible. `pressBackUnconditionally` avoids throwing if a
+     * back-press at the root would dismiss the activity; we never press back
+     * once the list is already on top. Each per-group delete is wrapped in
+     * `runCatching` so one stuck delete doesn't strand the others.
+     */
+    @After
+    fun cleanupCreatedGroups() {
+        log("@After cleanup → delete created groups")
+        repeat(5) {
+            if (groupListVisible()) return@repeat
+            runCatching { Espresso.pressBackUnconditionally() }
+        }
+        runCatching { nav.openChats() }
+        runCatching { list.assertOnScreen() }
+        createdGroups.forEach { name ->
+            // Group may not exist (creation failed) or already be deleted.
+            val present = composeTestRule.onAllNodesWithText(name).fetchSemanticsNodes().isNotEmpty()
+            if (!present) {
+                log("@After skip $name (not present)")
+                return@forEach
+            }
+            runCatching {
+                list.longPressGroup(name)
+                    .chooseDeleteInContextMenu()
+                    .confirmDeleteAction()
+                list.assertGroupGone(name)
+                log("@After deleted $name")
+            }.onFailure { Log.w(TAG, "@After failed to delete $name: ${it.message}") }
+        }
+    }
+
+    private fun groupListVisible(): Boolean = runCatching {
+        composeTestRule
+            .onAllNodes(androidx.compose.ui.test.hasTestTag(TestTags.GroupList.Screen))
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+    }.getOrDefault(false)
+
+    // ── 01–02: onboarding ───────────────────────────────────────────────
+    //
+    // Note: the "Restore from Recovery Phrase" flow is intentionally NOT
+    // covered here. Its TextButton onClick calls both onRestore() (navigate)
+    // AND onDismiss() (write has_seen_onboarding=true, hide sheet) — see
+    // GroupListScreen.kt around line 649. Once you tap it, the onboarding
+    // sheet is gone for the rest of the session, which would cut off all
+    // subsequent onboarding-page assertions. Restore-identity also overwrites
+    // the live KeyManager via replaceKeyManager(), which is destructive and
+    // outside the user's "solo, non-destructive" scope.
+
+    private fun stage_01_onboarding_sheet_visible_on_first_launch() {
+        log("stage_01 onboarding sheet visible")
+        onboarding.assertVisible()
+        composeTestRule.awaitText("metadata are encrypted", substring = true)
+    }
+
+    private fun stage_02_walk_through_onboarding_and_dismiss() {
+        log("stage_02 walk through onboarding pages and dismiss")
+        // Page 1 → 2
+        onboarding.tapPrimary()
+        composeTestRule.awaitText("Private by design", substring = true)
+        // Page 2 → 3
+        onboarding.tapPrimary()
+        composeTestRule.awaitText("Truly shared ownership", substring = true)
+        // Page 3 → 4
+        onboarding.tapPrimary()
+        composeTestRule.awaitText("What makes this different")
+        composeTestRule.awaitText("Get Started")
+        // Get Started → dismiss
+        onboarding.tapPrimary()
+        composeTestRule.awaitTagGone(TestTags.GroupList.OnboardingSheet)
+        list.assertOnScreen()
+    }
+
+    // ── 03–06: create one group of each governance and send a message ──
+
+    private fun stage_03_create_anarchy_and_send_message() {
+        log("stage_03 create anarchy + send")
+        list.tapAddFab().assertAddDialogVisible().chooseCreateInAddDialog()
+        create
+            .assertOnScreen()
+            .typeGroupName(anarchy)
+            .selectGovernance("Anarchy")
+            .tapNext()
+            .assertOnPeopleStep()
+            .createAndOpen()
+        chat.assertOnScreen(anarchy)
+            .typeAndSend("Hello anarchy")
+            .assertMessageVisible("Hello anarchy")
+            .assertOutgoingStatusIconVisible()
+            .goBack()
+        list.assertOnScreen().assertGroupVisible(anarchy)
+    }
+
+    private fun stage_04_create_one_on_one_and_send_message() {
+        log("stage_04 create 1v1 + send")
+        list.tapAddFab().chooseCreateInAddDialog()
+        create
+            .assertOnScreen()
+            .typeGroupName(oneOnOne)
+            .selectGovernance("1v1")
+            .tapNext()
+            .assertOnPeopleStep()
+            .createAndOpen()
+        chat.assertOnScreen(oneOnOne)
+            .typeAndSend("Hi Bob")
+            .assertMessageVisible("Hi Bob")
+            .assertOutgoingStatusIconVisible()
+            .goBack()
+        list.assertOnScreen().assertGroupVisible(oneOnOne)
+    }
+
+    private fun stage_05_create_democracy_and_send_message() {
+        log("stage_05 create democracy + send")
+        list.tapAddFab().chooseCreateInAddDialog()
+        create
+            .assertOnScreen()
+            .typeGroupName(democracy)
+            .selectGovernance("Democracy")
+            .tapNext()
+            .assertOnPeopleStep()
+            .createAndOpen()
+        chat.assertOnScreen(democracy)
+            .typeAndSend("Vote on motion")
+            .assertMessageVisible("Vote on motion")
+            .assertOutgoingStatusIconVisible()
+            .goBack()
+        list.assertOnScreen().assertGroupVisible(democracy)
+    }
+
+    private fun stage_06_create_oligarchy_and_send_message() {
+        log("stage_06 create oligarchy + send")
+        list.tapAddFab().chooseCreateInAddDialog()
+        create
+            .assertOnScreen()
+            .typeGroupName(oligarchy)
+            .selectGovernance("Oligarchy")
+            .tapNext()
+            .assertOnPeopleStep()
+            .createAndOpen()
+        chat.assertOnScreen(oligarchy)
+            .typeAndSend("Quorum check")
+            .assertMessageVisible("Quorum check")
+            .assertOutgoingStatusIconVisible()
+            .goBack()
+        list.assertOnScreen().assertGroupVisible(oligarchy)
+    }
+
+    // ── 07: GroupInfoScreen open + back ─────────────────────────────────
+
+    private fun stage_07_open_group_info_from_chat_and_back() {
+        log("stage_07 group info open + back")
+        list.openGroup(anarchy)
+        chat.assertOnScreen(anarchy).openGroupInfo()
+        // Hero shows the group name + "End-to-end encrypted" chip.
+        composeTestRule.awaitText(anarchy)
+        composeTestRule.awaitText("End-to-end encrypted")
+        composeTestRule.awaitText("MEMBERS")
+        composeTestRule.tapBackArrow()
+        chat.assertOnScreen(anarchy).goBack()
+        list.assertOnScreen()
+    }
+
+    // ── 08: pin / unpin via context menu ───────────────────────────────
+
+    private fun stage_08_pin_group_then_long_press_shows_unpin() {
+        log("stage_08 pin → context menu shows Unpin")
+        list.longPressGroup(anarchy)
+        composeTestRule.awaitTag(TestTags.GroupList.ContextMenu)
+        list.choosePinInContextMenu()
+        // togglePinGroup re-sorts the list (pinned floats to top) AND closes
+        // the dialog. Wait for the dialog tag to be gone before the next
+        // long-press — otherwise the gesture lands on the still-open
+        // AlertDialog scrim and the context menu never reopens.
+        composeTestRule.awaitTagGone(TestTags.GroupList.ContextMenu)
+        list.assertOnScreen()
+        list.longPressGroup(anarchy)
+        composeTestRule.awaitTag(TestTags.GroupList.ContextMenu)
+        list.chooseUnpinInContextMenu()
+        composeTestRule.awaitTagGone(TestTags.GroupList.ContextMenu)
+        // Restore default (unpinned) state for the rest of the journey.
+        list.assertOnScreen().assertGroupVisible(anarchy)
+    }
+
+    // ── 09: search ─────────────────────────────────────────────────────
+
+    private fun stage_09_search_finds_created_group_by_name() {
+        log("stage_09 search by name")
+        nav.openSearch()
+        search
+            .assertOnScreen()
+            .typeQuery("Anarchy Crew")
+            .assertResultVisible(anarchy)
+            .clearQuery()
+    }
+
+    // ── 10–13: settings ────────────────────────────────────────────────
+
+    private fun stage_10_settings_lands_on_invite_tab_by_default() {
+        log("stage_10 settings invite tab default")
+        nav.openSettings()
+        settings
+            .assertOnScreen()
+            .assertShareLinkButtonVisible()
+    }
+
+    private fun stage_11_settings_preferences_shows_all_sections() {
+        log("stage_11 settings preferences sections")
+        settings
+            .selectPreferencesTab()
+            .assertNetworkSectionVisible()
+            .assertProtocolSectionVisible()
+            .assertSecuritySectionVisible()
+            .assertAdvancedSectionVisible()
+            .assertAboutSectionVisible()
+    }
+
+    private fun stage_12_settings_sub_screens_open_and_back() {
+        log("stage_12 sub-screens open + back ×4")
+        // Relays
+        settings.tapRelaysRow()
+        composeTestRule.awaitText("ADD RELAY")
+        composeTestRule.tapBackArrow()
+        settings.assertOnScreen()
+        // Blossom
+        settings.tapBlossomRow()
+        composeTestRule.awaitText("ADD SERVER")
+        composeTestRule.tapBackArrow()
+        settings.assertOnScreen()
+        // Stellar Contract — anchor on a header unique to that screen
+        settings.tapStellarContractRow()
+        composeTestRule.awaitText("RELAYER (OPTIONAL)")
+        composeTestRule.tapBackArrow()
+        settings.assertOnScreen()
+        // Advanced
+        settings.tapAdvancedRow()
+        composeTestRule.awaitText("NOSTR IDENTITY")
+        composeTestRule.tapBackArrow()
+        settings.assertOnScreen()
+    }
+
+    private fun stage_13_settings_recovery_phrase_intro_and_cancel() {
+        log("stage_13 recovery phrase intro + cancel")
+        settings.selectPreferencesTab().tapBackupRecoveryPhraseRow()
+        // Intro step's TopAppBar title is "Back up keys".
+        composeTestRule.awaitText("Back up keys")
+        // Intro step nav icon is a TextButton labelled "Cancel".
+        composeTestRule.onNode(androidx.compose.ui.test.hasText("Cancel")).performClick()
+        settings.assertOnScreen()
+    }
+
+    // ── 14–15: bottom-nav tour ─────────────────────────────────────────
+
+    private fun stage_14_contacts_tab_renders() {
+        log("stage_14 contacts tab renders")
+        nav.openContacts()
+        composeTestRule.awaitTag(TestTags.Contacts.Screen)
+    }
+
+    private fun stage_15_returning_to_chats_keeps_all_created_groups() {
+        log("stage_15 back to chats keeps all 4 groups")
+        nav.openChats()
+        list.assertOnScreen()
+        createdGroups.forEach { list.assertGroupVisible(it) }
+    }
+
+    // Cleanup of created groups happens unconditionally in `@After`
+    // (`cleanupCreatedGroups`), not in the journey body — so groups still get
+    // removed when an earlier stage throws.
+
+    private fun log(stage: String) {
+        Log.i(TAG, "▶︎ $stage")
+        reportRule.logStage(stage)
+    }
+
+    companion object {
+        private const val TAG = "SoloUserJourneyTest"
+    }
+}

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/MainActivity.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import chat.onym.android.ui.TestTags
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -190,7 +192,7 @@ fun StellarChatNavHost(
     Scaffold(
         bottomBar = {
             if (showBottomBar) {
-                NavigationBar {
+                NavigationBar(modifier = Modifier.testTag(TestTags.BottomNav.Bar)) {
                     tabs.forEach { tab ->
                         NavigationBarItem(
                             selected = currentRoute == tab.route,
@@ -204,7 +206,8 @@ fun StellarChatNavHost(
                                 }
                             },
                             icon = { Icon(tab.icon, contentDescription = tab.label) },
-                            label = { Text(tab.label) }
+                            label = { Text(tab.label) },
+                            modifier = Modifier.testTag(TestTags.BottomNav.item(tab.route))
                         )
                     }
                 }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/TestTags.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/TestTags.kt
@@ -1,0 +1,67 @@
+package chat.onym.android.ui
+
+object TestTags {
+    object GroupList {
+        const val Screen = "groupList.screen"
+        const val Fab = "groupList.fab"
+        const val InvitationsButton = "groupList.invitations"
+        const val OnboardingSheet = "groupList.onboardingSheet"
+        const val OnboardingPrimaryButton = "groupList.onboarding.primary"
+        const val EmptyState = "groupList.empty"
+        // Long-press context menu (Pin/Unpin shares one tag — only one is shown at a time).
+        const val ContextMenu = "groupList.contextMenu"
+        const val ContextMenuPin = "groupList.contextMenu.pin"
+        const val ContextMenuDelete = "groupList.contextMenu.delete"
+        const val ContextMenuCancel = "groupList.contextMenu.cancel"
+        // Confirm-delete AlertDialog.
+        const val DeleteDialogConfirm = "groupList.deleteDialog.confirm"
+        const val DeleteDialogCancel = "groupList.deleteDialog.cancel"
+        fun item(id: String) = "groupList.item.$id"
+    }
+
+    object Chat {
+        const val Screen = "chat.screen"
+        const val Back = "chat.back"
+        const val GroupInfo = "chat.groupInfo"
+        const val MessageInput = "chat.messageInput"
+        const val SendButton = "chat.send"
+    }
+
+    object CreateGroup {
+        const val Screen = "createGroup.screen"
+        const val NameField = "createGroup.name"
+        const val NextButton = "createGroup.next"
+        const val CreateButton = "createGroup.create"
+        const val CancelButton = "createGroup.cancel"
+        const val BackButton = "createGroup.back"
+    }
+
+    object JoinGroup {
+        const val Screen = "joinGroup.screen"
+        const val InviteField = "joinGroup.invite"
+        const val PasteButton = "joinGroup.paste"
+        const val ScanButton = "joinGroup.scan"
+    }
+
+    object Settings {
+        const val Screen = "settings.screen"
+        const val InviteTab = "settings.tab.invite"
+        const val PreferencesTab = "settings.tab.preferences"
+        const val ShareLink = "settings.shareLink"
+        const val CopyKey = "settings.copyKey"
+    }
+
+    object Search {
+        const val Screen = "search.screen"
+        const val Field = "search.field"
+    }
+
+    object Contacts {
+        const val Screen = "contacts.screen"
+    }
+
+    object BottomNav {
+        const val Bar = "bottomNav.bar"
+        fun item(route: String) = "bottomNav.item.$route"
+    }
+}

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ChatScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ChatScreen.kt
@@ -88,6 +88,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import chat.onym.android.ui.TestTags
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.text.font.FontWeight
@@ -167,16 +169,23 @@ fun ChatScreen(
     }
 
     Scaffold(
+        modifier = Modifier.testTag(TestTags.Chat.Screen),
         topBar = {
             TopAppBar(
                 title = { Text(groupName) },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag(TestTags.Chat.Back)
+                    ) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
                 actions = {
-                    IconButton(onClick = onGroupInfo) {
+                    IconButton(
+                        onClick = onGroupInfo,
+                        modifier = Modifier.testTag(TestTags.Chat.GroupInfo)
+                    ) {
                         Icon(Icons.Filled.Group, contentDescription = "Group Info")
                     }
                 }
@@ -757,7 +766,9 @@ fun ChatScreen(
                     TextField(
                         value = viewModel.inputText,
                         onValueChange = { viewModel.inputText = it },
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag(TestTags.Chat.MessageInput),
                         placeholder = { Text("Message...") },
                         singleLine = true
                     )
@@ -772,7 +783,8 @@ fun ChatScreen(
                             onClick = {
                                 view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
                                 viewModel.sendMessage()
-                            }
+                            },
+                            modifier = Modifier.testTag(TestTags.Chat.SendButton)
                         ) {
                             Icon(
                                 Icons.AutoMirrored.Filled.Send,

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ContactsScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/ContactsScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import chat.onym.android.ui.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -154,7 +156,9 @@ fun ContactsScreen(
 
     val isEmpty = activeContacts.isEmpty() && invitedPending.isEmpty() && phonebook.isEmpty()
 
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(modifier = Modifier
+        .fillMaxSize()
+        .testTag(TestTags.Contacts.Screen)) {
         if (isEmpty && permission != ContactsPermission.AUTHORIZED) {
             item {
                 Box(

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/CreateGroupScreen.kt
@@ -80,8 +80,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import chat.onym.android.ui.TestTags
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -170,6 +172,7 @@ fun CreateGroupScreen(
     val bg = MaterialTheme.colorScheme.surfaceContainerLowest
 
     Scaffold(
+        modifier = Modifier.testTag(TestTags.CreateGroup.Screen),
         containerColor = bg,
         topBar = {
             TopAppBar(
@@ -200,10 +203,16 @@ fun CreateGroupScreen(
                 navigationIcon = {
                     when {
                         viewModel.phase == CreationPhase.INPUT && step == InputStep.PEOPLE -> {
-                            TextButton(onClick = { step = InputStep.IDENTITY }) { Text("Back") }
+                            TextButton(
+                                onClick = { step = InputStep.IDENTITY },
+                                modifier = Modifier.testTag(TestTags.CreateGroup.BackButton)
+                            ) { Text("Back") }
                         }
                         viewModel.phase == CreationPhase.INPUT -> {
-                            TextButton(onClick = onBack) { Text("Cancel") }
+                            TextButton(
+                                onClick = onBack,
+                                modifier = Modifier.testTag(TestTags.CreateGroup.CancelButton)
+                            ) { Text("Cancel") }
                         }
                         viewModel.phase == CreationPhase.DONE -> {
                             IconButton(onClick = {
@@ -220,18 +229,22 @@ fun CreateGroupScreen(
                         viewModel.phase == CreationPhase.INPUT && step == InputStep.IDENTITY -> {
                             TextButton(
                                 onClick = { step = InputStep.PEOPLE },
-                                enabled = viewModel.groupName.isNotBlank()
+                                enabled = viewModel.groupName.isNotBlank(),
+                                modifier = Modifier.testTag(TestTags.CreateGroup.NextButton)
                             ) { Text("Next", fontWeight = FontWeight.SemiBold) }
                         }
                         viewModel.phase == CreationPhase.INPUT && step == InputStep.PEOPLE -> {
-                            TextButton(onClick = {
-                                viewModel.startCreation(
-                                    keyManager,
-                                    groupListViewModel.defaultGroupTier,
-                                    groupListViewModel,
-                                    invitationTransport
-                                )
-                            }) { Text("Create", fontWeight = FontWeight.SemiBold) }
+                            TextButton(
+                                onClick = {
+                                    viewModel.startCreation(
+                                        keyManager,
+                                        groupListViewModel.defaultGroupTier,
+                                        groupListViewModel,
+                                        invitationTransport
+                                    )
+                                },
+                                modifier = Modifier.testTag(TestTags.CreateGroup.CreateButton)
+                            ) { Text("Create", fontWeight = FontWeight.SemiBold) }
                         }
                         viewModel.phase == CreationPhase.DONE -> {
                             TextButton(onClick = {
@@ -371,7 +384,9 @@ private fun IdentityStep(
             value = viewModel.groupName,
             onValueChange = { viewModel.groupName = it },
             placeholder = { Text("Group name", fontSize = 18.sp) },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(TestTags.CreateGroup.NameField),
             singleLine = true,
             shape = RoundedCornerShape(14.dp)
         )

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupListScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/GroupListScreen.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import chat.onym.android.ui.TestTags
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -95,11 +97,15 @@ fun GroupListScreen(
     var showOnboarding by remember { mutableStateOf(!prefs.getBoolean("has_seen_onboarding", false)) }
 
     Scaffold(
+        modifier = Modifier.testTag(TestTags.GroupList.Screen),
         topBar = {
             TopAppBar(
                 title = { Text("Chats") },
                 actions = {
-                    IconButton(onClick = onInvitations) {
+                    IconButton(
+                        onClick = onInvitations,
+                        modifier = Modifier.testTag(TestTags.GroupList.InvitationsButton)
+                    ) {
                         BadgedBox(
                             badge = {
                                 if (pendingInvitationCount > 0) {
@@ -114,7 +120,10 @@ fun GroupListScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = { showAddDialog = true }) {
+            FloatingActionButton(
+                onClick = { showAddDialog = true },
+                modifier = Modifier.testTag(TestTags.GroupList.Fab)
+            ) {
                 Icon(Icons.Default.Add, contentDescription = "Add Group")
             }
         }
@@ -157,7 +166,10 @@ fun GroupListScreen(
             ) {
                 if (groups.isEmpty()) {
                     Column(
-                        modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag(TestTags.GroupList.EmptyState)
+                            .padding(horizontal = 32.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.Center
                     ) {
@@ -258,13 +270,17 @@ fun GroupListScreen(
         groupForContextMenu?.let { group ->
             AlertDialog(
                 onDismissRequest = { groupForContextMenu = null },
+                modifier = Modifier.testTag(TestTags.GroupList.ContextMenu),
                 title = { Text(group.name) },
                 text = {
                     Column {
-                        TextButton(onClick = {
-                            onTogglePin(group.id)
-                            groupForContextMenu = null
-                        }) {
+                        TextButton(
+                            onClick = {
+                                onTogglePin(group.id)
+                                groupForContextMenu = null
+                            },
+                            modifier = Modifier.testTag(TestTags.GroupList.ContextMenuPin)
+                        ) {
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
                                 verticalAlignment = Alignment.CenterVertically,
@@ -274,10 +290,13 @@ fun GroupListScreen(
                                 Text(if (group.isPinned) "Unpin" else "Pin")
                             }
                         }
-                        TextButton(onClick = {
-                            groupForContextMenu = null
-                            groupToDelete = group
-                        }) {
+                        TextButton(
+                            onClick = {
+                                groupForContextMenu = null
+                                groupToDelete = group
+                            },
+                            modifier = Modifier.testTag(TestTags.GroupList.ContextMenuDelete)
+                        ) {
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
                                 verticalAlignment = Alignment.CenterVertically,
@@ -291,7 +310,10 @@ fun GroupListScreen(
                 },
                 confirmButton = {},
                 dismissButton = {
-                    TextButton(onClick = { groupForContextMenu = null }) {
+                    TextButton(
+                        onClick = { groupForContextMenu = null },
+                        modifier = Modifier.testTag(TestTags.GroupList.ContextMenuCancel)
+                    ) {
                         Text("Cancel")
                     }
                 }
@@ -304,15 +326,21 @@ fun GroupListScreen(
                 title = { Text("Delete Group") },
                 text = { Text("Delete \"${group.name}\"? This cannot be undone.") },
                 confirmButton = {
-                    TextButton(onClick = {
-                        onDeleteGroup(group.id)
-                        groupToDelete = null
-                    }) {
+                    TextButton(
+                        onClick = {
+                            onDeleteGroup(group.id)
+                            groupToDelete = null
+                        },
+                        modifier = Modifier.testTag(TestTags.GroupList.DeleteDialogConfirm)
+                    ) {
                         Text("Delete", color = Color.Red)
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = { groupToDelete = null }) {
+                    TextButton(
+                        onClick = { groupToDelete = null },
+                        modifier = Modifier.testTag(TestTags.GroupList.DeleteDialogCancel)
+                    ) {
                         Text("Cancel")
                     }
                 }
@@ -385,6 +413,7 @@ private fun GroupListItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .testTag(TestTags.GroupList.item(group.id))
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick
@@ -533,7 +562,8 @@ fun OnboardingSheet(onDismiss: () -> Unit, isRevisit: Boolean = false, onRestore
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        modifier = Modifier.testTag(TestTags.GroupList.OnboardingSheet)
     ) {
         Column(
             modifier = Modifier
@@ -623,6 +653,7 @@ fun OnboardingSheet(onDismiss: () -> Unit, isRevisit: Boolean = false, onRestore
                 },
                 modifier = Modifier
                     .fillMaxWidth()
+                    .testTag(TestTags.GroupList.OnboardingPrimaryButton)
                     .padding(horizontal = 32.dp)
             ) {
                 val lastPageText = if (isRevisit) "Done" else "Get Started"

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/JoinGroupScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/JoinGroupScreen.kt
@@ -35,7 +35,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import chat.onym.android.ui.TestTags
 import chat.onym.android.model.ChatGroup
 import chat.onym.android.onchain.OnChainVerificationResult
 import chat.onym.android.ui.components.QRScannerView
@@ -92,6 +94,7 @@ fun JoinGroupScreen(
     }
 
     Scaffold(
+        modifier = Modifier.testTag(TestTags.JoinGroup.Screen),
         topBar = {
             TopAppBar(
                 title = { Text("Join Group") },
@@ -125,7 +128,8 @@ fun JoinGroupScreen(
                 label = { Text("Invite Code") },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(120.dp),
+                    .height(120.dp)
+                    .testTag(TestTags.JoinGroup.InviteField),
                 maxLines = 5
             )
 
@@ -139,7 +143,9 @@ fun JoinGroupScreen(
                         viewModel.inviteText = clip.getItemAt(0).text?.toString() ?: ""
                     }
                 },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(TestTags.JoinGroup.PasteButton)
             ) {
                 Text("Paste from Clipboard")
             }
@@ -148,7 +154,9 @@ fun JoinGroupScreen(
 
             OutlinedButton(
                 onClick = { showScanner = true },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(TestTags.JoinGroup.ScanButton)
             ) {
                 Text("Scan QR Code")
             }

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/SearchScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/SearchScreen.kt
@@ -26,11 +26,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import chat.onym.android.model.ChatGroup
 import chat.onym.android.model.ChatMessage
+import chat.onym.android.ui.TestTags
 import java.util.Calendar
 import java.util.Date
 
@@ -61,6 +63,7 @@ fun SearchScreen(
     }
 
     Scaffold(
+        modifier = Modifier.testTag(TestTags.Search.Screen),
         topBar = {
             TopAppBar(title = { Text("Search") })
         }
@@ -77,6 +80,7 @@ fun SearchScreen(
                 singleLine = true,
                 modifier = Modifier
                     .fillMaxWidth()
+                    .testTag(TestTags.Search.Field)
                     .padding(horizontal = 16.dp, vertical = 8.dp)
             )
 

--- a/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/SettingsScreen.kt
+++ b/clients/android/StellarChat/app/src/main/java/chat/onym/android/ui/screens/SettingsScreen.kt
@@ -57,15 +57,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import chat.onym.android.BuildConfig
+import chat.onym.android.ui.TestTags
 import chat.onym.android.ui.components.QRCodeImage
 import chat.onym.android.ui.components.SettingsIconBox
 import chat.onym.android.ui.components.SettingsIconColors
@@ -87,12 +90,13 @@ fun SettingsScreen(
     onOpenAdvanced: () -> Unit = {},
     onJoinGroup: () -> Unit = {},
 ) {
-    var tab by remember { mutableStateOf(SettingsTab.Invite) }
+    var tab by rememberSaveable { mutableStateOf(SettingsTab.Invite) }
     var showAbout by remember { mutableStateOf(false) }
     var showRegenerateConfirm by remember { mutableStateOf(false) }
     var regenerateError by remember { mutableStateOf<String?>(null) }
 
     Scaffold(
+        modifier = Modifier.testTag(TestTags.Settings.Screen),
         topBar = {
             TopAppBar(
                 title = { Text("Settings") },
@@ -120,12 +124,14 @@ fun SettingsScreen(
                 SegmentedButton(
                     selected = tab == SettingsTab.Invite,
                     onClick = { tab = SettingsTab.Invite },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                    modifier = Modifier.testTag(TestTags.Settings.InviteTab)
                 ) { Text("Invite Key") }
                 SegmentedButton(
                     selected = tab == SettingsTab.Preferences,
                     onClick = { tab = SettingsTab.Preferences },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                    modifier = Modifier.testTag(TestTags.Settings.PreferencesTab)
                 ) { Text("Preferences") }
             }
 

--- a/clients/android/StellarChat/app/src/test/java/chat/onym/android/GroupCryptoTest.kt
+++ b/clients/android/StellarChat/app/src/test/java/chat/onym/android/GroupCryptoTest.kt
@@ -160,4 +160,44 @@ class GroupCryptoTest {
         val k2 = GroupCrypto.hkdf(ikm, salt, "info2".toByteArray(), 32)
         assertFalse(k1.contentEquals(k2))
     }
+
+    @Test
+    fun hkdf_differentSaltsDifferentOutput() {
+        val ikm = ByteArray(32) { 0x42 }
+        val info = "info".toByteArray()
+        val k1 = GroupCrypto.hkdf(ikm, "salt1".toByteArray(), info, 32)
+        val k2 = GroupCrypto.hkdf(ikm, "salt2".toByteArray(), info, 32)
+        assertFalse(k1.contentEquals(k2))
+    }
+
+    @Test
+    fun hkdf_respectsRequestedLength_16Bytes() {
+        val key = GroupCrypto.hkdf(
+            ikm = ByteArray(32),
+            salt = "salt".toByteArray(),
+            info = "info".toByteArray(),
+            length = 16
+        )
+        assertEquals(16, key.size)
+    }
+
+    @Test
+    fun hkdf_respectsRequestedLength_32Bytes() {
+        val key = GroupCrypto.hkdf(
+            ikm = ByteArray(32),
+            salt = "salt".toByteArray(),
+            info = "info".toByteArray(),
+            length = 32
+        )
+        assertEquals(32, key.size)
+    }
+
+    @Test
+    fun hkdf_differentIkmDifferentOutput() {
+        val salt = "salt".toByteArray()
+        val info = "info".toByteArray()
+        val k1 = GroupCrypto.hkdf(ByteArray(32) { 0x01 }, salt, info, 32)
+        val k2 = GroupCrypto.hkdf(ByteArray(32) { 0x02 }, salt, info, 32)
+        assertFalse(k1.contentEquals(k2))
+    }
 }

--- a/clients/android/StellarChat/scripts/run-solo-journey.sh
+++ b/clients/android/StellarChat/scripts/run-solo-journey.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Runs the Compose UI solo-user-journey instrumentation test on the connected
+# device, then `adb pull`s the auto-generated Markdown reports written by
+# MarkdownReportRule into ./result_autotest/ on the host.
+#
+# Usage:
+#   ./scripts/run-solo-journey.sh
+#
+# Env overrides:
+#   ADB     — path to adb (defaults to `adb` on $PATH; falls back to
+#             $ANDROID_HOME/platform-tools/adb when ADB is unset and `adb`
+#             isn't found).
+#   GRADLE  — path to gradle wrapper (defaults to ./gradlew).
+#
+# Exit codes mirror the gradle test exit code.
+
+set -u
+set -o pipefail
+
+# Resolve repo paths from this script's location so it works regardless of CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+# Resolve adb.
+if [[ -z "${ADB:-}" ]]; then
+  if command -v adb >/dev/null 2>&1; then
+    ADB="adb"
+  elif [[ -n "${ANDROID_HOME:-}" && -x "$ANDROID_HOME/platform-tools/adb" ]]; then
+    ADB="$ANDROID_HOME/platform-tools/adb"
+  elif [[ -x "$HOME/AppData/Local/Android/Sdk/platform-tools/adb.exe" ]]; then
+    ADB="$HOME/AppData/Local/Android/Sdk/platform-tools/adb.exe"
+  else
+    echo "✗ adb not found — set ADB or ANDROID_HOME" >&2
+    exit 127
+  fi
+fi
+
+GRADLE="${GRADLE:-./gradlew}"
+APP_PKG="chat.onym.android"
+DEVICE_REPORT_DIR="/sdcard/Android/data/$APP_PKG/files/autotest-reports"
+HOST_REPORT_DIR="$PROJECT_DIR/result_autotest"
+TEST_CLASS="uitests.SoloUserJourneyTest"
+
+mkdir -p "$HOST_REPORT_DIR"
+
+# Verify a device is attached before we burn 2+ minutes on a build.
+DEVICES=$("$ADB" devices | awk 'NR>1 && $2=="device" {print $1}')
+if [[ -z "$DEVICES" ]]; then
+  echo "✗ no device attached — connect a device or start an emulator" >&2
+  exit 1
+fi
+
+echo "▶ Device(s):"
+echo "$DEVICES" | sed 's/^/    /'
+echo "▶ Running $TEST_CLASS …"
+echo
+
+# Run gradle, preserving its exit code.
+"$GRADLE" :app:connectedPlayDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class="$TEST_CLASS"
+GRADLE_RC=$?
+
+# Always try to pull whatever the rule managed to write — even on failure
+# (especially on failure: that's where logcat lives).
+echo
+echo "▶ Pulling reports from $DEVICE_REPORT_DIR …"
+PULL_OUT=$("$ADB" pull "$DEVICE_REPORT_DIR" "$HOST_REPORT_DIR/" 2>&1) || true
+echo "$PULL_OUT" | tail -5
+
+# Show a summary of what's now in the host dir (newest first).
+echo
+echo "▶ Reports in $HOST_REPORT_DIR/$(basename "$DEVICE_REPORT_DIR")/:"
+LATEST_DIR="$HOST_REPORT_DIR/$(basename "$DEVICE_REPORT_DIR")"
+if [[ -d "$LATEST_DIR" ]]; then
+  ls -1t "$LATEST_DIR" 2>/dev/null | head -5 | sed 's/^/    /'
+else
+  echo "    (no reports yet — was the test built and installed?)"
+fi
+
+echo
+if [[ $GRADLE_RC -eq 0 ]]; then
+  echo "✓ Test passed"
+else
+  echo "✗ Test failed (gradle exit $GRADLE_RC) — see latest -FAIL.md for stage timeline + logcat"
+fi
+exit $GRADLE_RC

--- a/clients/ios/StellarChat/SMOKE_TESTS.md
+++ b/clients/ios/StellarChat/SMOKE_TESTS.md
@@ -1,0 +1,490 @@
+# Smoke-тесты Onym iOS — pre-release чек
+
+Список сценариев для **ручного** прогона перед каждым релизом. Цель — за 10–15 минут на одном устройстве удостовериться, что критический путь не сломан. Сценарии соответствуют стадиям авто-теста `StellarChatUITests.SoloUserJourneyUITest` (см. таблицу в конце документа) — если что-то падает в проде, проверь сначала, что делает соответствующая стадия в коде.
+
+> **Как пользоваться:** проставлять `[x]` напротив каждого пункта по мере выполнения. Если хоть один пункт упал — **релиз стопаем**, заводим issue со ссылкой на соответствующую стадию авто-теста.
+
+> **Solo-сессия.** Все сценарии проходят без второго пользователя: группы создаются на этом же устройстве, сообщения отправляются "в пустоту" (статус `Sending`/`Sent`/`Delivered`/`Tap to retry` ловится визуально). Сценарии с двумя устройствами (deeplink invite, реальная доставка, knock-and-let-in) — **вне smoke**, в регрессию.
+
+> **Разрушающие операции.** Smoke создаёт 4 временные группы с суффиксом `… QA` и удаляет их в финале (SM-15). Реальные пользовательские группы и identity не затрагиваются.
+
+> **Порядок стадий ручного smoke vs. авто-теста.** Ручной чек-лист отсортирован по логике пользовательского сценария (создал группы → потыкал, поискал, прошёлся по настройкам). Авто-тест **выполняет SM-9 (поиск) последним**, после SM-15, не в середине: это обходной манёвр под iOS 26 — `Tab(role: .search)` после Cancel оставляет нижнюю tab-bar в свёрнутом состоянии (видно только активную «таблетку»), и XCUITest не может надёжно её раскрыть, чтобы перейти на Settings/Contacts/Chats. Для **человека** этот баг не проблема — пальцем tab-bar разворачивается естественно, поэтому ручной порядок 1→15 остаётся правильным.
+
+> **Платформенные отличия от Android-смоук-листа:**
+> - У iOS нет диалога-посредника `Add Group` — плюс в тулбаре сразу показывает меню `Create Group` / `Join Group`.
+> - У iOS нет long-press контекстного меню в списке. Пин/удаление — через свайп слева (trailing edge).
+> - GroupInfo на iOS открывается как `.sheet`, а не как push в навигацию — закрывается кнопкой `Close`, не системной стрелкой Back.
+> - Вместо `BiometricPrompt` на Android в Recovery Phrase используется `LAContext` (Face ID / Touch ID) — XCUITest её всё равно не водит, поэтому пункт SM-13 заканчивается на `Cancel` тулбара.
+
+---
+
+## 0. Подготовка окружения
+
+**Перед каждым прогоном:**
+
+- [ ] IPA свежей сборки установлен на физическое устройство (не Simulator) — для **ручного** smoke. Авто-тест работает на симуляторе iPhone 17 Pro Max, iOS 26.0, проверено
+- [ ] Зафиксированы данные сборки:
+  - MARKETING_VERSION: `_____`
+  - CURRENT_PROJECT_VERSION: `_____`
+  - Конфигурация: `Debug` / `Release`
+- [ ] Зафиксировано устройство:
+  - Модель: `_____`
+  - iOS: `_____`
+- [ ] В Settings → Accessibility → Motion отключено `Reduce Motion`/включён по желанию (не критично, но стабильнее)
+- [ ] Wi-Fi включён, есть интернет (Soroban testnet + Nostr-relays нужны для создания групп)
+- [ ] Уведомления и звук отключены
+- [ ] Прогоняющий: `_____`, дата: `_____`
+
+> **НЕ нужно** удалять и переустанавливать приложение между прогонами smoke — пишется так, чтобы не уничтожать пользовательские данные. Онбординг показывается только при первом запуске; если SM-1 не воспроизводится — сначала ставится свежий IPA на чистое устройство (Settings → General → iPhone Storage → Onym → Delete App, потом установить заново).
+
+---
+
+## SM-1. Холодный старт + онбординг (страница 1)
+
+> Стадия авто-теста: `stage_01_onboarding_sheet_visible_on_first_launch`
+
+**Цель:** при первом запуске показывается онбординг-sheet с темой шифрования.
+
+### Шаги
+- [ ] 1. Запустить приложение с домашнего экрана
+- [ ] 2. Дождаться появления нижнего sheet (страница 1)
+
+### Ожидаемый результат
+- [ ] Виден sheet с заголовком про шифрование сообщений и метаданных (substring `metadata are encrypted`)
+- [ ] Видна кнопка `Next` снизу
+- [ ] Sheet нельзя скрыть свайпом вниз (interactiveDismissDisabled)
+
+---
+
+## SM-2. Онбординг — все 4 страницы + Get Started
+
+> Стадия авто-теста: `stage_02_walk_through_onboarding_and_dismiss`
+
+**Цель:** все 4 страницы прокликиваются, последний `Get Started` закрывает sheet и пускает в Chats.
+
+**Предусловие:** SM-1 пройден; sheet на странице 1.
+
+### Шаги
+- [ ] 1. Тапнуть `Next` → страница 2 (виден текст `Private by design`)
+- [ ] 2. Тапнуть `Next` → страница 3 (виден текст `Truly shared ownership`)
+- [ ] 3. Тапнуть `Next` → страница 4 (видны заголовок `What makes this different` и кнопка `Get Started`)
+- [ ] 4. Тапнуть `Get Started` → sheet закрылся
+
+### Ожидаемый результат
+- [ ] Sheet полностью пропал
+- [ ] Активный экран — Chats; видна нижняя TabView (`Contacts` / `Chats` / `Search` / `Settings`)
+- [ ] Активный таб — `Chats`
+
+> **Restore from Recovery Phrase** — намеренно не покрывается smoke'ом: тап одновременно навигирует и (после успешного восстановления) закрывает sheet, переписывает identity. Проверять только в регрессии на отдельном устройстве.
+
+---
+
+## SM-3. Создать группу `Anarchy Crew QA` + первое сообщение
+
+> Стадия авто-теста: `stage_03_create_anarchy_and_send_message`
+
+**Цель:** "анархичный" governance создаётся on-chain, чат открывается, сообщение отправляется.
+
+**Предусловие:** SM-2 завершён, экран Chats.
+
+### Шаги
+- [ ] 1. Тапнуть `+` (правый верхний угол)
+- [ ] 2. В выпадающем меню выбрать `Create Group`
+- [ ] 3. На экране `New Group` (Step 1 of 2):
+  - [ ] Ввести имя `Anarchy Crew QA`
+  - [ ] В сегмент-пикере governance выбрать `Anarchy`
+  - [ ] Тапнуть `Next`
+- [ ] 4. На Step 2 of 2 тапнуть `Create`
+- [ ] 5. Дождаться кнопки `Open` в правом верхнем углу (до 2 минут — Soroban testnet ledger close)
+- [ ] 6. Тапнуть `Open` → открылся Chat
+- [ ] 7. Ввести в поле `Hello anarchy` и тапнуть кнопку отправки (стрелка вверх)
+- [ ] 8. Тапнуть стрелку Back в навигации → вернуться в Chats
+
+### Ожидаемый результат
+- [ ] На Chat экране сообщение `Hello anarchy` отрисовано
+- [ ] У сообщения виден один из статусов: `Sending` (часы) / `Sent` (галочка) / `Delivered` (синий чекмарк) / `Tap to retry` (красный кружок) — любой
+- [ ] В Chats есть строка `Anarchy Crew QA`
+
+---
+
+## SM-4. Создать `Direct Bob QA` (1v1)
+
+> Стадия авто-теста: `stage_04_create_one_on_one_and_send_message`
+
+**Цель:** 1v1-governance работает (это технически другой контракт, чем Anarchy).
+
+### Шаги
+- [ ] 1. `+` → `Create Group`
+- [ ] 2. Имя `Direct Bob QA`, governance `1v1`, Next → Create
+- [ ] 3. Дождаться `Open`, открыть чат
+- [ ] 4. Отправить `Hi Bob`
+- [ ] 5. Back в Chats
+
+### Ожидаемый результат
+- [ ] Сообщение `Hi Bob` со статусной иконкой
+- [ ] Группа `Direct Bob QA` есть в Chats
+
+---
+
+## SM-5. Создать `Democracy Council QA`
+
+> Стадия авто-теста: `stage_05_create_democracy_and_send_message`
+
+**Цель:** Democracy-governance создаётся.
+
+### Шаги
+- [ ] 1. `+` → `Create Group`
+- [ ] 2. Имя `Democracy Council QA`, governance `Democracy`, Next → Create
+- [ ] 3. Дождаться `Open`, открыть чат
+- [ ] 4. Отправить `Vote on motion`
+- [ ] 5. Back
+
+### Ожидаемый результат
+- [ ] Сообщение со статусной иконкой
+- [ ] Группа в Chats
+
+---
+
+## SM-6. Создать `Oligarchy Inner QA`
+
+> Стадия авто-теста: `stage_06_create_oligarchy_and_send_message`
+
+**Цель:** Oligarchy-governance создаётся (последний из 4 типов).
+
+### Шаги
+- [ ] 1. `+` → `Create Group`
+- [ ] 2. Имя `Oligarchy Inner QA`, governance `Oligarchy`, Next → Create
+- [ ] 3. Дождаться `Open`, открыть чат
+- [ ] 4. Отправить `Quorum check`
+- [ ] 5. Back
+
+### Ожидаемый результат
+- [ ] Сообщение со статусной иконкой
+- [ ] Группа в Chats; всего на экране **4 группы** с суффиксом `QA`
+
+---
+
+## SM-7. Открыть GroupInfo из чата + Close
+
+> Стадия авто-теста: `stage_07_open_group_info_from_chat_and_back`
+
+**Цель:** sheet Group Info открывается с правильными hero-данными, Close возвращает в чат.
+
+### Шаги
+- [ ] 1. В Chats тапнуть `Anarchy Crew QA` → открылся Chat
+- [ ] 2. Тапнуть иконку `person.3` в правом верхнем углу → открылся sheet Group Info
+- [ ] 3. Тапнуть `Close` в тулбаре sheet'а
+- [ ] 4. Тапнуть Back в навигации → вернулись в Chats
+
+### Ожидаемый результат
+- [ ] На Group Info видно: имя группы, чип `End-to-end encrypted`, заголовок секции `MEMBERS`
+- [ ] После Close + Back — в Chats; список 4 групп на месте
+
+> Действия `Add people` / `Leave Group` / `Rotate encryption key` из этого экрана — **не покрываются** smoke (требуют второго пользователя или необратимо ломают группу).
+
+---
+
+## SM-8. Pin / Unpin группы через свайп
+
+> Стадия авто-теста: `stage_08_pin_group_then_swipe_shows_unpin`
+
+**Цель:** trailing-свайп открывает swipe-actions, тап `Pin` закрепляет (📌 рядом с именем), повторный свайп показывает `Unpin`.
+
+### Шаги
+- [ ] 1. В Chats свайпнуть `Anarchy Crew QA` справа налево (trailing)
+- [ ] 2. Появились action-кнопки: красная `Delete` и оранжевая `Pin`
+- [ ] 3. Тапнуть `Pin`
+- [ ] 4. Список перерисовался; рядом с именем виден оранжевый `pin.fill`
+- [ ] 5. Свайпнуть `Anarchy Crew QA` ещё раз справа налево
+- [ ] 6. Теперь оранжевая action-кнопка называется `Unpin` (вместо `Pin`)
+- [ ] 7. Тапнуть `Unpin`
+- [ ] 8. Иконка 📌 пропала, порядок групп вернулся к предыдущему
+
+### Ожидаемый результат
+- [ ] Pin/Unpin срабатывают мгновенно (не дольше 500 мс на каждый шаг)
+- [ ] В Chats всё ещё 4 QA-группы на месте
+
+---
+
+## SM-9. Search — найти группу по имени
+
+> Стадия авто-теста: `stage_09_search_finds_created_group_by_name`
+> **В авто-тесте эта стадия выполняется последней** (после SM-15) — см. вступительную заметку про порядок стадий. В ручном smoke порядок естественный.
+
+**Цель:** глобальный поиск находит группу по части её имени.
+
+### Шаги
+- [ ] 1. Bottom-tab → `Search`
+- [ ] 2. Перед вводом — на экране плейсхолдер `Search across all your chats and messages.`
+- [ ] 3. В поле поиска ввести `Anarchy Crew`
+- [ ] 4. Дождаться появления результата
+- [ ] 5. Тапнуть `Cancel` справа от поля поиска
+
+### Ожидаемый результат
+- [ ] В выдаче в секции `Chats` есть строка `Anarchy Crew QA`
+- [ ] После Cancel — выдача очищена, плейсхолдер `Search across all your chats and messages.` снова виден
+- [ ] **iOS 26 нюанс:** после Cancel нижняя tab-bar может остаться свёрнутой (видна одна «таблетка» активного таба). Это нормально — для перехода на другой таб тапни эту таблетку и tab-bar развернётся обратно
+
+---
+
+## SM-10. Settings — Invite Key tab по умолчанию
+
+> Стадия авто-теста: `stage_10_settings_lands_on_invite_tab_by_default`
+
+**Цель:** при первом заходе в Settings активна вкладка Invite Key с QR-кодом и кнопкой `Share link`.
+
+### Шаги
+- [ ] 1. Bottom-tab → `Settings`
+- [ ] 2. Виден сегмент-пикер `Invite Key` / `Preferences` (выделен `Invite Key`)
+- [ ] 3. На экране виден QR-код
+
+### Ожидаемый результат
+- [ ] Кнопка `Share link` отрисована и активна
+
+---
+
+## SM-11. Settings → Preferences: 5 секций видны
+
+> Стадия авто-теста: `stage_11_settings_preferences_shows_all_sections`
+
+**Цель:** на вкладке Preferences отрисованы все 5 заголовков секций.
+
+### Шаги
+- [ ] 1. В Settings переключиться на вкладку `Preferences`
+
+### Ожидаемый результат — видны все 5 заголовков (поскролить, если нужно):
+- [ ] `NETWORK`
+- [ ] `PROTOCOL`
+- [ ] `SECURITY`
+- [ ] `ADVANCED`
+- [ ] `ABOUT`
+
+---
+
+## SM-12. Settings sub-screens: 4 раза открыть и Back
+
+> Стадия авто-теста: `stage_12_settings_sub_screens_open_and_back`
+
+**Цель:** 4 sub-screen'а открываются (NavigationStack push), у каждого виден ожидаемый navigation title, Back возвращает в Settings и **сохраняет вкладку Preferences**.
+
+**Предусловие:** в Settings → Preferences (SM-11).
+
+### Шаги
+- [ ] 1. Тапнуть строку `Relays` → виден navigation title `Relays` → Back → снова на Preferences (НЕ на Invite!)
+- [ ] 2. Тапнуть `Blossom Servers` → виден navigation title `Blossom Servers` → Back → Preferences
+- [ ] 3. Тапнуть `Stellar Contract` → виден navigation title `Stellar Contract` → Back → Preferences
+- [ ] 4. Тапнуть `Advanced` → виден navigation title `Advanced` → Back → Preferences
+
+### Ожидаемый результат
+- [ ] После каждого Back: всё ещё активна вкладка `Preferences`, navigation title `Settings`
+- [ ] Все 4 sub-screen открываются без задержек > 1 сек
+
+> **Содержимое sub-screen'ов** (список реле, кнопки add/remove, статусы) — **вне smoke**: реальный контент зависит от сети. В smoke проверяется только факт открытия экрана и navigation title.
+
+---
+
+## SM-13. Recovery Phrase — Intro экран + Cancel
+
+> Стадия авто-теста: `stage_13_settings_recovery_phrase_intro_and_cancel`
+
+**Цель:** заходим в Recovery Phrase wizard, видим intro, отменяем БЕЗ ввода фразы и БЕЗ биометрики.
+
+**Предусловие:** в Settings → Preferences.
+
+### Шаги
+- [ ] 1. Тапнуть строку `Backup Recovery Phrase`
+- [ ] 2. Виден intro-экран с navigation title `Back up keys`
+- [ ] 3. Тапнуть кнопку `Cancel` (тулбар, leading)
+
+### Ожидаемый результат
+- [ ] Wizard закрылся, вернулись в Settings (Preferences активна)
+
+> **Дальше intro не идём** — следующий шаг wizard вызывает системный `LAContext` (Face ID / Touch ID), который не управляется через XCUITest (и потенциально зачерпнёт реальные системные подтверждения на твоём личном устройстве).
+
+---
+
+## SM-14. Bottom-tab: Contacts таб открывается
+
+> Стадия авто-теста: `stage_14_contacts_tab_renders`
+
+**Цель:** таб Contacts открывается без падений.
+
+### Шаги
+- [ ] 1. Bottom-tab → `Contacts`
+
+### Ожидаемый результат
+- [ ] Экран Contacts отрисован (navigation title `Contacts`)
+- [ ] В зависимости от состояния разрешения Contacts видно либо empty state, либо список, либо приглашение синка
+
+> **Не тапаем кнопку синка контактов** — это запросит системное разрешение на доступ к контактам. Smoke только проверяет факт рендера экрана.
+
+---
+
+## SM-15. Возврат в Chats и удаление 4 QA-групп
+
+> Стадии авто-теста: `stage_15_returning_to_chats_keeps_all_created_groups` + `tearDown cleanupCreatedGroups`
+
+**Цель:** все 4 группы на месте после хождения по табам; финал — удалить 4 QA-группы, чтобы устройство вернулось в исходное состояние.
+
+### Шаги
+- [ ] 1. Bottom-tab → `Chats`
+- [ ] 2. Видны все 4 группы:
+  - [ ] `Anarchy Crew QA`
+  - [ ] `Direct Bob QA`
+  - [ ] `Democracy Council QA`
+  - [ ] `Oligarchy Inner QA`
+- [ ] 3. Удалить **каждую** через trailing-свайп → красная `Delete`:
+  - [ ] `Anarchy Crew QA` снесена
+  - [ ] `Direct Bob QA` снесена
+  - [ ] `Democracy Council QA` снесена
+  - [ ] `Oligarchy Inner QA` снесена
+
+### Ожидаемый результат
+- [ ] В Chats нет ни одной группы с суффиксом `QA`
+- [ ] Реальные пользовательские группы (если были) на месте, нетронутые
+
+---
+
+## Финальная проверка после смоука
+
+- [ ] В Recents (App Switcher) приложение `Onym` не висит с краш-баннером
+- [ ] `xcrun simctl spawn booted log show --predicate 'process == "StellarChat"' --last 5m | grep -i 'crash\|fatal'` — пусто (для simulator) ИЛИ `Settings → Privacy → Analytics & Improvements → Analytics Data` не содержит свежих `StellarChat-*.ips` (для физического устройства)
+- [ ] Удалённые QA-группы не вернулись после повторного открытия Chats
+
+---
+
+## Решение по релизу
+
+- [ ] **GO** — все 15 пунктов smoke зелёные → можно публиковать
+- [ ] **NO GO** — хотя бы один пункт упал → релиз заблокирован, заводится issue с привязкой к стадии авто-теста
+
+Подпись: `_____`   Дата: `_____`   Решение: `GO` / `NO GO`
+
+---
+
+## Что НЕ покрывается этим smoke (намеренно)
+
+> Если хочется проверить что-то ниже — это **регрессия**, заводи отдельный чек-лист и отдельный временной слот. По мере того, как фичи будут двигаться к проду, переноси точечно по одному.
+
+**Вне solo-сессии (нужен второй пользователь / устройство):**
+- OnboardLandingView (`You're invited`) — открывается только по deeplink-приглашению
+- Реальный приём приглашения и присоединение к группе через `DeepLinkJoinGroupView`
+- Multi-user сообщения и доставка через Nostr-relay
+- Membership-операции с валидным charter (knock-and-let-in, kick, role change)
+- Verify on-chain (свайп leading edge → `Verify`) — требует confirmed publish
+
+**Вне XCUITest (системный UI / разрешения):**
+- Recovery Phrase reveal: после Intro вызывается `LAContext` (Face ID / Touch ID) — системное окно, не управляется тестом
+- Restore identity happy-path — `replaceKeyManager` необратимо перетирает identity
+- Запрос разрешений: Camera, Contacts, Notifications, Microphone, Photos
+- QR-сканирование (`QRScannerView`) и `Paste invite key` (Scan просит Camera, Paste — мусор из буфера)
+- Universal Link / custom URL scheme handlers (требуют `xcrun simctl openurl` и могут конфликтовать с реальными Universal Links устройства)
+
+**Деструктивные / необратимые:**
+- Settings → "Generate new identity" (alert "Generate new identity?") — пересоздаёт BIP39, делает все группы read-only
+- Leave Group / любые destructive-actions из GroupInfoView (есть только удаление через trailing-swipe из списка)
+- Rotate encryption key — необратимо пересоздаёт epoch
+
+**Не реализованные в коде или dead-code:**
+- LegacyIdentityScreen (legacy pre-BIP39 инстанс)
+- FirstGroupView / FirstJoinView (определены, но без точки входа в `ContentView`)
+
+**Не глубоко smoke'аем (только факт рендера):**
+- Settings sub-screens — содержимое (список реле, статусы blossom, контракт): зависит от сети, в smoke только nav title
+- ContactsView — список контактов: зависит от системного разрешения
+- ShareLink-действия (`Share link…`) — открывают системный share sheet, не валидируем содержимое
+
+---
+
+## Связанные авто-тесты
+
+Если smoke упал — сначала прогнать соответствующую стадию авто-теста: если она зелёная, проблема скорее всего в окружении/устройстве, а не в коде.
+
+В таблице ниже **левый столбец — порядок ручного smoke** (естественный пользовательский сценарий). **Средний столбец — порядок выполнения в авто-тесте** (search вынесен в самый конец из-за iOS 26 collapsed-tab-bar quirk). Имена методов всё равно остались `stage_01`…`stage_15`, поэтому маппинг 1:1.
+
+| Smoke | Порядок в авто-тесте | Стадия `StellarChatUITests.SoloUserJourneyUITest` |
+|---|---|---|
+| SM-1 | 1 | `stage_01_onboarding_sheet_visible_on_first_launch` |
+| SM-2 | 2 | `stage_02_walk_through_onboarding_and_dismiss` |
+| SM-3 | 3 | `stage_03_create_anarchy_and_send_message` |
+| SM-4 | 4 | `stage_04_create_one_on_one_and_send_message` |
+| SM-5 | 5 | `stage_05_create_democracy_and_send_message` |
+| SM-6 | 6 | `stage_06_create_oligarchy_and_send_message` |
+| SM-7 | 7 | `stage_07_open_group_info_from_chat_and_back` |
+| SM-8 | 8 | `stage_08_pin_group_then_swipe_shows_unpin` |
+| SM-9 | **15** ⚠️ | `stage_09_search_finds_created_group_by_name` |
+| SM-10 | 9 | `stage_10_settings_lands_on_invite_tab_by_default` |
+| SM-11 | 10 | `stage_11_settings_preferences_shows_all_sections` |
+| SM-12 | 11 | `stage_12_settings_sub_screens_open_and_back` |
+| SM-13 | 12 | `stage_13_settings_recovery_phrase_intro_and_cancel` |
+| SM-14 | 13 | `stage_14_contacts_tab_renders` |
+| SM-15 | 14 | `stage_15_returning_to_chats_keeps_all_created_groups` + `tearDown cleanupCreatedGroups` |
+
+### Известные ограничения авто-теста (не блокируют PASS, но видны в отчёте)
+
+- **TearDown cleanup может оставить QA-группы на устройстве.** После того как авто-тест выполнил search-стадию последней, iOS 26 удерживает нижнюю tab-bar в свёрнутом виде (`value: Collapsed`). `tearDown` пытается переключиться на вкладку Chats через `app.tabBars.buttons["Chats"]`, но та может быть недоступна → 4 QA-группы остаются. Их видно в Chats при следующем ручном запуске app — можно удалить руками trailing-swipe → Delete. Авто-тест следующего прогона создаёт **другие** QA-группы (с теми же именами — будут дубли). TODO: добавить tab-bar restoration в начало tearDown.
+
+- **Авто-тест не проверяет `Restore from Recovery Phrase`** в SM-2 и `Backup Recovery Phrase` reveal-flow в SM-13. Оба требуют Face ID / биометрики (`LAContext`), которую XCUITest не водит. Эти ветки покрываются только ручным smoke.
+
+- **Welcome-banner в чате** (`Your group is ready…`) появляется в каждом чате при первом входе. Авто-тест его не дисмиссит — просто игнорирует. Если в продакшене баннер начнёт перекрывать message input, авто-тест не поймает (но пользователь поймает).
+
+### Prerequisites для прогона авто-теста
+
+- **macOS** с Xcode 26.0+ (проверено на 26.0.1)
+- **Симулятор iPhone 17 Pro Max, iOS 26.0** (загружается через Xcode → Settings → Components)
+- **`xcodegen`** (`brew install xcodegen`) — генерирует `.xcodeproj` из `project.yml`
+- **Rust toolchain** (`brew install rustup` → `rustup-init -y`) с таргетом `aarch64-apple-ios-sim` — нужен **один раз** при первой сборке для компиляции `SEPMLSFFI.xcframework` (FFI-binding к Rust-крейту `sep-xxxx-circuits`)
+- **Интернет**: реальный Soroban testnet RPC + Nostr-relays используются в стадиях SM-3 / SM-4 / SM-5 / SM-6 (создание групп on-chain). Без интернета эти стадии валятся по таймауту 120 сек
+
+### Прогон всего solo-journey авто-теста:
+
+```bash
+cd "clients/ios/StellarChat"
+./scripts/run-solo-journey.sh
+```
+
+Что делает скрипт:
+1. Регенерирует `StellarChat.xcodeproj` через `xcodegen` (если `project.yml` свежее).
+2. Прогоняет `xcodebuild test` с фильтром на `StellarChatUITests/SoloUserJourneyUITest`.
+3. Из xcodebuild-лога вытаскивает Markdown-отчёт между маркерами `=== MARKDOWN REPORT BEGIN/END ===` и сохраняет его в `result_autotest/`.
+4. На любом исходе (PASS или FAIL) отчёт включает таймлайн стадий с offset'ами + длительность; на FAIL добавляется last-stage + текст ошибки.
+
+Файлы отчётов: `result_autotest/solo-journey-YYYYMMDD-HHMMSS-{PASS|FAIL}.md`.
+**Время прогона:** ~5 минут на чистом симуляторе (build ~60s + 4×Soroban create ~150s + остальные стадии ~90s + cleanup).
+
+### Первая сборка (только при первом запуске на новой машине):
+
+```bash
+# 1. Поставить инструменты
+brew install xcodegen rustup
+rustup-init -y --no-modify-path --default-toolchain none --profile minimal
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# 2. Собрать xcframework для симулятора (~40s)
+cd "/path/to/repo"
+cargo build --manifest-path Cargo.toml --release --target aarch64-apple-ios-sim
+xcodebuild -create-xcframework \
+  -library target/aarch64-apple-ios-sim/release/libsep_xxxx_circuits.a \
+  -headers swift-mls/Sources/CSEPMLSFFI/include \
+  -output build/SEPMLSFFI.xcframework
+
+# 3. Прогон
+cd clients/ios/StellarChat
+./scripts/run-solo-journey.sh
+```
+
+### Ручной прогон (без обёртки):
+
+```bash
+cd "clients/ios/StellarChat"
+xcodegen generate    # если project.yml менялся
+xcodebuild test \
+  -scheme StellarChat \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:StellarChatUITests/SoloUserJourneyUITest \
+  CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY=""
+
+# Затем достать отчёт из xcresult вручную:
+xcrun xcresulttool get --path TestResults.xcresult --format json
+# (XCAttachment с именем solo-journey-*.md лежит внутри)
+```

--- a/clients/ios/StellarChat/StellarChat/DemoFixtures.swift
+++ b/clients/ios/StellarChat/StellarChat/DemoFixtures.swift
@@ -115,16 +115,17 @@ enum DemoFixtures {
     private static func makeMessages(
         groupID: String,
         now: Date,
-        entries: [(sender: String, text: String, isMine: Bool, offsetSeconds: TimeInterval)]
+        entries: [(String, String, Bool, Int)]
     ) -> [ChatMessage] {
-        entries.enumerated().map { idx, entry in
-            ChatMessage(
+        entries.enumerated().map { idx, tuple in
+            let (sender, text, isMine, offsetSeconds) = tuple
+            return ChatMessage(
                 id: "demo-\(groupID.prefix(8))-\(idx)",
                 groupID: groupID,
-                senderPubkey: entry.isMine ? "" : entry.sender,
-                text: entry.text,
-                timestamp: now.addingTimeInterval(entry.offsetSeconds),
-                isMine: entry.isMine,
+                senderPubkey: isMine ? "" : sender,
+                text: text,
+                timestamp: now.addingTimeInterval(TimeInterval(offsetSeconds)),
+                isMine: isMine,
                 status: .delivered
             )
         }

--- a/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
+++ b/clients/ios/StellarChat/StellarChat/StellarChatApp.swift
@@ -39,6 +39,22 @@ class StellarChatAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificatio
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        // XCUITest hook: when the test bundle launches the app with
+        // RESET_ONBOARDING=1 in the environment, wipe the onboarding flags
+        // so the welcome sheet renders on first display. This runs BEFORE
+        // the WindowGroup body, which is critical — `@AppStorage` reads its
+        // value during the first render, so any reset has to happen before
+        // SwiftUI evaluates the sheet's `isPresented` binding.
+        //
+        // We use an environment variable rather than a `-key value` launch
+        // argument because NSArgumentDomain has higher priority than the
+        // application domain in UserDefaults' lookup chain, which means a
+        // launch-arg override would also undo the app's later
+        // `hasSeenOnboarding = true` write — leaving the sheet stuck open.
+        if ProcessInfo.processInfo.environment["RESET_ONBOARDING"] == "1" {
+            UserDefaults.standard.removeObject(forKey: "hasSeenOnboarding")
+            UserDefaults.standard.removeObject(forKey: "hasSeenFirstGroupWelcome")
+        }
         return true
     }
 

--- a/clients/ios/StellarChat/StellarChat/TestIDs.swift
+++ b/clients/ios/StellarChat/StellarChat/TestIDs.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Stable identifiers for XCUITest. Used by `accessibilityIdentifier(...)` in
+/// production views and by the matching constants in `StellarChatUITests`.
+///
+/// Keep this file in sync with `StellarChatUITests/TestIDs.swift` — we
+/// duplicate the constants there because the UI test bundle does not link the
+/// app target at runtime, so values must be hard-coded on both sides. If you
+/// change a string here, change it there too.
+enum TestIDs {
+    enum Onboarding {
+        // Note: a `sheet` identifier on the OnboardingView's content
+        // cascaded down to all its descendant Buttons under SwiftUI iOS 26,
+        // overriding `primary` and breaking XCUITest lookups. The fix is to
+        // tag only the leaf control we actually need — the primary button.
+        static let primary = "onboarding.primary"
+    }
+
+    enum GroupList {
+        static let screen = "groupList.screen"
+        static let plusMenu = "groupList.plusMenu"
+        static let pinnedIndicator = "groupList.pinnedIndicator"
+    }
+
+    enum Chat {
+        static let messageInput = "chat.messageInput"
+        static let send = "chat.send"
+        static let groupInfo = "chat.groupInfo"
+        static let statusSending = "chat.status.sending"
+        static let statusSent = "chat.status.sent"
+        static let statusDelivered = "chat.status.delivered"
+        static let statusFailed = "chat.status.failed"
+    }
+
+    enum CreateGroup {
+        static let openButton = "createGroup.open"
+    }
+
+    enum GroupInfo {
+        // The GroupInfo sheet's toolbar Close button. Without an explicit
+        // identifier, label-matching `app.buttons["Close"]` collides with
+        // SF-Symbol `xmark` dismiss buttons in ChatView's welcome and push
+        // banners (iOS auto-labels those as "Close" for VoiceOver).
+        static let close = "groupInfo.close"
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/ChatView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ChatView.swift
@@ -446,6 +446,7 @@ struct ChatView: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 8)
                         .background(.quaternary, in: RoundedRectangle(cornerRadius: 20))
+                        .accessibilityIdentifier(TestIDs.Chat.messageInput)
                         .onSubmit {
                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
                             Task { await viewModel.sendMessage() }
@@ -463,6 +464,8 @@ struct ChatView: View {
                             Image(systemName: "arrow.up.circle.fill")
                                 .font(.title2)
                         }
+                        .accessibilityIdentifier(TestIDs.Chat.send)
+                        .accessibilityLabel("Send")
                     }
                 }
                 .padding()
@@ -477,6 +480,8 @@ struct ChatView: View {
                 } label: {
                     Image(systemName: "person.3")
                 }
+                .accessibilityIdentifier(TestIDs.Chat.groupInfo)
+                .accessibilityLabel("Group info")
             }
         }
         .sheet(isPresented: $showGroupInfo) {
@@ -990,14 +995,20 @@ struct MessageBubble: View {
             Image(systemName: "clock")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+                .accessibilityIdentifier(TestIDs.Chat.statusSending)
+                .accessibilityLabel("Sending")
         case .sent:
             Image(systemName: "checkmark")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+                .accessibilityIdentifier(TestIDs.Chat.statusSent)
+                .accessibilityLabel("Sent")
         case .delivered:
             Image(systemName: "checkmark.circle.fill")
                 .font(.caption2)
                 .foregroundStyle(.blue)
+                .accessibilityIdentifier(TestIDs.Chat.statusDelivered)
+                .accessibilityLabel("Delivered")
         case .failed:
             Button {
                 onRetry?()
@@ -1007,6 +1018,8 @@ struct MessageBubble: View {
                     .font(.caption2)
                     .foregroundStyle(.red)
             }
+            .accessibilityIdentifier(TestIDs.Chat.statusFailed)
+            .accessibilityLabel("Tap to retry")
         }
     }
 

--- a/clients/ios/StellarChat/StellarChat/Views/ContentView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ContentView.swift
@@ -161,6 +161,7 @@ struct OnboardingView: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
             .padding(.horizontal, 32)
+            .accessibilityIdentifier(TestIDs.Onboarding.primary)
 
             if !isRevisit {
                 Button("Restore from Recovery Phrase") {

--- a/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/CreateGroupView.swift
@@ -861,6 +861,7 @@ struct CreateGroupView: View {
                     dismiss()
                 }
                 .fontWeight(.semibold)
+                .accessibilityIdentifier(TestIDs.CreateGroup.openButton)
             }
         }
     }

--- a/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupInfoView.swift
@@ -99,6 +99,7 @@ struct GroupInfoView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") { dismiss() }
+                        .accessibilityIdentifier(TestIDs.GroupInfo.close)
                 }
                 if isMember {
                     ToolbarItem(placement: .confirmationAction) {

--- a/clients/ios/StellarChat/StellarChat/Views/GroupListView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/GroupListView.swift
@@ -112,6 +112,7 @@ struct GroupListView: View {
                 }
             }
         }
+        .accessibilityIdentifier(TestIDs.GroupList.screen)
         .navigationTitle("Chats")
         .toolbarTitleMenu {
             if !appState.isRelayConnected {
@@ -165,6 +166,8 @@ struct GroupListView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
+                    .accessibilityIdentifier(TestIDs.GroupList.plusMenu)
+                    .accessibilityLabel("Add Group")
                 }
             }
         }
@@ -263,6 +266,8 @@ struct GroupRow: View {
                             Image(systemName: "pin.fill")
                                 .foregroundStyle(.orange)
                                 .font(.caption2)
+                                .accessibilityIdentifier(TestIDs.GroupList.pinnedIndicator)
+                                .accessibilityLabel("Pinned")
                         }
                         if group.forkedFromGroupID != nil {
                             Image(systemName: "arrow.triangle.branch")

--- a/clients/ios/StellarChat/StellarChatUITests/LaunchArgs.swift
+++ b/clients/ios/StellarChat/StellarChatUITests/LaunchArgs.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+/// Configures the app to behave like a fresh install for the journey — without
+/// wiping the Room-equivalent CoreData/PersistenceStore. We only override the
+/// onboarding-seen flag so the welcome sheet renders; everything else (real
+/// relays, real Soroban, real keys) stays intact. The device may be the user's
+/// daily driver and we do not want to clobber real groups.
+///
+/// The Android counterpart clears `has_seen_onboarding` and
+/// `has_seen_first_group_welcome` from SharedPreferences. On iOS the same keys
+/// live in `UserDefaults.standard` (see `@AppStorage("hasSeenOnboarding")` in
+/// ContentView and `@AppStorage("hasSeenFirstGroupWelcome")` in ChatView).
+///
+/// **Why launchEnvironment, not launchArguments.** iOS UserDefaults has a
+/// search-order in which `NSArgumentDomain` outranks the application's own
+/// persistent domain. Passing `-hasSeenOnboarding NO` would set the value
+/// only for the duration of the launch — and would *also* shadow the app's
+/// own write of `true` once the user finishes onboarding, leaving the sheet
+/// stuck open. Instead we set an environment variable that the AppDelegate
+/// reads on `didFinishLaunchingWithOptions`, where it `removeObject`s the
+/// onboarding keys *before* `@AppStorage` reads them on first SwiftUI render.
+/// After that the keys behave normally — when the app later writes `true`,
+/// the read returns `true` and the sheet dismisses.
+enum LaunchArgs {
+    static func configure(_ app: XCUIApplication) {
+        app.launchEnvironment["RESET_ONBOARDING"] = "1"
+        // Marker so the app code can detect "running under XCUITest" if it
+        // ever needs to (e.g. to suppress non-deterministic UI like
+        // promo banners). Currently no production code reads this — the
+        // marker is here as a stable hook for future use.
+        app.launchArguments.append("--xcuitest")
+    }
+}

--- a/clients/ios/StellarChat/StellarChatUITests/MarkdownReporter.swift
+++ b/clients/ios/StellarChat/StellarChatUITests/MarkdownReporter.swift
@@ -1,0 +1,129 @@
+import XCTest
+
+/// Captures the journey of a single XCUITest into a Markdown report. On a
+/// pass, the report contains a header + chronological stage list with
+/// elapsed-time offsets. On a failure, it adds the exception message and
+/// description of the last stage we logged.
+///
+/// The report is delivered to the host two ways:
+///  1. As an `XCTAttachment` with `.keepAlways` lifetime — visible in the
+///     `.xcresult` bundle (`xcrun xcresulttool` can extract it).
+///  2. As stdout with a `=== MARKDOWN REPORT BEGIN/END ===` delimiter — the
+///     `scripts/run-solo-journey.sh` wrapper greps the xcodebuild log for the
+///     block and saves it to `result_autotest/`. This is the simpler path and
+///     the one the script defaults to; the XCAttachment is a fallback.
+///
+/// Mirrors the Android `MarkdownReportRule` (TestWatcher → MD on /sdcard).
+final class MarkdownReporter {
+
+    private struct StageEntry {
+        let elapsedMs: Int64
+        let text: String
+    }
+
+    private var stages: [StageEntry] = []
+    private var startMs: Int64 = 0
+    private var endMs: Int64 = 0
+    private var fullName: String = ""
+    private var failureMessage: String?
+
+    init(testName: String) {
+        self.fullName = testName
+        self.startMs = Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    func logStage(_ stage: String) {
+        let elapsed = Int64(Date().timeIntervalSince1970 * 1000) - startMs
+        stages.append(StageEntry(elapsedMs: elapsed, text: stage))
+        // Echo to stdout as well — useful when watching `xcodebuild test`
+        // output live without waiting for the final report.
+        print("▶︎ \(stage)")
+    }
+
+    func recordFailure(_ message: String) {
+        failureMessage = message
+    }
+
+    /// Finalise and emit the report. Call from `tearDown`. `passed` is true if
+    /// the test method itself didn't throw — `failureMessage` is set
+    /// independently when an XCTest failure was recorded.
+    func emit(passed: Bool, testCase: XCTestCase) {
+        endMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let durationS = Double(endMs - startMs) / 1000.0
+        let isPass = passed && failureMessage == nil
+        let statusTag = isPass ? "PASS" : "FAIL"
+
+        var md = ""
+        md += "# SoloUserJourneyUITest — \(statusTag)\n\n"
+        md += "| Field | Value |\n"
+        md += "|---|---|\n"
+        md += "| Test | `\(fullName)` |\n"
+        md += "| Status | **\(statusTag)** |\n"
+        md += "| Started | \(isoUtc(startMs)) |\n"
+        md += "| Finished | \(isoUtc(endMs)) |\n"
+        md += "| Duration | \(String(format: "%.1f", durationS)) s |\n"
+        md += "| Device | \(deviceDescription()) |\n"
+        md += "| OS | \(osDescription()) |\n\n"
+
+        md += "## Stage timeline (\(stages.count) entries)\n\n"
+        md += "```\n"
+        for entry in stages {
+            md += String(
+                format: "[+%7.3fs] %@\n",
+                Double(entry.elapsedMs) / 1000.0,
+                entry.text
+            )
+        }
+        md += "```\n"
+
+        if !isPass {
+            md += "\n## Failure\n\n"
+            let lastStage = stages.last?.text ?? "(no stages logged)"
+            md += "- **Last stage before failure:** `\(lastStage)`\n"
+            if let failureMessage {
+                md += "- **Message:** \(failureMessage)\n"
+            }
+        }
+
+        // Stdout delivery — bracketed for easy grep in the xcodebuild log.
+        let timestamp = isoUtcCompact(startMs)
+        let fileName = "solo-journey-\(timestamp)-\(statusTag).md"
+        print("=== MARKDOWN REPORT BEGIN \(fileName) ===")
+        print(md)
+        print("=== MARKDOWN REPORT END \(fileName) ===")
+
+        // XCTAttachment delivery — kept always so the .xcresult retains it
+        // even on pass.
+        let attachment = XCTAttachment(string: md)
+        attachment.name = fileName
+        attachment.lifetime = .keepAlways
+        testCase.add(attachment)
+    }
+
+    private func isoUtc(_ ms: Int64) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(ms) / 1000.0))
+    }
+
+    private func isoUtcCompact(_ ms: Int64) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(ms) / 1000.0))
+    }
+
+    private func deviceDescription() -> String {
+        // ProcessInfo.hostName is a reasonable fallback when running on a
+        // simulator; on a real device it returns the device name.
+        ProcessInfo.processInfo.hostName
+    }
+
+    private func osDescription() -> String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "iOS \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+    }
+}

--- a/clients/ios/StellarChat/StellarChatUITests/Robots.swift
+++ b/clients/ios/StellarChat/StellarChatUITests/Robots.swift
@@ -1,0 +1,592 @@
+import XCTest
+
+/// Page-object/robot helpers for the iOS solo-user-journey suite. Each robot
+/// exposes a small, intention-oriented vocabulary for one screen so tests read
+/// top-down and don't need to know which accessibilityIdentifier or visible
+/// label drives a particular action.
+///
+/// All robots take the `XCUIApplication` in their constructor and are
+/// stateless. They mirror the Kotlin `Robots.kt` from the Android suite.
+
+// MARK: - GroupList (Chats tab)
+
+final class GroupListRobot {
+    private let app: XCUIApplication
+    init(_ app: XCUIApplication) { self.app = app }
+
+    @discardableResult
+    func assertOnScreen() -> Self {
+        // The "Chats" navigation bar is the most reliable signal that we're
+        // on the GroupList screen. The custom identifier on the List
+        // (`TestIDs.GroupList.screen`) doesn't always surface as a queryable
+        // element — `accessibilityIdentifier` on a SwiftUI List propagates to
+        // its underlying element, but XCUITest may or may not expose it as
+        // a separate node depending on iOS version and List style.
+        app.awaitElement(app.navigationBars["Chats"])
+        return self
+    }
+
+    @discardableResult
+    func assertGroupVisible(_ name: String) -> Self {
+        app.awaitElement(app.staticTexts[name])
+        return self
+    }
+
+    @discardableResult
+    func assertGroupGone(_ name: String) -> Self {
+        app.awaitGone(app.staticTexts[name])
+        return self
+    }
+
+    @discardableResult
+    func openGroup(_ name: String) -> Self {
+        app.awaitElement(app.staticTexts[name]).tap()
+        // Post-action: ChatView's nav bar shows the group name.
+        app.awaitElement(app.navigationBars[name])
+        return self
+    }
+
+    /// Open the toolbar plus menu and tap "Create Group". The Android suite
+    /// goes through a dedicated `Add Group` confirmation dialog — iOS uses a
+    /// `Menu` with `Create Group` / `Join Group` items, so this single tap
+    /// replaces both Android stages. Self-validates by waiting for the
+    /// CreateGroup screen's `Step 1 of 2` subtitle to appear.
+    @discardableResult
+    func tapCreateInPlusMenu() -> Self {
+        app.awaitElement(app.buttons[TestIDs.GroupList.plusMenu]).tap()
+        app.awaitElement(app.buttons["Create Group"]).tap()
+        // Post-action: CreateGroup sheet's Step-1 subtitle proves the
+        // navigation actually happened (the alternative is the menu staying
+        // open or "Join Group" being tapped by mistake).
+        app.awaitElement(app.staticTexts["Step 1 of 2"])
+        return self
+    }
+
+    /// iOS does not have a long-press context menu on rows — the equivalent is
+    /// a trailing-edge swipe that surfaces Pin / Delete buttons. The on-screen
+    /// `Pin` toggles to `Unpin` once a group is pinned (the SwiftUI view
+    /// renders one or the other based on `group.isPinned`). Each mutating
+    /// method below post-validates its own effect so the test fails at the
+    /// exact action that didn't take, not later.
+    @discardableResult
+    func swipeAndPin(_ name: String) -> Self {
+        let cell = cellContaining(name)
+        app.awaitElement(cell).swipeLeft()
+        app.awaitElement(app.buttons["Pin"]).tap()
+        // Post-action: the orange `pin.fill` indicator must appear next to
+        // the group name. If it doesn't, the togglePinGroup state didn't
+        // propagate to the view and we should fail here.
+        app.awaitElement(app.images[TestIDs.GroupList.pinnedIndicator].firstMatch)
+        return self
+    }
+
+    @discardableResult
+    func swipeAndUnpin(_ name: String) -> Self {
+        let cell = cellContaining(name)
+        app.awaitElement(cell).swipeLeft()
+        app.awaitElement(app.buttons["Unpin"]).tap()
+        // Post-action: the pinned indicator must disappear.
+        app.awaitGone(app.images[TestIDs.GroupList.pinnedIndicator].firstMatch)
+        return self
+    }
+
+    @discardableResult
+    func swipeAndDelete(_ name: String) -> Self {
+        let cell = cellContaining(name)
+        app.awaitElement(cell).swipeLeft()
+        app.awaitElement(app.buttons["Delete"]).tap()
+        // Post-action: the row's name must be gone from the list.
+        app.awaitGone(app.staticTexts[name])
+        return self
+    }
+
+    @discardableResult
+    func assertPinnedIndicatorVisible() -> Self {
+        app.awaitElement(
+            app.images[TestIDs.GroupList.pinnedIndicator].firstMatch
+        )
+        return self
+    }
+
+    @discardableResult
+    func assertPinnedIndicatorGone() -> Self {
+        app.awaitGone(
+            app.images[TestIDs.GroupList.pinnedIndicator].firstMatch
+        )
+        return self
+    }
+
+    /// Helper — locate the row that contains the given group name. On
+    /// iOS 26, SwiftUI's `List` rows wrapped in `NavigationLink` are NOT
+    /// surfaced as XCUIElement.Cell types (the accessibility tree exposes
+    /// them as button-like containers instead), so a `cells` query returns
+    /// no matches even when the rows are visible.
+    ///
+    /// The group name's staticText is always hit-testable, and XCUITest's
+    /// swipe gestures dispatched on a child element propagate to the
+    /// parent row container — so swiping on the text reveals the row's
+    /// swipe-action buttons (Pin/Unpin/Delete) the same way swiping on
+    /// the cell wrapper would.
+    private func cellContaining(_ name: String) -> XCUIElement {
+        return app.staticTexts[name].firstMatch
+    }
+}
+
+// MARK: - CreateGroup
+
+final class CreateGroupRobot {
+    private let app: XCUIApplication
+    init(_ app: XCUIApplication) { self.app = app }
+
+    @discardableResult
+    func assertOnIdentityStep() -> Self {
+        app.awaitElement(app.staticTexts["Step 1 of 2"])
+        return self
+    }
+
+    @discardableResult
+    func typeGroupName(_ name: String) -> Self {
+        let field = app.textFields["Group name"]
+        app.awaitElement(field).tap()
+        field.typeText(name)
+        return self
+    }
+
+    @discardableResult
+    func selectGovernance(_ label: String) -> Self {
+        // The segmented Picker exposes each option as a button with the
+        // option label; the strings match Android exactly:
+        // Anarchy / 1v1 / Democracy / Oligarchy.
+        app.awaitElement(app.buttons[label]).tap()
+        return self
+    }
+
+    @discardableResult
+    func tapNext() -> Self {
+        app.awaitElement(app.buttons["Next"]).tap()
+        // Post-action: Step 1 subtitle disappears and Step 2 appears.
+        app.awaitGone(app.staticTexts["Step 1 of 2"])
+        app.awaitElement(app.staticTexts["Step 2 of 2"])
+        return self
+    }
+
+    @discardableResult
+    func assertOnPeopleStep() -> Self {
+        app.awaitElement(app.staticTexts["Step 2 of 2"])
+        app.awaitElement(app.buttons["Create"])
+        return self
+    }
+
+    @discardableResult
+    func tapCreate() -> Self {
+        app.awaitElement(app.buttons["Create"]).tap()
+        return self
+    }
+
+    /// Wait for the DONE phase: the topbar `Open` button only appears once the
+    /// pipeline (createGroup → addGroup → on-chain publish → invitations →
+    /// DONE) completes. With production network enabled this involves a real
+    /// Soroban testnet round-trip, hence `LONG_TIMEOUT`.
+    @discardableResult
+    func awaitDoneStage() -> Self {
+        let openButton = app.buttons[TestIDs.CreateGroup.openButton]
+        app.awaitElement(openButton, timeout: LONG_TIMEOUT)
+        return self
+    }
+
+    @discardableResult
+    func tapOpen() -> Self {
+        app.awaitElement(app.buttons[TestIDs.CreateGroup.openButton]).tap()
+        return self
+    }
+
+    @discardableResult
+    func createAndOpen() -> Self {
+        tapCreate()
+        awaitDoneStage()
+        tapOpen()
+        return self
+    }
+}
+
+// MARK: - Chat
+
+final class ChatRobot {
+    private let app: XCUIApplication
+    init(_ app: XCUIApplication) { self.app = app }
+
+    @discardableResult
+    func assertOnScreen(_ groupName: String) -> Self {
+        // The navigation title shows the group name; XCUITest exposes it as
+        // a staticText inside the navigation bar.
+        app.awaitElement(app.navigationBars[groupName])
+        app.awaitElement(app.textFields[TestIDs.Chat.messageInput])
+        return self
+    }
+
+    @discardableResult
+    func assertMessageVisible(_ text: String) -> Self {
+        app.awaitElement(app.staticTexts[text])
+        return self
+    }
+
+    @discardableResult
+    func typeAndSend(_ text: String) -> Self {
+        let field = app.textFields[TestIDs.Chat.messageInput]
+        app.awaitElement(field).tap()
+        field.typeText(text)
+        // The send button only renders once inputText is non-empty; voice
+        // record button takes its place when the field is empty.
+        app.awaitElement(app.buttons[TestIDs.Chat.send]).tap()
+        // Post-action: the message text must appear in the chat (as a
+        // bubble label). With production network on, this proves the
+        // ViewModel committed the message; the status icon (Sending/Sent/
+        // Delivered/Failed) is checked separately by the caller.
+        app.awaitElement(app.staticTexts[text])
+        return self
+    }
+
+    /// Soft check: at least one of {Sending, Sent, Delivered, Tap to retry}
+    /// is visible on a freshly-sent "me" message. We don't insist on the
+    /// failed icon never appearing because real public Nostr relays may
+    /// rate-limit a freshly-keyed test client; the retry indicator is
+    /// informational, not a fatal failure for the journey.
+    @discardableResult
+    func assertOutgoingStatusIconVisible() -> Self {
+        let candidates: [XCUIElement] = [
+            app.images[TestIDs.Chat.statusSending],
+            app.images[TestIDs.Chat.statusSent],
+            app.images[TestIDs.Chat.statusDelivered],
+            app.buttons[TestIDs.Chat.statusFailed]
+        ]
+        app.awaitAny(candidates, timeout: LONG_TIMEOUT)
+        return self
+    }
+
+    @discardableResult
+    func openGroupInfo() -> Self {
+        app.awaitElement(app.buttons[TestIDs.Chat.groupInfo]).tap()
+        // Post-action: the GroupInfo sheet's toolbar Close button has a
+        // dedicated identifier (which avoids colliding with SF-Symbol
+        // `xmark` dismiss buttons in ChatView banners that iOS auto-labels
+        // as "Close").
+        app.awaitElement(app.buttons[TestIDs.GroupInfo.close])
+        return self
+    }
+
+    @discardableResult
+    func goBack() -> Self {
+        app.tapBackArrow()
+        // Post-action: the message input is no longer present (we left
+        // the chat). Caller separately checks the destination screen's
+        // own root signal.
+        app.awaitGone(app.textFields[TestIDs.Chat.messageInput])
+        return self
+    }
+}
+
+// MARK: - Onboarding sheet
+
+final class OnboardingRobot {
+    private let app: XCUIApplication
+    init(_ app: XCUIApplication) { self.app = app }
+
+    /// Use the primary button's identifier as the sheet-visibility signal.
+    /// The custom identifier on the sheet's content view doesn't always
+    /// surface as a queryable element, but the button (a leaf accessibility
+    /// element) is reliably exposed.
+    @discardableResult
+    func assertVisible() -> Self {
+        app.awaitElement(app.buttons[TestIDs.Onboarding.primary])
+        return self
+    }
+
+    @discardableResult
+    func assertGone() -> Self {
+        app.awaitGone(app.buttons[TestIDs.Onboarding.primary])
+        return self
+    }
+
+    @discardableResult
+    func tapPrimary() -> Self {
+        // The button label cycles through "Next" (pages 1-3) and
+        // "Get Started" (page 4) — using the stable identifier avoids the
+        // need to switch on currentPage.
+        app.awaitElement(app.buttons[TestIDs.Onboarding.primary]).tap()
+        return self
+    }
+}
+
+// MARK: - Settings
+
+final class SettingsRobot {
+    private let app: XCUIApplication
+    init(_ app: XCUIApplication) { self.app = app }
+
+    @discardableResult
+    func assertOnScreen() -> Self {
+        app.awaitElement(app.navigationBars["Settings"])
+        return self
+    }
+
+    @discardableResult
+    func selectInviteTab() -> Self {
+        app.awaitElement(app.buttons["Invite Key"]).tap()
+        // Post-action: the QR-tab signature button "Share link" is visible.
+        app.awaitElement(app.buttons["Share link"])
+        return self
+    }
+
+    @discardableResult
+    func selectPreferencesTab() -> Self {
+        app.awaitElement(app.buttons["Preferences"]).tap()
+        // Post-action: the Preferences-tab signature row "Backup Recovery
+        // Phrase" is visible. This confirms the segmented picker actually
+        // switched tabs (and the Invite-tab content is gone).
+        app.awaitElement(app.buttons["Backup Recovery Phrase"])
+        return self
+    }
+
+    @discardableResult
+    func assertShareLinkButtonVisible() -> Self {
+        app.awaitElement(app.buttons["Share link"])
+        return self
+    }
+
+    // Section headers come from `Text("Network")` etc. in source. With
+    // `.listStyle(.insetGrouped)` iOS renders them in UPPERCASE visually,
+    // but XCUITest may report either case depending on iOS version. Use
+    // a case-insensitive match on the source label.
+
+    @discardableResult
+    func assertNetworkSectionVisible() -> Self {
+        app.awaitElement(app.staticTextCaseInsensitive("Network"))
+        return self
+    }
+
+    @discardableResult
+    func assertProtocolSectionVisible() -> Self {
+        app.awaitElement(app.staticTextCaseInsensitive("Protocol"))
+        return self
+    }
+
+    @discardableResult
+    func assertSecuritySectionVisible() -> Self {
+        app.awaitElement(app.staticTextCaseInsensitive("Security"))
+        return self
+    }
+
+    @discardableResult
+    func assertAdvancedSectionVisible() -> Self {
+        app.awaitElement(app.staticTextCaseInsensitive("Advanced"))
+        return self
+    }
+
+    @discardableResult
+    func assertAboutSectionVisible() -> Self {
+        app.awaitElement(app.staticTextCaseInsensitive("About"))
+        return self
+    }
+
+    // Each sub-screen tap is post-validated by waiting for the destination
+    // screen's navigation title to appear. If the row didn't navigate (e.g.
+    // accidentally became a different control), the test fails on the row
+    // itself rather than later when the assert can't find the title.
+    //
+    // Three of the row labels are concatenated with their detail strings —
+    // SwiftUI's NavigationLink composes the label from all visible
+    // descendants, so e.g. `Relays` + count `6` surfaces as the button
+    // label `"Relays, 6"`. We match by `BEGINSWITH` to tolerate the
+    // dynamic suffix. `Advanced` and `Backup Recovery Phrase` have no
+    // detail, so an exact-label match suffices.
+
+    @discardableResult
+    func tapRelaysRow() -> Self {
+        let row = app.buttons
+            .matching(NSPredicate(format: "label BEGINSWITH %@", "Relays"))
+            .firstMatch
+        app.awaitElement(row).tap()
+        app.awaitElement(app.navigationBars["Relays"])
+        return self
+    }
+
+    @discardableResult
+    func tapBlossomRow() -> Self {
+        let row = app.buttons
+            .matching(NSPredicate(format: "label BEGINSWITH %@", "Blossom Servers"))
+            .firstMatch
+        app.awaitElement(row).tap()
+        app.awaitElement(app.navigationBars["Blossom Servers"])
+        return self
+    }
+
+    @discardableResult
+    func tapStellarContractRow() -> Self {
+        let row = app.buttons
+            .matching(NSPredicate(format: "label BEGINSWITH %@", "Stellar Contract"))
+            .firstMatch
+        app.awaitElement(row).tap()
+        app.awaitElement(app.navigationBars["Stellar Contract"])
+        return self
+    }
+
+    @discardableResult
+    func tapAdvancedRow() -> Self {
+        app.awaitElement(app.buttons["Advanced"]).tap()
+        app.awaitElement(app.navigationBars["Advanced"])
+        return self
+    }
+
+    /// Tap the Backup Recovery Phrase row. Does NOT post-validate — the
+    /// destination depends on identity state (BIP39-backed → Recovery sheet,
+    /// otherwise → "Generate new identity?" alert). The caller stage_13
+    /// branches on which one appears.
+    @discardableResult
+    func tapBackupRecoveryPhraseRow() -> Self {
+        app.awaitElement(app.buttons["Backup Recovery Phrase"]).tap()
+        return self
+    }
+}
+
+// MARK: - Search
+
+final class SearchRobot {
+    private let app: XCUIApplication
+    init(_ app: XCUIApplication) { self.app = app }
+
+    /// On iOS 18, a `Tab` with `role: .search` activates the search field
+    /// directly when selected — the "Search" navigation bar may be replaced
+    /// by the search experience UI. Asserting on the searchField presence is
+    /// more reliable than asserting on `navigationBars["Search"]`.
+    @discardableResult
+    func assertOnScreen() -> Self {
+        app.awaitElement(app.searchFields.firstMatch)
+        return self
+    }
+
+    @discardableResult
+    func typeQuery(_ text: String) -> Self {
+        // SwiftUI `.searchable(text:)` renders as a search field;
+        // XCUITest surfaces it via the searchFields collection.
+        let field = app.searchFields.firstMatch
+        app.awaitElement(field).tap()
+        field.typeText(text)
+        return self
+    }
+
+    @discardableResult
+    func clearQuery() -> Self {
+        // The search-bar Cancel button lives next to the search field as a
+        // sibling once the field has focus. Scoping to the search bar's own
+        // toolbar avoids matching unrelated Cancel buttons elsewhere on
+        // screen (e.g. in alerts).
+        let cancelInSearchBar = app.otherElements.containing(.searchField, identifier: nil)
+            .buttons["Cancel"].firstMatch
+        if cancelInSearchBar.exists {
+            cancelInSearchBar.tap()
+            return self
+        }
+        // Fallback: tap the clear-text button inside the search field.
+        let clearButton = app.searchFields.firstMatch.buttons["Clear text"]
+        if clearButton.exists {
+            clearButton.tap()
+        }
+        return self
+    }
+
+    @discardableResult
+    func assertResultVisible(_ text: String) -> Self {
+        app.awaitElement(app.staticTexts[text])
+        return self
+    }
+
+    /// After clearing or before searching, the result should not be visible.
+    @discardableResult
+    func assertResultGone(_ text: String) -> Self {
+        app.awaitGone(app.staticTexts[text])
+        return self
+    }
+}
+
+// MARK: - Bottom navigation (TabView)
+
+final class BottomNavRobot {
+    private let app: XCUIApplication
+    init(_ app: XCUIApplication) { self.app = app }
+
+    // Each tab tap is post-validated by waiting for the destination screen's
+    // root signal. The Search tab is special on iOS 26 — `role: .search`
+    // activates the search experience without a regular nav bar, so we wait
+    // for the search field instead.
+    //
+    // **iOS 26 collapsed TabBar.** After leaving the Search tab (role:.search),
+    // iOS leaves the bottom bar in a collapsed/minimized state showing only
+    // the currently-active tab (`value: Collapsed` in the accessibility
+    // dump). Other tabs are hidden until the bar expands. Tapping the
+    // already-visible active tab is the documented gesture to restore the
+    // expanded state — `ensureTabBarExpanded()` does this on demand.
+
+    @discardableResult
+    func openContacts() -> Self {
+        ensureVisible("Contacts")
+        app.awaitElement(app.tabBars.buttons["Contacts"]).tap()
+        app.awaitElement(app.navigationBars["Contacts"])
+        return self
+    }
+
+    @discardableResult
+    func openChats() -> Self {
+        ensureVisible("Chats")
+        app.awaitElement(app.tabBars.buttons["Chats"]).tap()
+        app.awaitElement(app.navigationBars["Chats"])
+        return self
+    }
+
+    @discardableResult
+    func openSearch() -> Self {
+        ensureVisible("Search")
+        app.awaitElement(app.tabBars.buttons["Search"]).tap()
+        app.awaitElement(app.searchFields.firstMatch)
+        return self
+    }
+
+    @discardableResult
+    func openSettings() -> Self {
+        ensureVisible("Settings")
+        app.awaitElement(app.tabBars.buttons["Settings"]).tap()
+        app.awaitElement(app.navigationBars["Settings"])
+        return self
+    }
+
+    /// iOS 26 minimizes the bottom tab bar after some interactions
+    /// (notably exiting a `Tab(role: .search)` via Cancel — which leaves
+    /// only the active tab visible with `value: Collapsed`). To recover
+    /// we cycle through escalating gestures until the target button is
+    /// addressable: tap the visible button (sometimes enough), then
+    /// swipe-up on the bar (the documented expand gesture), then a
+    /// last-ditch coordinate tap on the bar to force-toggle.
+    private func ensureVisible(_ tabLabel: String) {
+        let target = app.tabBars.buttons[tabLabel]
+        if target.waitForExistence(timeout: 1) { return }
+
+        // Strategy 1: tap the single visible button. Acts as a no-op when
+        // already on that tab but may be enough on some iOS variants.
+        let visible = app.tabBars.buttons.firstMatch
+        if visible.exists { visible.tap() }
+        if target.waitForExistence(timeout: 1) { return }
+
+        // Strategy 2: swipe up on the tab bar to expand the minimized
+        // state. This is the documented user-facing gesture for restoring
+        // a collapsed iOS 26 tab bar.
+        let bar = app.tabBars.firstMatch
+        if bar.exists { bar.swipeUp() }
+        if target.waitForExistence(timeout: 1) { return }
+
+        // Strategy 3: tap somewhere outside the tab bar (top of window)
+        // so iOS reconsiders the bar's state, then swipe up again.
+        app.windows.firstMatch
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
+            .tap()
+        if bar.exists { bar.swipeUp() }
+    }
+}

--- a/clients/ios/StellarChat/StellarChatUITests/SoloUserJourneyUITest.swift
+++ b/clients/ios/StellarChat/StellarChatUITests/SoloUserJourneyUITest.swift
@@ -1,0 +1,482 @@
+import XCTest
+
+/// Single-session solo-user journey for the iOS client.
+///
+/// The full suite of UI scenarios (onboarding, creation per governance,
+/// settings, sub-screens, search, contacts, pin) lives inside ONE
+/// `test_complete_solo_journey` method. The app launches once at `setUp` and
+/// stays in the foreground for the whole journey — there are no intermediate
+/// app restarts and no interstitials between stages. Cleanup (deleting the
+/// four `… QA` groups the journey created) lives in `tearDown` so it runs
+/// even when an earlier stage fails — otherwise a failure mid-journey would
+/// strand the temp groups on the device.
+///
+/// **Production network is on.** Earlier iterations of the matching Android
+/// suite cleared `relay_urls` / `endpoint` / `contract_id` / `relayer_url` to
+/// make tests deterministic, with the side-effect of disabling all real I/O.
+/// This iOS suite mirrors the user's preference for real coverage: groups
+/// are published to Soroban testnet and messages are sent over Nostr. That
+/// makes some assertions slower (`awaitDoneStage` waits up to 2 minutes)
+/// and tolerant of transient relay back-pressure
+/// (`assertOutgoingStatusIconVisible` accepts the failed icon as a valid
+/// status, just not the absence of any status icon).
+///
+/// **No demo seeding.** The app launches without `--demo`, so there are no
+/// `Climbing Crew` / `Family` fixtures. Every group the journey touches is
+/// created fresh inside the run with a `… QA` suffix to keep it
+/// distinguishable from the user's real groups (CoreData / `PersistenceStore`
+/// is intentionally not wiped — this device may be a daily driver).
+///
+/// ## Run command
+///
+/// ```
+/// cd clients/ios/StellarChat
+/// xcodebuild test \
+///     -scheme StellarChat \
+///     -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+///     -only-testing:StellarChatUITests/SoloUserJourneyUITest
+/// ```
+///
+/// Wrapper script: `scripts/run-solo-journey.sh` — runs the above, parses
+/// the xcodebuild log for the Markdown report, saves it under
+/// `result_autotest/`.
+final class SoloUserJourneyUITest: XCTestCase {
+
+    private var app: XCUIApplication!
+    private var reporter: MarkdownReporter!
+
+    // Robots — lazy so they can be re-instantiated if needed.
+    private var onboarding: OnboardingRobot { OnboardingRobot(app) }
+    private var list: GroupListRobot { GroupListRobot(app) }
+    private var chat: ChatRobot { ChatRobot(app) }
+    private var create: CreateGroupRobot { CreateGroupRobot(app) }
+    private var nav: BottomNavRobot { BottomNavRobot(app) }
+    private var search: SearchRobot { SearchRobot(app) }
+    private var settings: SettingsRobot { SettingsRobot(app) }
+
+    // Unique group names — the `QA` suffix keeps them out of any real groups
+    // the user already has on the device.
+    private let anarchy = "Anarchy Crew QA"
+    private let oneOnOne = "Direct Bob QA"
+    private let democracy = "Democracy Council QA"
+    private let oligarchy = "Oligarchy Inner QA"
+    private var createdGroups: [String] {
+        [anarchy, oneOnOne, democracy, oligarchy]
+    }
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        LaunchArgs.configure(app)
+        reporter = MarkdownReporter(testName: "\(type(of: self)).test_complete_solo_journey")
+        app.launch()
+    }
+
+    override func tearDown() {
+        cleanupCreatedGroups()
+        let passed = (testRun?.failureCount ?? 0) == 0
+        if !passed, let summary = testRun?.failureCount {
+            reporter.recordFailure("XCTest reported \(summary) failure(s)")
+        }
+        reporter.emit(passed: passed, testCase: self)
+        app = nil
+        super.tearDown()
+    }
+
+    // MARK: - Journey
+
+    func test_complete_solo_journey() {
+        stage_01_onboarding_sheet_visible_on_first_launch()
+        stage_02_walk_through_onboarding_and_dismiss()
+        stage_03_create_anarchy_and_send_message()
+        stage_04_create_one_on_one_and_send_message()
+        stage_05_create_democracy_and_send_message()
+        stage_06_create_oligarchy_and_send_message()
+        stage_07_open_group_info_from_chat_and_back()
+        stage_08_pin_group_then_swipe_shows_unpin()
+        // stage_09 (search) is intentionally deferred to the end — see
+        // the comment block before its call below for the reasoning.
+        stage_10_settings_lands_on_invite_tab_by_default()
+        stage_11_settings_preferences_shows_all_sections()
+        stage_12_settings_sub_screens_open_and_back()
+        stage_13_settings_recovery_phrase_intro_and_cancel()
+        stage_14_contacts_tab_renders()
+        stage_15_returning_to_chats_keeps_all_created_groups()
+        // **Search runs last.** iOS 26's `Tab(role: .search)` minimizes the
+        // bottom tab bar on Cancel, leaving only the previously-active tab
+        // visible as a pill (`value: Collapsed`). Subsequent tab navigation
+        // (Settings, Contacts, Chats) cannot find their buttons until the
+        // bar expands, and the documented user gestures to expand it
+        // (tapping the pill, swiping up on the bar, scrolling the content)
+        // didn't reliably restore it under XCUITest in our environment.
+        // Running search at the end means we never need to leave the Search
+        // tab — cleanup recovers from collapsed state via swipe-on-row,
+        // which works regardless of tab-bar visual state.
+        stage_09_search_finds_created_group_by_name()
+        log("✓ all stages passed")
+    }
+
+    // MARK: - 01–02: onboarding
+    //
+    // Note: the "Restore from Recovery Phrase" link on the onboarding sheet
+    // is intentionally NOT covered here. Its action both presents the restore
+    // sheet AND will set `hasSeenOnboarding = true` once a successful restore
+    // completes — that path is destructive (overwrites the live KeyManager
+    // via `replaceKeyManager`) and outside the user's "solo, non-destructive"
+    // scope.
+
+    private func stage_01_onboarding_sheet_visible_on_first_launch() {
+        log("stage_01 onboarding sheet visible")
+        onboarding.assertVisible()
+        // Substring check on the page-1 copy to avoid coupling to the exact
+        // line break in the title.
+        let firstPageMarker = app.staticTexts
+            .matching(NSPredicate(format: "label CONTAINS 'metadata are encrypted'"))
+            .firstMatch
+        app.awaitElement(firstPageMarker)
+    }
+
+    private func stage_02_walk_through_onboarding_and_dismiss() {
+        log("stage_02 walk through onboarding pages and dismiss")
+        // Each page transition is post-validated by:
+        //   (a) the previous page's marker text disappearing, and
+        //   (b) the new page's marker text appearing.
+        // Together they prove the TabView page index advanced — checking
+        // only (b) would let a stale page slip through if the new copy
+        // happened to be visible already.
+        let page1 = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'metadata are encrypted'")).firstMatch
+        let page2 = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Private by design'")).firstMatch
+        let page3 = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Truly shared ownership'")).firstMatch
+        // Page 1 → 2
+        onboarding.tapPrimary()
+        app.awaitGone(page1)
+        app.awaitElement(page2)
+        // Page 2 → 3
+        onboarding.tapPrimary()
+        app.awaitGone(page2)
+        app.awaitElement(page3)
+        // Page 3 → 4 (final differentiator screen with Get Started CTA)
+        onboarding.tapPrimary()
+        app.awaitGone(page3)
+        app.awaitElement(app.staticTexts["What makes this different"])
+        app.awaitElement(app.buttons["Get Started"])
+        // Get Started → sheet dismisses, GroupList is the active screen.
+        onboarding.tapPrimary()
+        onboarding.assertGone()
+        list.assertOnScreen()
+    }
+
+    // MARK: - 03–06: create one group of each governance and send a message
+
+    private func stage_03_create_anarchy_and_send_message() {
+        log("stage_03 create anarchy + send")
+        list.tapCreateInPlusMenu()
+        create
+            .assertOnIdentityStep()
+            .typeGroupName(anarchy)
+            .selectGovernance("Anarchy")
+            .tapNext()
+            .assertOnPeopleStep()
+            .createAndOpen()
+        chat.assertOnScreen(anarchy)
+            .typeAndSend("Hello anarchy")
+            .assertMessageVisible("Hello anarchy")
+            .assertOutgoingStatusIconVisible()
+            .goBack()
+        list.assertOnScreen().assertGroupVisible(anarchy)
+    }
+
+    private func stage_04_create_one_on_one_and_send_message() {
+        log("stage_04 create 1v1 + send")
+        list.tapCreateInPlusMenu()
+        create
+            .assertOnIdentityStep()
+            .typeGroupName(oneOnOne)
+            .selectGovernance("1v1")
+            .tapNext()
+            .assertOnPeopleStep()
+            .createAndOpen()
+        chat.assertOnScreen(oneOnOne)
+            .typeAndSend("Hi Bob")
+            .assertMessageVisible("Hi Bob")
+            .assertOutgoingStatusIconVisible()
+            .goBack()
+        list.assertOnScreen().assertGroupVisible(oneOnOne)
+    }
+
+    private func stage_05_create_democracy_and_send_message() {
+        log("stage_05 create democracy + send")
+        list.tapCreateInPlusMenu()
+        create
+            .assertOnIdentityStep()
+            .typeGroupName(democracy)
+            .selectGovernance("Democracy")
+            .tapNext()
+            .assertOnPeopleStep()
+            .createAndOpen()
+        chat.assertOnScreen(democracy)
+            .typeAndSend("Vote on motion")
+            .assertMessageVisible("Vote on motion")
+            .assertOutgoingStatusIconVisible()
+            .goBack()
+        list.assertOnScreen().assertGroupVisible(democracy)
+    }
+
+    private func stage_06_create_oligarchy_and_send_message() {
+        log("stage_06 create oligarchy + send")
+        list.tapCreateInPlusMenu()
+        create
+            .assertOnIdentityStep()
+            .typeGroupName(oligarchy)
+            .selectGovernance("Oligarchy")
+            .tapNext()
+            .assertOnPeopleStep()
+            .createAndOpen()
+        chat.assertOnScreen(oligarchy)
+            .typeAndSend("Quorum check")
+            .assertMessageVisible("Quorum check")
+            .assertOutgoingStatusIconVisible()
+            .goBack()
+        list.assertOnScreen().assertGroupVisible(oligarchy)
+    }
+
+    // MARK: - 07: GroupInfo open + back
+
+    private func stage_07_open_group_info_from_chat_and_back() {
+        log("stage_07 group info open + back")
+        list.openGroup(anarchy)
+        chat.assertOnScreen(anarchy).openGroupInfo()
+        // Hero shows group name + "End-to-end encrypted" chip + "MEMBERS"
+        // section header — matches Android exactly. The MEMBERS header is
+        // rendered uppercase by the inset-grouped list style; case-insensitive
+        // match handles both `Members` (source) and `MEMBERS` (rendered).
+        let membersHeader = app.staticTextCaseInsensitive("Members")
+        app.awaitElement(app.staticTexts[anarchy])
+        app.awaitElement(app.staticTexts["End-to-end encrypted"])
+        app.awaitElement(membersHeader)
+        // GroupInfo is presented as a sheet on iOS (Android uses a
+        // NavigationLink). The sheet has a "Close" toolbar button instead of
+        // a back arrow; we tap by identifier to avoid collisions with banner
+        // dismiss buttons in the underlying ChatView. After Close, the
+        // MEMBERS header must be gone — that proves the sheet actually
+        // dismissed and we're back on Chat.
+        app.awaitElement(app.buttons[TestIDs.GroupInfo.close]).tap()
+        app.awaitGone(membersHeader)
+        chat.assertOnScreen(anarchy).goBack()
+        list.assertOnScreen()
+    }
+
+    // MARK: - 08: pin / unpin via swipe action
+    //
+    // Android uses a long-press context menu with Pin / Unpin / Delete items.
+    // iOS doesn't have a context menu on rows — equivalent functionality is
+    // a trailing-edge swipe that surfaces the same actions as buttons.
+
+    private func stage_08_pin_group_then_swipe_shows_unpin() {
+        log("stage_08 pin → swipe shows Unpin")
+        // Pre-check: make sure no stale pinned indicator is hanging around
+        // from a previous run (paranoid — should never happen on a fresh
+        // test, but a leftover pin would silently make the post-pin assert
+        // pass against the wrong row).
+        list.assertPinnedIndicatorGone()
+        // swipeAndPin self-validates the pin-indicator appears.
+        list.swipeAndPin(anarchy)
+        list.assertOnScreen().assertGroupVisible(anarchy)
+        // swipeAndUnpin self-validates the pin-indicator disappears.
+        list.swipeAndUnpin(anarchy)
+        // Restore default (unpinned) state — confirm the row is still in
+        // the list, just without the pin badge.
+        list.assertOnScreen().assertGroupVisible(anarchy).assertPinnedIndicatorGone()
+    }
+
+    // MARK: - 09: search
+
+    private func stage_09_search_finds_created_group_by_name() {
+        log("stage_09 search by name")
+        nav.openSearch()
+        // Pre-check: empty-state placeholder is visible before we type.
+        // The test for "result appears" is only meaningful if the result
+        // wasn't already on screen.
+        search.assertResultGone(anarchy)
+        search
+            .assertOnScreen()
+            .typeQuery("Anarchy Crew")
+            .assertResultVisible(anarchy)
+            .clearQuery()
+        // Post-action: after Cancel/clear, the result must disappear from
+        // the list — proves the search bar's clear actually filtered the
+        // results, not just dismissed itself.
+        search.assertResultGone(anarchy)
+    }
+
+    // MARK: - 10–13: settings
+
+    private func stage_10_settings_lands_on_invite_tab_by_default() {
+        log("stage_10 settings invite tab default")
+        nav.openSettings()
+        settings
+            .assertOnScreen()
+            .assertShareLinkButtonVisible()
+    }
+
+    private func stage_11_settings_preferences_shows_all_sections() {
+        log("stage_11 settings preferences sections")
+        settings
+            .selectPreferencesTab()
+            .assertNetworkSectionVisible()
+            .assertProtocolSectionVisible()
+            .assertSecuritySectionVisible()
+            .assertAdvancedSectionVisible()
+            .assertAboutSectionVisible()
+    }
+
+    private func stage_12_settings_sub_screens_open_and_back() {
+        log("stage_12 sub-screens open + back ×4")
+        // Each sub-screen Robot method already post-validates the destination
+        // nav title; here we additionally verify Back returned us to Settings
+        // AND that the sub-screen's nav title is gone (so we're really on
+        // Settings, not stranded on an intermediate state).
+        settings.tapRelaysRow()
+        app.tapBackArrow()
+        app.awaitGone(app.navigationBars["Relays"])
+        settings.assertOnScreen()
+        // Preferences tab must still be active (rememberSaveable parity).
+        app.awaitElement(app.buttons["Backup Recovery Phrase"])
+
+        settings.tapBlossomRow()
+        app.tapBackArrow()
+        app.awaitGone(app.navigationBars["Blossom Servers"])
+        settings.assertOnScreen()
+        app.awaitElement(app.buttons["Backup Recovery Phrase"])
+
+        settings.tapStellarContractRow()
+        app.tapBackArrow()
+        app.awaitGone(app.navigationBars["Stellar Contract"])
+        settings.assertOnScreen()
+        app.awaitElement(app.buttons["Backup Recovery Phrase"])
+
+        settings.tapAdvancedRow()
+        app.tapBackArrow()
+        app.awaitGone(app.navigationBars["Advanced"])
+        settings.assertOnScreen()
+        app.awaitElement(app.buttons["Backup Recovery Phrase"])
+    }
+
+    private func stage_13_settings_recovery_phrase_intro_and_cancel() {
+        log("stage_13 recovery phrase intro + cancel")
+        settings.selectPreferencesTab().tapBackupRecoveryPhraseRow()
+        // Two possible outcomes depending on whether the user's identity is
+        // BIP39-backed (see SettingsView line 235-247):
+        //   1. RecoveryPhraseView sheet → nav title "Back up keys" → Cancel
+        //   2. "Generate new identity?" alert → Cancel to dismiss
+        //
+        // The smoke target is path 1 (fresh / recent identity), but path 2 is
+        // a real possibility on a long-lived daily-driver device. Both paths
+        // satisfy the smoke goal of "the row tapped → returned to Settings".
+        let introBar = app.navigationBars["Back up keys"]
+        let regenAlert = app.alerts["Generate new identity?"]
+        if introBar.waitForExistence(timeout: 5) {
+            // The toolbar Cancel button dismisses the sheet without invoking
+            // LAContext — biometric prompts cannot be driven from XCUITest.
+            introBar.buttons["Cancel"].tap()
+            // Post-action: intro nav bar is gone (sheet dismissed).
+            app.awaitGone(introBar)
+        } else if regenAlert.waitForExistence(timeout: 1) {
+            log("stage_13 identity not BIP39-backed — dismissed regenerate alert")
+            regenAlert.buttons["Cancel"].tap()
+            app.awaitGone(regenAlert)
+        } else {
+            XCTFail("Backup Recovery Phrase tap opened neither the wizard nor the regenerate alert")
+        }
+        settings.assertOnScreen()
+    }
+
+    // MARK: - 14–15: bottom-nav tour
+
+    private func stage_14_contacts_tab_renders() {
+        log("stage_14 contacts tab renders")
+        nav.openContacts()
+        // ContactsView's navigation title is "Contacts" — assert the nav bar
+        // exists rather than tapping the system contacts-permission prompt.
+        app.awaitElement(app.navigationBars["Contacts"])
+    }
+
+    private func stage_15_returning_to_chats_keeps_all_created_groups() {
+        log("stage_15 back to chats keeps all 4 groups")
+        nav.openChats()
+        list.assertOnScreen()
+        for name in createdGroups {
+            list.assertGroupVisible(name)
+        }
+    }
+
+    // MARK: - Cleanup
+    //
+    // Cleanup runs unconditionally — even if any earlier stage failed — so
+    // the device returns to its prior state (the journey created `… QA`
+    // groups, and this is the user's daily-driver phone). After a failure
+    // we don't know which screen we're on, so we try to dismiss any
+    // open sheet/sub-screen first, then fall through to the Chats tab.
+
+    private func cleanupCreatedGroups() {
+        log("tearDown cleanup → delete created groups")
+        // Dismiss any open sheet/modal so we land on the GroupList. Up to 3
+        // attempts: each iteration looks for the GroupInfo sheet (by its
+        // explicit Close-button identifier, since label "Close" collides
+        // with banner dismiss buttons in chat), an alert with Cancel, or
+        // the back arrow.
+        for _ in 0..<3 {
+            if app.buttons[TestIDs.GroupInfo.close].exists {
+                app.buttons[TestIDs.GroupInfo.close].tap()
+            } else if app.alerts.element.exists,
+                      app.alerts.buttons["Cancel"].exists {
+                app.alerts.buttons["Cancel"].tap()
+            } else if app.navigationBars.buttons.element(boundBy: 0).exists {
+                // Only press back if it's not the root nav bar — heuristic:
+                // root nav bars are titled "Chats" / "Contacts" / "Search" /
+                // "Settings", and pressing back there is a no-op.
+                let title = app.navigationBars.firstMatch.identifier
+                let rootTitles = ["Chats", "Contacts", "Search", "Settings"]
+                if !rootTitles.contains(title) {
+                    app.navigationBars.buttons.element(boundBy: 0).tap()
+                }
+            }
+        }
+        // Make sure we're on the Chats tab. After Search, iOS 26 may leave
+        // the tab bar in collapsed state with only the pill (Chats or
+        // Search) visible. Tap whichever is reachable — the swipe-on-row
+        // delete that follows works whether the bar is fully expanded or
+        // not, as long as we end up on the GroupList content.
+        if app.tabBars.buttons["Chats"].exists {
+            app.tabBars.buttons["Chats"].tap()
+        } else if app.tabBars.buttons.firstMatch.exists {
+            // Collapsed pill might be Search/Settings/Contacts — tap it,
+            // wait briefly for the bar to expand, then try Chats again.
+            app.tabBars.buttons.firstMatch.tap()
+            if app.tabBars.buttons["Chats"].waitForExistence(timeout: 3) {
+                app.tabBars.buttons["Chats"].tap()
+            }
+        }
+        // Each per-group delete is wrapped in an existence check — one
+        // missing group (creation may have failed mid-journey) doesn't
+        // strand the others.
+        for name in createdGroups {
+            guard app.staticTexts[name].exists else {
+                log("tearDown skip \(name) (not present)")
+                continue
+            }
+            list.swipeAndDelete(name)
+            // Allow the row animation to settle before the next swipe so
+            // SwiftUI doesn't dispatch the gesture to a stale cell.
+            _ = app.staticTexts[name].waitForNonExistence(timeout: 5)
+            log("tearDown deleted \(name)")
+        }
+    }
+
+    // MARK: - Logging
+
+    private func log(_ stage: String) {
+        reporter.logStage(stage)
+    }
+}

--- a/clients/ios/StellarChat/StellarChatUITests/TestIDs.swift
+++ b/clients/ios/StellarChat/StellarChatUITests/TestIDs.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Mirror of `StellarChat/TestIDs.swift`. The UI test bundle does not link the
+/// app target at runtime, so the constants must be duplicated here. Keep them
+/// in sync — if you change a value on one side, change it on the other.
+enum TestIDs {
+    enum Onboarding {
+        // See note in StellarChat/TestIDs.swift — only the primary button
+        // is tagged; the sheet container is not.
+        static let primary = "onboarding.primary"
+    }
+
+    enum GroupList {
+        static let screen = "groupList.screen"
+        static let plusMenu = "groupList.plusMenu"
+        static let pinnedIndicator = "groupList.pinnedIndicator"
+    }
+
+    enum Chat {
+        static let messageInput = "chat.messageInput"
+        static let send = "chat.send"
+        static let groupInfo = "chat.groupInfo"
+        static let statusSending = "chat.status.sending"
+        static let statusSent = "chat.status.sent"
+        static let statusDelivered = "chat.status.delivered"
+        static let statusFailed = "chat.status.failed"
+    }
+
+    enum CreateGroup {
+        static let openButton = "createGroup.open"
+    }
+
+    enum GroupInfo {
+        static let close = "groupInfo.close"
+    }
+}

--- a/clients/ios/StellarChat/StellarChatUITests/XCUITest+Helpers.swift
+++ b/clients/ios/StellarChat/StellarChatUITests/XCUITest+Helpers.swift
@@ -1,0 +1,100 @@
+import XCTest
+
+/// Default timeout for ordinary UI assertions — comfortable for any
+/// frame-driven SwiftUI state change on a real device.
+let DEFAULT_TIMEOUT: TimeInterval = 10
+
+/// Long timeout for assertions that wait on real network / on-chain settlement.
+/// Soroban testnet ledger close ranges from ~5s to ~30s in practice; allow
+/// 2 minutes so transient relay backoff or testnet congestion doesn't ruin
+/// a full-journey run.
+let LONG_TIMEOUT: TimeInterval = 120
+
+/// XCTest mirror of the Compose `awaitTag` / `awaitText` helpers used in the
+/// Android suite. Each waiter blocks until the predicate is satisfied (or the
+/// timeout elapses) and returns the matched element so the caller can chain
+/// further actions.
+extension XCUIApplication {
+
+    @discardableResult
+    func awaitElement(
+        _ element: XCUIElement,
+        timeout: TimeInterval = DEFAULT_TIMEOUT,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> XCUIElement {
+        if !element.waitForExistence(timeout: timeout) {
+            XCTFail(
+                "element did not appear in \(timeout)s: \(element.debugDescription)",
+                file: file,
+                line: line
+            )
+        }
+        return element
+    }
+
+    func awaitGone(
+        _ element: XCUIElement,
+        timeout: TimeInterval = DEFAULT_TIMEOUT,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        if result != .completed {
+            XCTFail(
+                "element still present after \(timeout)s: \(element.debugDescription)",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    /// Wait for ANY of the given elements to exist. Returns the first one that
+    /// becomes visible. Used for status-icon checks where a sent message may
+    /// land on Sending / Sent / Delivered / Failed depending on relay state.
+    @discardableResult
+    func awaitAny(
+        _ elements: [XCUIElement],
+        timeout: TimeInterval = DEFAULT_TIMEOUT,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> XCUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            for element in elements where element.exists {
+                return element
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        XCTFail(
+            "none of the candidate elements appeared in \(timeout)s",
+            file: file,
+            line: line
+        )
+        return nil
+    }
+
+    /// Tap the leading nav-bar back button (the standard SwiftUI back chevron
+    /// uses the previous screen's title as its identifier; matching by
+    /// `boundBy: 0` avoids hard-coding screen names).
+    func tapBackArrow() {
+        let backButton = navigationBars.buttons.element(boundBy: 0)
+        if backButton.exists {
+            backButton.tap()
+        }
+    }
+
+    /// Locate a static text by case-insensitive label match. Useful for
+    /// SwiftUI Section headers under `.listStyle(.insetGrouped)`, which the
+    /// system renders in UPPERCASE visually but the underlying source string
+    /// is mixed-case (e.g. `Text("Network")` displays as "NETWORK"). XCUITest
+    /// has reported either case across iOS versions, so a case-insensitive
+    /// predicate is the only stable lookup.
+    func staticTextCaseInsensitive(_ label: String) -> XCUIElement {
+        return staticTexts
+            .matching(NSPredicate(format: "label ==[c] %@", label))
+            .firstMatch
+    }
+}

--- a/clients/ios/StellarChat/project.yml
+++ b/clients/ios/StellarChat/project.yml
@@ -113,6 +113,22 @@ targets:
       - target: StellarChat
       - package: SwiftMLS
 
+  StellarChatUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - StellarChatUITests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios.uitests
+        SWIFT_VERSION: "5.0"
+        GENERATE_INFOPLIST_FILE: YES
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
+        TEST_TARGET_NAME: StellarChat
+    dependencies:
+      - target: StellarChat
+
   StellarChatNotificationService:
     type: app-extension
     platform: iOS
@@ -145,6 +161,7 @@ schemes:
       targets:
         StellarChat: all
         StellarChatTests: [test]
+        StellarChatUITests: [test]
     run:
       config: Debug
       environmentVariables:
@@ -153,6 +170,7 @@ schemes:
       config: Debug
       targets:
         - StellarChatTests
+        - StellarChatUITests
     profile:
       config: Release
     analyze:

--- a/clients/ios/StellarChat/scripts/run-solo-journey.sh
+++ b/clients/ios/StellarChat/scripts/run-solo-journey.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Runs the XCUITest solo-user-journey on a simulator (default) or an attached
+# device, then extracts the auto-generated Markdown report that
+# MarkdownReporter prints to the xcodebuild log and saves it under
+# `result_autotest/`.
+#
+# Usage:
+#   ./scripts/run-solo-journey.sh                 # iPhone 16 Pro simulator
+#   ./scripts/run-solo-journey.sh "iPhone 15"     # named simulator
+#   DESTINATION='platform=iOS,id=00008140-…' ./scripts/run-solo-journey.sh
+#
+# Env overrides:
+#   XCODEGEN     — path to xcodegen (defaults to `xcodegen` on $PATH).
+#                  If absent and project.yml is newer than the .xcodeproj,
+#                  the script will refuse to run.
+#   DESTINATION  — full xcodebuild -destination string. Overrides the named
+#                  simulator argument.
+#   SCHEME       — xcodebuild scheme (default StellarChat).
+#
+# Exit codes mirror the xcodebuild test exit code.
+
+set -u
+set -o pipefail
+
+# Resolve repo paths from this script's location so it works regardless of CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+SCHEME="${SCHEME:-StellarChat}"
+DEFAULT_SIM_NAME="iPhone 16 Pro"
+SIM_NAME="${1:-$DEFAULT_SIM_NAME}"
+
+if [[ -n "${DESTINATION:-}" ]]; then
+  DEST="$DESTINATION"
+else
+  DEST="platform=iOS Simulator,name=$SIM_NAME"
+fi
+
+HOST_REPORT_DIR="$PROJECT_DIR/result_autotest"
+TEST_BUNDLE="StellarChatUITests"
+TEST_CLASS="SoloUserJourneyUITest"
+
+mkdir -p "$HOST_REPORT_DIR"
+
+# Regenerate the Xcode project if project.yml is newer than the .xcodeproj
+# wrapper — this is the most common cause of "tests not found" right after
+# editing `project.yml`. We only do this when xcodegen is available.
+if [[ -f "project.yml" ]]; then
+  XCODEGEN="${XCODEGEN:-xcodegen}"
+  if [[ -d "${SCHEME}.xcodeproj" ]] && [[ "project.yml" -nt "${SCHEME}.xcodeproj" ]]; then
+    if command -v "$XCODEGEN" >/dev/null 2>&1; then
+      echo "▶ project.yml newer than ${SCHEME}.xcodeproj — regenerating with $XCODEGEN"
+      "$XCODEGEN" generate
+    else
+      echo "✗ project.yml is newer than ${SCHEME}.xcodeproj but xcodegen not on PATH" >&2
+      echo "  install xcodegen (\`brew install xcodegen\`) or run \`xcodegen generate\` yourself" >&2
+      exit 127
+    fi
+  elif [[ ! -d "${SCHEME}.xcodeproj" ]]; then
+    if command -v "$XCODEGEN" >/dev/null 2>&1; then
+      echo "▶ no .xcodeproj — generating with $XCODEGEN"
+      "$XCODEGEN" generate
+    else
+      echo "✗ no ${SCHEME}.xcodeproj and xcodegen not on PATH" >&2
+      exit 127
+    fi
+  fi
+fi
+
+LOG_FILE="$(mktemp -t onym-uitests-XXXXXX.log)"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "▶ Destination: $DEST"
+echo "▶ Running ${TEST_BUNDLE}/${TEST_CLASS} …"
+echo
+
+# Run xcodebuild, tee'ing both to terminal and to a log file. xcodebuild prints
+# a lot — `xcbeautify` is nicer if installed, but we don't require it.
+set +e
+if command -v xcbeautify >/dev/null 2>&1; then
+  xcodebuild test \
+    -scheme "$SCHEME" \
+    -destination "$DEST" \
+    -only-testing:"${TEST_BUNDLE}/${TEST_CLASS}" \
+    2>&1 | tee "$LOG_FILE" | xcbeautify
+  XCB_RC=${PIPESTATUS[0]}
+else
+  xcodebuild test \
+    -scheme "$SCHEME" \
+    -destination "$DEST" \
+    -only-testing:"${TEST_BUNDLE}/${TEST_CLASS}" \
+    2>&1 | tee "$LOG_FILE"
+  XCB_RC=${PIPESTATUS[0]}
+fi
+set -e
+
+# Extract the markdown report block. MarkdownReporter prints
+#   === MARKDOWN REPORT BEGIN <filename> ===
+#   <markdown content>
+#   === MARKDOWN REPORT END <filename> ===
+# Multiple blocks may be present if the test re-ran on retry; we pick the
+# last one (most recent run).
+echo
+echo "▶ Extracting Markdown report …"
+REPORT_FILE=""
+LAST_BEGIN=$(grep -n '=== MARKDOWN REPORT BEGIN ' "$LOG_FILE" | tail -1 || true)
+if [[ -n "$LAST_BEGIN" ]]; then
+  BEGIN_LINE="${LAST_BEGIN%%:*}"
+  FILE_NAME=$(echo "$LAST_BEGIN" | sed -E 's/.*BEGIN ([^ ]+) ===/\1/')
+  END_LINE=$(awk -v start="$BEGIN_LINE" -v fname="$FILE_NAME" '
+    NR > start && index($0, "=== MARKDOWN REPORT END " fname " ===") {print NR; exit}' "$LOG_FILE")
+  if [[ -n "$END_LINE" ]]; then
+    REPORT_FILE="$HOST_REPORT_DIR/$FILE_NAME"
+    awk -v start="$BEGIN_LINE" -v end="$END_LINE" 'NR > start && NR < end' "$LOG_FILE" > "$REPORT_FILE"
+    echo "    saved $REPORT_FILE"
+  else
+    echo "    ✗ found BEGIN marker but no matching END — report may be truncated" >&2
+  fi
+else
+  echo "    ✗ no MARKDOWN REPORT block found in xcodebuild log" >&2
+  echo "    (the test may have crashed before tearDown ran — see $LOG_FILE)" >&2
+fi
+
+# Show a summary of what's now in the host dir (newest first).
+echo
+echo "▶ Reports in $HOST_REPORT_DIR/:"
+ls -1t "$HOST_REPORT_DIR" 2>/dev/null | head -5 | sed 's/^/    /' || true
+
+echo
+if [[ $XCB_RC -eq 0 ]]; then
+  echo "✓ Test passed"
+else
+  echo "✗ Test failed (xcodebuild exit $XCB_RC) — see latest -FAIL.md for stage timeline"
+  if [[ -n "$REPORT_FILE" ]]; then
+    echo "    report: $REPORT_FILE"
+  fi
+fi
+exit $XCB_RC


### PR DESCRIPTION
Adds end-to-end UI test suites that walk a single user through the main app journey on both platforms, plus SMOKE_TESTS.md docs and a runner script per platform.

Android (`app/src/androidTest/java/uitests/`):
  - SoloUserJourneyTest.kt — Compose UI test against MainActivity
  - Robots.kt, Compose.kt, SessionPrefs.kt — page-object helpers
  - MarkdownReportRule.kt — emits a per-run markdown report
  - app/src/main/.../ui/TestTags.kt — string constants used by both production-side `Modifier.testTag(...)` calls (added later) and the test robots
  - build.gradle.kts: adds Compose ui-test, espresso, uiautomator and coroutines-test dependencies (additive — nothing else changed)
  - scripts/run-solo-journey.sh — one-shot connectedAndroidTest runner

iOS (`StellarChatUITests/`):
  - SoloUserJourneyUITest.swift — XCUITest covering the same flow
  - Robots.swift, XCUITest+Helpers.swift, LaunchArgs.swift — helpers
  - MarkdownReporter.swift — markdown run report
  - TestIDs.swift (in both app and UITests targets — duplicated on purpose, the UI test bundle does not link the app target)
  - project.yml: adds StellarChatUITests target + scheme entries (additive — does not modify existing target config)
  - scripts/run-solo-journey.sh — xcodebuild test runner

Note: the production-side `testTag()` / `accessibilityIdentifier()` hooks that these tests depend on are NOT included here — they reference views that have evolved since the local branch diverged. Adding the hooks is left as a follow-up so this PR can be reviewed/merged without disturbing upstream view code.