### PR TITLE
feat(ios): redesign Settings tab as Onym Settings tree

### DIFF
--- a/clients/ios/StellarChat/StellarChat/Views/ContentView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/ContentView.swift
@@ -40,7 +40,7 @@ struct ContentView: View {
 
             Tab("Settings", systemImage: "gearshape", value: .settings) {
                 NavigationStack {
-                    SettingsView()
+                    OnymSettingsHomeView()
                 }
             }
         }

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymAnchorsView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymAnchorsView.swift
@@ -1,0 +1,736 @@
+import SwiftUI
+
+// MARK: - Anchors home (Network)
+
+struct OnymAnchorsView: View {
+    @Bindable var model: OnymSettingsModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Anchors", onBack: { dismiss() })
+                OnymLargeTitle(text: "Anchors")
+                OnymFootnote(text: "Choose the contract version used to anchor on-chain group state. Selection per (network, governance type) pins to new chats; existing chats keep the contract they were created with.")
+
+                OnymSectionLabel(text: "NETWORK")
+                OnymCard {
+                    NavigationLink { OnymAnchorNetworkView(model: model) } label: {
+                        OnymRow(
+                            title: "Testnet",
+                            subtitle: "5 governance types · all current",
+                            onTap: {}
+                        ) {
+                            OnymTile(bg: OnymTokens.Tile.green) {
+                                Text("T").font(.system(size: 11, weight: .bold)).foregroundStyle(.white)
+                            }
+                        }
+                    }.buttonStyle(.plain)
+
+                    OnymRow(
+                        title: "Mainnet",
+                        subtitle: "No contracts yet",
+                        hasChevron: false,
+                        last: true
+                    ) {
+                        OnymTile(bg: OnymTokens.Tile.gray) {
+                            Text("M").font(.system(size: 11, weight: .bold)).foregroundStyle(.white)
+                        }
+                    } right: {
+                        Text("Soon").foregroundStyle(OnymTokens.text3).font(.system(size: 14))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Anchor network → governance type list
+
+struct OnymAnchorNetworkView: View {
+    @Bindable var model: OnymSettingsModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Testnet", onBack: { dismiss() })
+                OnymSectionLabel(text: "GOVERNANCE TYPES")
+                OnymCard {
+                    ForEach(Array(OnymCatalog.governance.enumerated()), id: \.element.id) { idx, g in
+                        NavigationLink { OnymAnchorVersionView(model: model, govId: g.id) } label: {
+                            OnymRow(
+                                title: g.label,
+                                subtitle: "\(g.sub) · v0.0.5 (latest)",
+                                inset: 56,
+                                last: idx == OnymCatalog.governance.count - 1,
+                                onTap: {}
+                            ) {
+                                OnymGovTile(id: g.id)
+                            }
+                        }.buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct OnymGovTile: View {
+    let id: String
+    private var palette: (bg: Color, fg: Color) {
+        switch id {
+        case "anarchy":   return (OnymTokens.Tile.orange.opacity(0.16), Color(red: 0.82, green: 0.29, blue: 0))
+        case "democracy": return (OnymTokens.green.opacity(0.16),       Color(red: 0.10, green: 0.51, blue: 0.28))
+        case "oligarchy": return (OnymTokens.Tile.indigo.opacity(0.16), Color(red: 0.24, green: 0.24, blue: 0.79))
+        case "dialog":    return (OnymTokens.blue.opacity(0.16),        OnymTokens.blue)
+        case "tyranny":   return (OnymTokens.red.opacity(0.16),         OnymTokens.red)
+        default:          return (OnymTokens.Tile.gray.opacity(0.16),   OnymTokens.text2)
+        }
+    }
+    var body: some View {
+        let p = palette
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(p.bg)
+            .frame(width: 30, height: 30)
+            .overlay(Text(String(id.prefix(2)).uppercased())
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(p.fg))
+    }
+}
+
+// MARK: - Anchor version list
+
+struct OnymAnchorVersionView: View {
+    @Bindable var model: OnymSettingsModel
+    let govId: String
+    @Environment(\.dismiss) private var dismiss
+    @State private var selected: String = "v0.0.5"
+
+    private var gov: OnymGovType {
+        OnymCatalog.governance.first(where: { $0.id == govId }) ?? OnymCatalog.governance[0]
+    }
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Testnet · \(gov.label)", onBack: { dismiss() })
+                OnymSectionLabel(text: "CONTRACT VERSION")
+                OnymCard {
+                    ForEach(Array(OnymCatalog.versions.enumerated()), id: \.element.v) { idx, v in
+                        NavigationLink { OnymContractDetailView(govId: govId, version: v.v) } label: {
+                            OnymRow(
+                                title: v.v,
+                                titleMono: true,
+                                subtitle: "\(v.date) · \(v.audit)",
+                                inset: 16,
+                                last: idx == OnymCatalog.versions.count - 1,
+                                onTap: {}
+                            ) {
+                                EmptyView()
+                            } right: {
+                                HStack(spacing: 8) {
+                                    if v.current {
+                                        Text("LATEST")
+                                            .font(.system(size: 10.5, weight: .bold))
+                                            .padding(.horizontal, 6).padding(.vertical, 2)
+                                            .background(OnymTokens.green.opacity(0.16),
+                                                        in: RoundedRectangle(cornerRadius: 4))
+                                            .foregroundStyle(Color(red: 0.10, green: 0.51, blue: 0.28))
+                                    }
+                                    if selected == v.v {
+                                        Image(systemName: "checkmark")
+                                            .font(.system(size: 14, weight: .bold))
+                                            .foregroundStyle(OnymTokens.blue)
+                                    }
+                                }
+                            }
+                        }.buttonStyle(.plain)
+                    }
+                }
+                OnymFootnote(text: "Tap a version to view the contract, source code, and audit report.")
+
+                OnymSectionLabel(text: "CUSTOM")
+                OnymCard {
+                    NavigationLink { OnymDeployContractView(govId: govId) } label: {
+                        OnymRow(
+                            title: "Deploy from source",
+                            subtitle: "Build & publish your own contract",
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "chevron.left.forwardslash.chevron.right",
+                                           bg: OnymTokens.text)
+                        }
+                    }.buttonStyle(.plain)
+
+                    NavigationLink { OnymEnterContractView(model: model, govId: govId) } label: {
+                        OnymRow(
+                            title: "Use existing address",
+                            subtitle: "Point to a deployed contract",
+                            last: true,
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "shippingbox.fill", bg: OnymTokens.Tile.indigo)
+                        }
+                    }.buttonStyle(.plain)
+                }
+                OnymFootnote(text: "Onym only ships audited (or pending-audit) contracts. If you've forked or deployed your own, point new chats at it here. Existing chats keep the contract they were created with.")
+            }
+        }
+    }
+}
+
+// MARK: - Contract detail
+
+struct OnymContractDetailView: View {
+    let govId: String
+    let version: String
+    @Environment(\.dismiss) private var dismiss
+
+    private var gov: OnymGovType {
+        OnymCatalog.governance.first(where: { $0.id == govId }) ?? OnymCatalog.governance[0]
+    }
+    private var v: OnymContractVersion {
+        OnymCatalog.versions.first(where: { $0.v == version }) ?? OnymCatalog.versions[0]
+    }
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: version, subtitle: gov.label, onBack: { dismiss() })
+
+                HStack(spacing: 14) {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(LinearGradient(colors: [Color(red: 0.996, green: 0.941, blue: 0.878),
+                                                       Color(red: 1.0, green: 0.878, blue: 0.753)],
+                                              startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .frame(width: 56, height: 56)
+                        .overlay(OnymMark(size: 32, color: Color(red: 0.82, green: 0.29, blue: 0)))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("CONTRACT · \(gov.label.uppercased())")
+                            .font(.system(size: 11.5, weight: .medium))
+                            .foregroundStyle(OnymTokens.text2)
+                            .tracking(0.46)
+                        Text(version)
+                            .font(.system(size: 22, weight: .bold, design: .monospaced))
+                            .tracking(-0.26)
+                            .foregroundStyle(OnymTokens.text)
+                        Text("Deployed \(v.date) · \(v.audit)")
+                            .font(.system(size: 12.5))
+                            .foregroundStyle(OnymTokens.text2)
+                    }
+                    Spacer()
+                }
+                .padding(18)
+                .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
+                OnymSectionLabel(text: "ON-CHAIN")
+                OnymCard {
+                    OnymRow(
+                        title: "Stellar Expert",
+                        subtitle: v.sha,
+                        subtitleMono: true,
+                        hasChevron: false,
+                        onTap: { open("https://stellar.expert") }
+                    ) {
+                        OnymTile(bg: OnymTokens.Tile.indigo) {
+                            Text("SX").font(.system(size: 11, weight: .bold)).foregroundStyle(.white)
+                        }
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(
+                        title: "Copy contract address",
+                        hasChevron: false,
+                        last: true,
+                        onTap: { UIPasteboard.general.string = v.sha }
+                    ) {
+                        OnymSymbolTile(symbol: "doc.on.doc.fill", bg: OnymTokens.Tile.gray)
+                    }
+                }
+
+                OnymSectionLabel(text: "SOURCE")
+                OnymCard {
+                    OnymRow(
+                        title: "View source on GitHub",
+                        subtitle: "onymchat/contracts @ \(version)",
+                        subtitleMono: true,
+                        hasChevron: false,
+                        onTap: { open(OnymCatalog.contractRepoURL.absoluteString) }
+                    ) {
+                        OnymSymbolTile(symbol: "chevron.left.forwardslash.chevron.right",
+                                       bg: OnymTokens.text)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(
+                        title: "Audit report",
+                        subtitle: "Pending — no audits yet",
+                        hasChevron: false,
+                        last: true,
+                        onTap: {}
+                    ) {
+                        OnymSymbolTile(symbol: "exclamationmark.circle.fill", bg: OnymTokens.amber)
+                    }
+                }
+
+                OnymFootnote(text: "This is the contract that anchors \(gov.label.lowercased()) groups created on testnet. Existing chats keep the contract they were created with — picking a different version only affects new chats.")
+            }
+        }
+    }
+
+    private func open(_ s: String) {
+        if let u = URL(string: s) { UIApplication.shared.open(u) }
+    }
+}
+
+// MARK: - Enter existing contract address
+
+struct OnymEnterContractView: View {
+    @Bindable var model: OnymSettingsModel
+    let govId: String
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var addr = ""
+    @State private var label = ""
+    @State private var verifying = false
+    @State private var verdict: Verdict?
+
+    enum Verdict { case ok, bad }
+
+    private var gov: OnymGovType {
+        OnymCatalog.governance.first(where: { $0.id == govId }) ?? OnymCatalog.governance[0]
+    }
+    private var looksValid: Bool {
+        let trimmed = addr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.count == 56 && trimmed.first == "C" &&
+            trimmed.allSatisfy { $0.isLetter || $0.isNumber } &&
+            trimmed == trimmed.uppercased()
+    }
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Use existing address", subtitle: gov.label, onBack: { dismiss() })
+
+                heroCard
+
+                OnymSectionLabel(text: "STELLAR CONTRACT ADDRESS")
+                OnymCard {
+                    VStack(alignment: .leading, spacing: 4) {
+                        TextEditor(text: $addr)
+                            .font(.system(size: 14, design: .monospaced))
+                            .frame(minHeight: 72)
+                            .scrollContentBackground(.hidden)
+                            .background(Color.clear)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                            .onChange(of: addr) { _, v in
+                                let cleaned = v.replacingOccurrences(of: " ", with: "").uppercased()
+                                if cleaned != addr { addr = cleaned }
+                                verdict = nil
+                            }
+                        if !addr.isEmpty {
+                            HStack(spacing: 8) {
+                                OnymChip(
+                                    text: looksValid ? "Valid format" : "\(addr.count)/56 chars",
+                                    fg: looksValid ? OnymTokens.green : OnymTokens.red,
+                                    bg: looksValid
+                                        ? OnymTokens.green.opacity(0.14)
+                                        : OnymTokens.red.opacity(0.14)
+                                )
+                                Text("Stellar Soroban contract ID")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(OnymTokens.text3)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 16).padding(.vertical, 12)
+                }
+
+                OnymSectionLabel(text: "LABEL")
+                OnymCard {
+                    TextField("My fork v0.0.5", text: $label)
+                        .font(.system(size: 16))
+                        .padding(.horizontal, 16).padding(.vertical, 12)
+                        .onChange(of: label) { _, v in
+                            if v.count > 30 { label = String(v.prefix(30)) }
+                        }
+                }
+                OnymFootnote(text: "Shown alongside the contract address in chats and on the Anchors list.")
+
+                OnymPrimaryButton(
+                    disabled: !looksValid || verifying,
+                    action: {
+                        if verdict == .ok { dismiss() }
+                        else { verify() }
+                    }
+                ) {
+                    Text(verifying ? "Verifying on Stellar…" :
+                         verdict == .ok ? "Use this contract" : "Verify")
+                }
+                .padding(.horizontal, 16).padding(.top, 20)
+
+                if verdict == .ok { verifiedBanner }
+                if verdict == .bad {
+                    Text("Address format invalid. Expected 56 chars starting with C.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.red)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 12)
+                }
+
+                OnymSectionLabel(text: "HOW TO FIND IT")
+                OnymCard {
+                    OnymRow(
+                        title: "Browse on Stellar Expert",
+                        subtitle: "testnet.stellar.expert",
+                        hasChevron: false,
+                        onTap: { open("https://testnet.stellar.expert") }
+                    ) {
+                        OnymTile(bg: OnymTokens.Tile.indigo) {
+                            Text("SX").font(.system(size: 11, weight: .bold)).foregroundStyle(.white)
+                        }
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(
+                        title: "Soroban CLI",
+                        subtitle: "soroban contract id …",
+                        subtitleMono: true,
+                        hasChevron: false,
+                        last: true,
+                        onTap: {}
+                    ) {
+                        OnymSymbolTile(symbol: "terminal.fill", bg: OnymTokens.Tile.gray)
+                    }
+                }
+            }
+        }
+    }
+
+    private var heroCard: some View {
+        HStack(spacing: 14) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(LinearGradient(colors: [Color(red: 0.898, green: 0.898, blue: 0.996),
+                                                Color(red: 0.78, green: 0.78, blue: 0.957)],
+                                      startPoint: .topLeading, endPoint: .bottomTrailing))
+                .frame(width: 52, height: 52)
+                .overlay(Image(systemName: "shippingbox.fill")
+                    .foregroundStyle(OnymTokens.Tile.indigo))
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Bring your own contract")
+                    .font(.system(size: 16.5, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("Anchor new \(gov.label.lowercased()) chats on a Stellar contract you've already deployed.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+                    .lineSpacing(2)
+            }
+        }
+        .padding(18)
+        .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+
+    private var verifiedBanner: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Circle().fill(OnymTokens.green).frame(width: 22, height: 22)
+                .overlay(Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.white))
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Contract verified")
+                    .font(.system(size: 13.5, weight: .semibold))
+                    .foregroundStyle(Color(red: 0.09, green: 0.37, blue: 0.18))
+                Text("Compiled hash matches onymchat/contracts@v0.0.4. Tap \"Use this contract\" to anchor new chats here.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color(red: 0.19, green: 0.43, blue: 0.28))
+                    .lineSpacing(2)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(OnymTokens.green.opacity(0.10),
+                    in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+    }
+
+    private func verify() {
+        verifying = true; verdict = nil
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
+            verifying = false
+            verdict = looksValid ? .ok : .bad
+        }
+    }
+
+    private func open(_ s: String) {
+        if let u = URL(string: s) { UIApplication.shared.open(u) }
+    }
+}
+
+// MARK: - Deploy contract from source
+
+struct OnymDeployContractView: View {
+    let govId: String
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var ref = "main"
+    @State private var stage: Stage = .idle
+    @State private var progress = 0
+    @State private var logs: [String] = []
+    @State private var deployedAddr: String?
+    @State private var copiedCmd = false
+
+    enum Stage { case idle, building, deploying, done }
+
+    private var gov: OnymGovType {
+        OnymCatalog.governance.first(where: { $0.id == govId }) ?? OnymCatalog.governance[0]
+    }
+    private var networkPassphrase: String { "Test SDF Network ; September 2015" }
+    private var cliCmd: String {
+        "soroban contract deploy \\\n  --network testnet \\\n  --source-account onym-deploy \\\n  --wasm onym_\(gov.id).wasm"
+    }
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Deploy from source",
+                           subtitle: gov.label,
+                           onBack: stage == .idle || stage == .done ? { dismiss() } : nil)
+
+                hero
+
+                OnymSectionLabel(text: "SOURCE")
+                OnymCard {
+                    OnymRow(
+                        title: "Repository",
+                        subtitle: "github.com/onymchat/contracts",
+                        subtitleMono: true,
+                        hasChevron: false,
+                        onTap: { open(OnymCatalog.contractRepoURL.absoluteString) }
+                    ) {
+                        OnymSymbolTile(symbol: "chevron.left.forwardslash.chevron.right",
+                                       bg: OnymTokens.text)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+
+                    HStack(spacing: 12) {
+                        OnymSymbolTile(symbol: "arrow.triangle.branch", bg: OnymTokens.Tile.indigo)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Ref").font(.system(size: 13)).foregroundStyle(OnymTokens.text2)
+                            TextField("main · v0.0.5 · commit sha", text: $ref)
+                                .font(.system(size: 15.5, design: .monospaced))
+                                .disabled(stage != .idle)
+                        }
+                    }
+                    .padding(.horizontal, 16).padding(.vertical, 12)
+                    Rectangle().fill(OnymTokens.hairline).frame(height: 0.5).padding(.leading, 16)
+
+                    OnymRow(title: "Network", hasChevron: false) {
+                        OnymTile(bg: OnymTokens.Tile.green) {
+                            Text("T").font(.system(size: 11, weight: .bold)).foregroundStyle(.white)
+                        }
+                    } right: {
+                        Text("Testnet").foregroundStyle(OnymTokens.text2).font(.system(size: 14))
+                    }
+                    OnymRow(title: "Module", hasChevron: false, last: true) {
+                        OnymTile(bg: OnymTokens.Tile.purple) {
+                            Text(String(gov.id.prefix(2)).uppercased())
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(.white)
+                        }
+                    } right: {
+                        Text(gov.label).foregroundStyle(OnymTokens.text2).font(.system(size: 14))
+                    }
+                }
+
+                if stage == .idle {
+                    OnymPrimaryButton(action: startDeploy) {
+                        HStack(spacing: 8) {
+                            Image(systemName: "arrow.up.circle.fill")
+                            Text("Build & Deploy")
+                        }
+                    }
+                    .padding(.horizontal, 16).padding(.top, 20)
+                } else {
+                    deployConsole.padding(.horizontal, 16).padding(.top, 20)
+                }
+
+                if stage == .done, let addr = deployedAddr {
+                    deployedCard(addr)
+                    OnymPrimaryButton(action: { dismiss() }) { Text("Use this contract") }
+                        .padding(.horizontal, 16).padding(.top, 20)
+                }
+
+                OnymSectionLabel(text: "OR USE THE CLI")
+                ZStack(alignment: .topTrailing) {
+                    Text(cliCmd)
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .foregroundStyle(Color(red: 0.65, green: 1.0, blue: 0.6))
+                        .lineSpacing(3)
+                        .padding(.horizontal, 12).padding(.vertical, 12)
+                        .padding(.trailing, 36)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(red: 0.051, green: 0.067, blue: 0.090),
+                                    in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    Button {
+                        UIPasteboard.general.string = cliCmd
+                        copiedCmd = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { copiedCmd = false }
+                    } label: {
+                        Image(systemName: copiedCmd ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(width: 26, height: 26)
+                            .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+                    }.buttonStyle(.plain).padding(8)
+                }
+                .padding(.horizontal, 16)
+
+                OnymFootnote(text: "Network passphrase: \(networkPassphrase). After deploying via CLI, come back and choose Use existing address.")
+            }
+        }
+    }
+
+    private var hero: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    .font(.system(size: 14)).foregroundStyle(.white)
+                Text("onymchat/contracts")
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.65))
+            }
+            Text("Build, deploy, anchor")
+                .font(.system(size: 22, weight: .bold))
+                .tracking(-0.26).foregroundStyle(.white)
+            Text("Compile the \(gov.label.lowercased()) contract from source and deploy it to Stellar Testnet from this device. Onym signs with a one-time deploy key.")
+                .font(.system(size: 13))
+                .foregroundStyle(.white.opacity(0.7))
+                .lineSpacing(3)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(LinearGradient(colors: [Color(red: 0.106, green: 0.122, blue: 0.141),
+                                              Color(red: 0.051, green: 0.067, blue: 0.090)],
+                                    startPoint: .topLeading, endPoint: .bottomTrailing),
+                     in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+
+    private var deployConsole: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Circle().fill(stage == .done ? OnymTokens.green : OnymTokens.amber)
+                    .frame(width: 8, height: 8)
+                Text(stage == .building ? "Building wasm…" :
+                     stage == .deploying ? "Deploying to Stellar…" : "Complete")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.6))
+                Spacer()
+                Text("\(progress)%")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.4))
+            }
+            Capsule()
+                .fill(.white.opacity(0.08))
+                .frame(height: 3)
+                .overlay(GeometryReader { geo in
+                    Capsule().fill(stage == .done ? OnymTokens.green : OnymTokens.blue)
+                        .frame(width: geo.size.width * CGFloat(progress) / 100)
+                }, alignment: .leading)
+                .padding(.bottom, 4)
+            ForEach(Array(logs.enumerated()), id: \.offset) { _, l in
+                Text(l)
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundStyle(l.hasPrefix("✓")
+                                     ? Color(red: 0.65, green: 1.0, blue: 0.6)
+                                     : (l.hasPrefix("↗") ? Color(red: 0.49, green: 0.76, blue: 1.0) : .white))
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(red: 0.051, green: 0.067, blue: 0.090),
+                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func deployedCard(_ addr: String) -> some View {
+        Group {
+            OnymSectionLabel(text: "DEPLOYED CONTRACT")
+            OnymCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 8) {
+                        Circle().fill(OnymTokens.green).frame(width: 22, height: 22)
+                            .overlay(Image(systemName: "checkmark").font(.system(size: 11, weight: .bold)).foregroundStyle(.white))
+                        Text("Contract deployed")
+                            .font(.system(size: 14.5, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text)
+                    }
+                    Text(addr)
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text)
+                        .padding(.horizontal, 12).padding(.vertical, 10)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(OnymTokens.card2, in: RoundedRectangle(cornerRadius: 10))
+                }
+                .padding(.horizontal, 16).padding(.vertical, 14)
+                Rectangle().fill(OnymTokens.hairline).frame(height: 0.5).padding(.leading, 16)
+                HStack(spacing: 0) {
+                    Button { UIPasteboard.general.string = addr } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(OnymTokens.blue)
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                    Rectangle().fill(OnymTokens.hairline).frame(width: 0.5)
+                    Button { open("https://testnet.stellar.expert/explorer/testnet/contract/\(addr)") } label: {
+                        HStack(spacing: 6) {
+                            Text("View on Stellar Expert")
+                            Image(systemName: "arrow.up.right.square").font(.system(size: 11))
+                        }
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(OnymTokens.blue)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                }
+            }
+        }
+    }
+
+    private func startDeploy() {
+        stage = .building; progress = 0; logs = []; deployedAddr = nil
+        let plan: [(t: Double, log: String, p: Int, stage: Stage?, addr: String?)] = [
+            (0.6, "✓ Cloned onymchat/contracts @ \(ref)", 12, nil, nil),
+            (1.4, "✓ cargo build --release --target wasm32", 38, nil, nil),
+            (2.2, "✓ Built onym_\(gov.id).wasm (47 KB)", 56, .deploying, nil),
+            (3.0, "↗ stellar.testnet  · uploading wasm", 72, nil, nil),
+            (3.7, "↗ stellar.testnet  · invoking deploy", 88, nil, nil),
+            (4.4, "✓ Deployed", 100, .done, randomCAddr()),
+        ]
+        for ev in plan {
+            DispatchQueue.main.asyncAfter(deadline: .now() + ev.t) {
+                logs.append(ev.log)
+                progress = ev.p
+                if let s = ev.stage { stage = s }
+                if let a = ev.addr { deployedAddr = a }
+            }
+        }
+    }
+
+    private func randomCAddr() -> String {
+        let alphabet = Array("ABCDEFGHJKLMNPQRSTUVWXYZ234567")
+        return "C" + String((0..<55).map { _ in alphabet.randomElement()! })
+    }
+
+    private func open(_ s: String) {
+        if let u = URL(string: s) { UIApplication.shared.open(u) }
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymBackupFlowView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymBackupFlowView.swift
@@ -1,0 +1,283 @@
+import SwiftUI
+
+struct OnymBackupFlowView: View {
+    @Bindable var model: OnymSettingsModel
+    let identityId: String
+    @Environment(\.dismiss) private var dismiss
+    @State private var step: Step = .intro
+
+    enum Step { case intro, reveal, verify, done }
+
+    private var identity: OnymIdentity {
+        model.identities.first(where: { $0.id == identityId }) ?? model.identities[0]
+    }
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(
+                    title: step == .done ? "Backup verified" : "Recovery phrase",
+                    subtitle: step == .done ? nil : "For \(identity.name)",
+                    onBack: step == .done ? nil : { dismiss() }
+                )
+                switch step {
+                case .intro:  intro
+                case .reveal: reveal
+                case .verify: verify
+                case .done:   done
+                }
+            }
+        }
+    }
+
+    // MARK: Intro
+
+    private var intro: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(spacing: 16) {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(LinearGradient(colors: [Color(red: 0.78, green: 0.7, blue: 1.0), OnymTokens.purple],
+                                          startPoint: .topLeading, endPoint: .bottomTrailing))
+                    .frame(width: 72, height: 72)
+                    .overlay(OnymMark(size: 42, color: .white))
+                Text("Your identity, in 12 words")
+                    .font(.system(size: 22, weight: .bold))
+                    .tracking(-0.26)
+                    .foregroundStyle(OnymTokens.text)
+                Text("Write them down. Keep them offline. This phrase restores \(identity.name)'s Nostr, Stellar, and BLS keys on any device.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text2)
+                    .lineSpacing(3)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 320)
+            }
+            .padding(.horizontal, 20).padding(.vertical, 28)
+            .frame(maxWidth: .infinity)
+            .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .padding(.horizontal, 16)
+
+            OnymSectionLabel(text: "BEFORE YOU START")
+            OnymCard {
+                OnymRow(title: "Never share or photograph", hasChevron: false) {
+                    OnymTile(bg: OnymTokens.Tile.orange) {
+                        Text("!").font(.system(size: 14, weight: .bold)).foregroundStyle(.white)
+                    }
+                }
+                OnymRow(title: "Store offline (paper or metal)", hasChevron: false) {
+                    OnymSymbolTile(symbol: "shield.fill", bg: OnymTokens.Tile.green)
+                }
+                OnymRow(title: "Anyone with it can read your chats", hasChevron: false, last: true) {
+                    OnymSymbolTile(symbol: "lock.fill", bg: OnymTokens.Tile.gray)
+                }
+            }
+
+            OnymPrimaryButton(action: { withAnimation { step = .reveal } }) {
+                HStack(spacing: 8) {
+                    Image(systemName: "faceid")
+                    Text("Continue with Face ID")
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 24)
+        }
+    }
+
+    // MARK: Reveal
+
+    private var reveal: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            OnymStepIndicator(step: 0)
+            Text("Write down these 12 words in order. You'll confirm three of them on the next screen.")
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text2)
+                .lineSpacing(3)
+                .padding(.horizontal, 20).padding(.bottom, 16)
+
+            wordsCard
+
+            HStack(spacing: 8) {
+                Button { UIPasteboard.general.string = OnymCatalog.recoveryWords.joined(separator: " ") } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "doc.on.doc")
+                        Text("Copy").font(.system(size: 15, weight: .semibold))
+                    }
+                    .foregroundStyle(revealed ? OnymTokens.blue : OnymTokens.text3)
+                    .frame(maxWidth: .infinity, minHeight: 48)
+                    .background(revealed ? Color(red: 0.863, green: 0.918, blue: 0.988) : Color(red: 0.914, green: 0.914, blue: 0.922),
+                                in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                }
+                .disabled(!revealed)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 14)
+
+            OnymPrimaryButton(disabled: !revealed,
+                              action: { withAnimation { step = .verify } }) {
+                Text("I've written it down")
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+
+            OnymFootnote(text: "The phrase is generated on-device and never sent off the device.")
+        }
+    }
+
+    @State private var revealed = false
+
+    private var wordsCard: some View {
+        ZStack {
+            VStack(spacing: 8) {
+                ForEach(0..<6, id: \.self) { row in
+                    HStack(spacing: 8) {
+                        wordCell(row * 2)
+                        wordCell(row * 2 + 1)
+                    }
+                }
+            }
+            .padding(14)
+            .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .blur(radius: revealed ? 0 : 8)
+            .padding(.horizontal, 16)
+
+            if !revealed {
+                Button { withAnimation { revealed = true } } label: {
+                    VStack(spacing: 8) {
+                        ZStack {
+                            Circle().fill(.white.opacity(0.85))
+                                .frame(width: 44, height: 44)
+                                .shadow(color: .black.opacity(0.08), radius: 4, y: 2)
+                            Image(systemName: "eye.slash.fill")
+                                .font(.system(size: 18))
+                                .foregroundStyle(OnymTokens.text)
+                        }
+                        Text("Tap to reveal")
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func wordCell(_ idx: Int) -> some View {
+        HStack(spacing: 8) {
+            Text("\(idx + 1)")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(OnymTokens.text3)
+                .frame(width: 16, alignment: .leading)
+            Text(OnymCatalog.recoveryWords[idx])
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(OnymTokens.text)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 10)
+        .background(OnymTokens.card2, in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: Verify
+
+    @State private var picked: String?
+    @State private var error = false
+
+    private var verify: some View {
+        let wordIndex = 3
+        let correct = OnymCatalog.recoveryWords[wordIndex]
+        let options: [String] = {
+            let others = OnymCatalog.recoveryWords.filter { $0 != correct }.shuffled().prefix(2)
+            return Array(others) + [correct]
+        }().shuffled()
+
+        return VStack(alignment: .leading, spacing: 0) {
+            OnymStepIndicator(step: 1)
+
+            VStack(spacing: 4) {
+                Text("Select word number")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+                Text("\(wordIndex + 1)")
+                    .font(.system(size: 56, weight: .bold))
+                    .tracking(-1.12)
+                    .foregroundStyle(OnymTokens.blue)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
+            .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .padding(.horizontal, 16)
+
+            VStack(spacing: 8) {
+                ForEach(options, id: \.self) { w in
+                    Button {
+                        choose(w, correct: correct)
+                    } label: {
+                        Text(w)
+                            .font(.system(size: 17, weight: .medium))
+                            .foregroundStyle(picked == w && error ? OnymTokens.red : OnymTokens.text)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 16).padding(.vertical, 14)
+                            .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                            .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .stroke(picked == w && error ? OnymTokens.red : .clear, lineWidth: 1.5))
+                    }
+                    .disabled(picked != nil)
+                }
+            }
+            .padding(.horizontal, 16).padding(.top, 12)
+
+            if error {
+                Text("Not the right word. Check your phrase and try again.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.red)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 12)
+            }
+        }
+    }
+
+    private func choose(_ w: String, correct: String) {
+        picked = w
+        if w == correct {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { withAnimation { step = .done } }
+        } else {
+            error = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) { picked = nil; error = false }
+        }
+    }
+
+    // MARK: Done
+
+    private var done: some View {
+        VStack(spacing: 24) {
+            Circle().fill(OnymTokens.green)
+                .frame(width: 88, height: 88)
+                .overlay(Circle().stroke(OnymTokens.green.opacity(0.18), lineWidth: 12))
+                .overlay(Image(systemName: "checkmark")
+                    .font(.system(size: 36, weight: .bold))
+                    .foregroundStyle(.white))
+                .padding(.top, 40)
+            VStack(spacing: 8) {
+                Text("Backup verified")
+                    .font(.system(size: 26, weight: .bold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("\(identity.name)'s recovery phrase is confirmed. Store it somewhere safe — you'll only need it if you lose this device.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(3)
+                    .frame(maxWidth: 320)
+            }
+
+            OnymPrimaryButton(action: {
+                model.markBackedUp(identityId)
+                dismiss()
+            }) { Text("Done") }
+            .padding(.horizontal, 16).padding(.top, 12)
+
+            Spacer(minLength: 24)
+            Text("Backed up \(OnymSettingsModel.todayString()) · BIP-39 English")
+                .font(.system(size: 12))
+                .foregroundStyle(OnymTokens.text3)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 24)
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymDesign.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymDesign.swift
@@ -1,0 +1,474 @@
+import SwiftUI
+
+// MARK: - Design tokens
+
+enum OnymTokens {
+    static let bg       = Color(red: 0.949, green: 0.949, blue: 0.957)   // #F2F2F4
+    static let card     = Color.white
+    static let card2    = Color(red: 0.969, green: 0.969, blue: 0.976)   // #F7F7F9
+    static let hairline = Color(red: 60/255, green: 60/255, blue: 67/255).opacity(0.12)
+    static let text     = Color(red: 10/255, green: 10/255, blue: 12/255)
+    static let text2    = Color(red: 60/255, green: 60/255, blue: 67/255).opacity(0.62)
+    static let text3    = Color(red: 60/255, green: 60/255, blue: 67/255).opacity(0.42)
+    static let text4    = Color(red: 60/255, green: 60/255, blue: 67/255).opacity(0.28)
+    static let blue     = Color(red: 10/255, green: 132/255, blue: 255/255) // #0A84FF
+    static let green    = Color(red: 48/255, green: 180/255, blue: 90/255)  // #30B45A
+    static let amber    = Color(red: 255/255, green: 149/255, blue: 0/255)  // #FF9500
+    static let red     = Color(red: 229/255, green: 57/255, blue: 46/255)   // #E5392E
+    static let purple   = Color(red: 160/255, green: 76/255, blue: 224/255) // #A04CE0
+
+    enum Tile {
+        static let purple  = Color(red: 160/255, green: 76/255, blue: 224/255)
+        static let blue    = Color(red: 10/255,  green: 132/255, blue: 255/255)
+        static let indigo  = Color(red: 91/255,  green: 91/255,  blue: 226/255)
+        static let orange  = Color(red: 255/255, green: 122/255, blue: 45/255)
+        static let green   = Color(red: 48/255,  green: 180/255, blue: 90/255)
+        static let gray    = Color(red: 142/255, green: 142/255, blue: 147/255)
+        static let red     = Color(red: 229/255, green: 57/255,  blue: 46/255)
+        static let teal    = Color(red: 43/255,  green: 179/255, blue: 207/255)
+    }
+}
+
+// MARK: - Onym mark (broken-ring brand glyph)
+
+struct OnymMark: View {
+    var size: CGFloat = 28
+    var color: Color = OnymTokens.text
+    var strokeRatio: CGFloat = 0.18
+    var spin: Bool = false
+
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        let sw = 100 * strokeRatio
+        Canvas { ctx, _ in
+            let rect = CGRect(x: sw / 2, y: sw / 2, width: 100 - sw, height: 100 - sw)
+            var path = Path(ellipseIn: rect)
+            // Approximate dash pattern from the design (4 long arcs separated by 4 small gaps)
+            let circumference = .pi * (100 - sw)
+            let lung = circumference * 0.46
+            let kurz = circumference * 0.04
+            path = path.strokedPath(StrokeStyle(
+                lineWidth: sw,
+                lineCap: .butt,
+                dash: [lung, kurz, lung, kurz],
+                dashPhase: -circumference * 0.8333
+            ))
+            ctx.fill(path, with: .color(color))
+        }
+        .frame(width: size, height: size)
+        .rotationEffect(.degrees(rotation))
+        .onAppear {
+            guard spin else { return }
+            withAnimation(.linear(duration: 4.2).repeatForever(autoreverses: false)) {
+                rotation = 360
+            }
+        }
+    }
+}
+
+// MARK: - Apple-Settings-style square icon tile
+
+struct OnymTile<Content: View>: View {
+    let bg: Color
+    var size: CGFloat = 30
+    var radius: CGFloat = 8
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: radius, style: .continuous)
+            .fill(bg)
+            .frame(width: size, height: size)
+            .overlay(content().foregroundStyle(.white))
+            .overlay(
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
+            )
+    }
+}
+
+// MARK: - SF-Symbol shortcut filled into a tile
+
+struct OnymSymbolTile: View {
+    let symbol: String
+    let bg: Color
+    var size: CGFloat = 30
+    var weight: Font.Weight = .semibold
+
+    var body: some View {
+        OnymTile(bg: bg, size: size) {
+            Image(systemName: symbol)
+                .font(.system(size: size * 0.5, weight: weight))
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+// MARK: - Card surface
+
+struct OnymCard<Content: View>: View {
+    @ViewBuilder var content: () -> Content
+    var body: some View {
+        VStack(spacing: 0) { content() }
+            .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Section label & footnote
+
+struct OnymSectionLabel: View {
+    let text: String
+    var trailing: AnyView? = nil
+    var body: some View {
+        HStack(alignment: .bottom) {
+            Text(text)
+                .font(.system(size: 12.5, weight: .medium))
+                .foregroundStyle(OnymTokens.text2)
+                .tracking(-0.07)
+            Spacer()
+            if let trailing { trailing }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+        .padding(.bottom, 8)
+    }
+}
+
+struct OnymFootnote: View {
+    let text: String
+    var body: some View {
+        Text(text)
+            .font(.system(size: 12.5))
+            .foregroundStyle(OnymTokens.text2)
+            .lineSpacing(2)
+            .padding(.horizontal, 20)
+            .padding(.top, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct OnymLargeTitle: View {
+    let text: String
+    var body: some View {
+        Text(text)
+            .font(.system(size: 34, weight: .bold))
+            .foregroundStyle(OnymTokens.text)
+            .tracking(-0.75)
+            .padding(.horizontal, 20)
+            .padding(.top, 4)
+            .padding(.bottom, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Row with optional left tile, title, subtitle, accessory and chevron
+
+struct OnymRow<Tile: View, Right: View, Accessory: View>: View {
+    @ViewBuilder var tile: () -> Tile
+    let title: String
+    var titleMono: Bool = false
+    var subtitle: String? = nil
+    var subtitleMono: Bool = false
+    var danger: Bool = false
+    var hasChevron: Bool = true
+    var inset: CGFloat = 60
+    var last: Bool = false
+    var onTap: (() -> Void)? = nil
+    @ViewBuilder var right: () -> Right
+    @ViewBuilder var accessory: () -> Accessory
+
+    var body: some View {
+        Button(action: { onTap?() }) {
+            VStack(spacing: 0) {
+                HStack(spacing: 12) {
+                    tile()
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(title)
+                            .font(.system(size: 16.5, design: titleMono ? .monospaced : .default))
+                            .foregroundStyle(danger ? OnymTokens.red : OnymTokens.text)
+                            .tracking(-0.16)
+                            .lineLimit(1)
+                        if let subtitle {
+                            Text(subtitle)
+                                .font(.system(size: 12.5, design: subtitleMono ? .monospaced : .default))
+                                .foregroundStyle(OnymTokens.text2)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                    Spacer(minLength: 8)
+                    right()
+                    accessory()
+                    if hasChevron, onTap != nil {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 11)
+
+                if !last {
+                    Rectangle()
+                        .fill(OnymTokens.hairline)
+                        .frame(height: 0.5)
+                        .padding(.leading, inset)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(onTap == nil)
+    }
+}
+
+extension OnymRow where Right == EmptyView, Accessory == EmptyView {
+    init(
+        title: String,
+        titleMono: Bool = false,
+        subtitle: String? = nil,
+        subtitleMono: Bool = false,
+        danger: Bool = false,
+        hasChevron: Bool = true,
+        inset: CGFloat = 60,
+        last: Bool = false,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder tile: @escaping () -> Tile
+    ) {
+        self.tile = tile
+        self.title = title
+        self.titleMono = titleMono
+        self.subtitle = subtitle
+        self.subtitleMono = subtitleMono
+        self.danger = danger
+        self.hasChevron = hasChevron
+        self.inset = inset
+        self.last = last
+        self.onTap = onTap
+        self.right = { EmptyView() }
+        self.accessory = { EmptyView() }
+    }
+}
+
+extension OnymRow where Accessory == EmptyView {
+    init(
+        title: String,
+        titleMono: Bool = false,
+        subtitle: String? = nil,
+        subtitleMono: Bool = false,
+        danger: Bool = false,
+        hasChevron: Bool = true,
+        inset: CGFloat = 60,
+        last: Bool = false,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder tile: @escaping () -> Tile,
+        @ViewBuilder right: @escaping () -> Right
+    ) {
+        self.tile = tile
+        self.title = title
+        self.titleMono = titleMono
+        self.subtitle = subtitle
+        self.subtitleMono = subtitleMono
+        self.danger = danger
+        self.hasChevron = hasChevron
+        self.inset = inset
+        self.last = last
+        self.onTap = onTap
+        self.right = right
+        self.accessory = { EmptyView() }
+    }
+}
+
+extension OnymRow where Right == EmptyView {
+    init(
+        title: String,
+        titleMono: Bool = false,
+        subtitle: String? = nil,
+        subtitleMono: Bool = false,
+        danger: Bool = false,
+        hasChevron: Bool = true,
+        inset: CGFloat = 60,
+        last: Bool = false,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder tile: @escaping () -> Tile,
+        @ViewBuilder accessory: @escaping () -> Accessory
+    ) {
+        self.tile = tile
+        self.title = title
+        self.titleMono = titleMono
+        self.subtitle = subtitle
+        self.subtitleMono = subtitleMono
+        self.danger = danger
+        self.hasChevron = hasChevron
+        self.inset = inset
+        self.last = last
+        self.onTap = onTap
+        self.right = { EmptyView() }
+        self.accessory = accessory
+    }
+}
+
+// MARK: - Chip badge
+
+struct OnymChip: View {
+    let text: String
+    let fg: Color
+    let bg: Color
+    var body: some View {
+        Text(text)
+            .font(.system(size: 9.5, weight: .bold))
+            .tracking(0.5)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(bg, in: RoundedRectangle(cornerRadius: 4))
+            .foregroundStyle(fg)
+    }
+}
+
+// MARK: - Switch matching iOS Settings
+
+struct OnymSwitch: View {
+    @Binding var on: Bool
+    var body: some View {
+        Toggle("", isOn: $on)
+            .labelsHidden()
+            .tint(OnymTokens.green)
+    }
+}
+
+// MARK: - Primary CTA
+
+struct OnymPrimaryButton<Label: View>: View {
+    var disabled: Bool = false
+    let action: () -> Void
+    @ViewBuilder var label: () -> Label
+
+    var body: some View {
+        Button(action: action) {
+            label()
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, minHeight: 50)
+                .background(disabled
+                    ? OnymTokens.blue.opacity(0.45)
+                    : OnymTokens.blue,
+                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .disabled(disabled)
+    }
+}
+
+// MARK: - Custom NavBar (sticky pill back-button + centered title)
+
+struct OnymNavBar: View {
+    let title: String
+    var subtitle: String? = nil
+    var onBack: (() -> Void)? = nil
+    var trailing: AnyView? = nil
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if let onBack {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.backward")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(OnymTokens.blue)
+                        .frame(width: 36, height: 36)
+                        .background(Color.white, in: Circle())
+                        .shadow(color: .black.opacity(0.05), radius: 1, y: 1)
+                }
+            } else {
+                Color.clear.frame(width: 36, height: 36)
+            }
+            Spacer()
+            VStack(spacing: 1) {
+                Text(title)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                    .tracking(-0.16)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(OnymTokens.text2)
+                }
+            }
+            Spacer()
+            if let trailing {
+                trailing.frame(width: 36, height: 36)
+            } else {
+                Color.clear.frame(width: 36, height: 36)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .frame(minHeight: 44)
+    }
+}
+
+// MARK: - Page wrapper (sets the bg + hides system nav bar)
+
+struct OnymPage<Content: View>: View {
+    @ViewBuilder var content: () -> Content
+    var body: some View {
+        ZStack(alignment: .top) {
+            OnymTokens.bg.ignoresSafeArea()
+            ScrollView { content().padding(.bottom, 40) }
+        }
+        .navigationBarBackButtonHidden(true)
+        #if os(iOS)
+        .toolbar(.hidden, for: .navigationBar)
+        #endif
+    }
+}
+
+// MARK: - Identity tile (round, with broken-ring mark)
+
+struct OnymIdentityTile: View {
+    var active: Bool = false
+    var size: CGFloat = 36
+
+    var body: some View {
+        Circle()
+            .fill(active ? Color(red: 0.878, green: 0.933, blue: 0.996) : Color(red: 0.918, green: 0.918, blue: 0.933))
+            .frame(width: size, height: size)
+            .overlay(OnymMark(size: size * 0.55, color: active ? OnymTokens.blue : Color(red: 142/255, green: 142/255, blue: 147/255)))
+            .overlay(Circle().stroke(active ? OnymTokens.blue : .clear, lineWidth: 1.5))
+    }
+}
+
+// MARK: - Step indicator
+
+struct OnymStepIndicator: View {
+    let step: Int
+    var count: Int = 3
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<count, id: \.self) { i in
+                Capsule()
+                    .fill(i <= step ? OnymTokens.blue : OnymTokens.text4)
+                    .frame(width: i == step ? 22 : 6, height: 6)
+            }
+        }
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - QR code wrapper that styles to match the design (rounded, with a centered Onym badge)
+
+struct OnymQRCode: View {
+    let value: String
+    var size: CGFloat = 220
+
+    var body: some View {
+        ZStack {
+            QRCodeView(value, size: size)
+            Color.white
+                .frame(width: size * 0.22, height: size * 0.22)
+                .overlay(OnymMark(size: size * 0.18, color: OnymTokens.text))
+                .clipShape(RoundedRectangle(cornerRadius: size * 0.05, style: .continuous))
+        }
+        .background(.white)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymIdentitiesView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymIdentitiesView.swift
@@ -1,0 +1,370 @@
+import SwiftUI
+
+// MARK: - Identities list
+
+struct OnymIdentitiesView: View {
+    @Bindable var model: OnymSettingsModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var showAdd = false
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Identities", onBack: { dismiss() })
+                OnymLargeTitle(text: "Identities")
+                OnymFootnote(text: "Tap an identity to open it. Each identity has its own keys, chats, and recovery phrase.")
+
+                OnymSectionLabel(text: "YOUR IDENTITIES")
+                OnymCard {
+                    ForEach(Array(model.identities.enumerated()), id: \.element.id) { index, id in
+                        NavigationLink { OnymIdentityDetailView(model: model, identityId: id.id) } label: {
+                            OnymRow(
+                                title: id.name,
+                                subtitle: String(id.npub.prefix(18)) + "…",
+                                subtitleMono: true,
+                                inset: 68,
+                                last: index == model.identities.count - 1,
+                                onTap: {}
+                            ) {
+                                OnymIdentityTile(active: id.active, size: 40)
+                            } right: {
+                                HStack(spacing: 6) {
+                                    if id.active {
+                                        Text("Active")
+                                            .font(.system(size: 11, weight: .semibold))
+                                            .padding(.horizontal, 8).padding(.vertical, 3)
+                                            .background(OnymTokens.green.opacity(0.14),
+                                                        in: RoundedRectangle(cornerRadius: 10))
+                                            .foregroundStyle(OnymTokens.green)
+                                    }
+                                    if !id.backedUp {
+                                        Image(systemName: "exclamationmark.triangle.fill")
+                                            .font(.system(size: 11))
+                                            .foregroundStyle(OnymTokens.amber)
+                                    }
+                                }
+                            }
+                        }.buttonStyle(.plain)
+                    }
+                }
+
+                Button { showAdd = true } label: {
+                    HStack(spacing: 10) {
+                        Circle().fill(OnymTokens.blue).frame(width: 22, height: 22)
+                            .overlay(Image(systemName: "plus")
+                                .font(.system(size: 13, weight: .bold))
+                                .foregroundStyle(.white))
+                        Text("Add Identity")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(OnymTokens.blue)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 13)
+                    .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .padding(.horizontal, 16)
+                    .padding(.top, 12)
+                }
+                .buttonStyle(.plain)
+
+                OnymFootnote(text: "Only the active identity's chats are visible. Switch between identities to see different inboxes.")
+            }
+        }
+        .sheet(isPresented: $showAdd) {
+            OnymAddIdentityView(model: model)
+        }
+    }
+}
+
+// MARK: - Identity detail
+
+struct OnymIdentityDetailView: View {
+    @Bindable var model: OnymSettingsModel
+    let identityId: String
+    @Environment(\.dismiss) private var dismiss
+    @State private var editing = false
+    @State private var editName = ""
+
+    private var identity: OnymIdentity? {
+        model.identities.first(where: { $0.id == identityId })
+    }
+
+    var body: some View {
+        guard let id = identity else {
+            return AnyView(OnymPage { EmptyView() })
+        }
+        return AnyView(content(id: id))
+    }
+
+    private func content(id: OnymIdentity) -> some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: id.name, onBack: { dismiss() })
+                hero(id)
+                inviteCard(id)
+                OnymFootnote(text: "Anyone with this code can start a chat with you. The chat itself is end-to-end encrypted.")
+
+                OnymSectionLabel(text: "BACKUP")
+                OnymCard {
+                    HStack(spacing: 12) {
+                        OnymTile(bg: id.backedUp ? OnymTokens.green : OnymTokens.amber, size: 36) {
+                            Image(systemName: id.backedUp ? "checkmark" : "exclamationmark")
+                                .font(.system(size: 16, weight: .bold))
+                                .foregroundStyle(.white)
+                        }
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(id.backedUp ? "Recovery phrase saved" : "Not backed up yet")
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundStyle(OnymTokens.text)
+                            Text(id.backedUp
+                                 ? "You verified your 12 words. Keep them safe."
+                                 : "Without your phrase you can't restore this identity.")
+                                .font(.system(size: 12.5))
+                                .foregroundStyle(OnymTokens.text2)
+                        }
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+                    Rectangle().fill(OnymTokens.hairline).frame(height: 0.5).padding(.leading, 16)
+
+                    NavigationLink { OnymBackupFlowView(model: model, identityId: id.id) } label: {
+                        OnymRow(
+                            title: id.backedUp ? "View recovery phrase" : "Back up now",
+                            subtitle: "12 words · BIP-39",
+                            last: true,
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "key.fill", bg: OnymTokens.Tile.orange)
+                        }
+                    }.buttonStyle(.plain)
+                }
+
+                OnymSectionLabel(text: "STATE")
+                OnymCard {
+                    OnymRow(
+                        title: "Set as active",
+                        hasChevron: !id.active,
+                        onTap: id.active ? nil : { model.setActive(id.id) }
+                    ) {
+                        OnymSymbolTile(symbol: "checkmark.circle.fill", bg: OnymTokens.Tile.green)
+                    } right: {
+                        if id.active { Text("Active").font(.system(size: 14.5)).foregroundStyle(OnymTokens.text2) }
+                    }
+                    NavigationLink { OnymShareKeyView(identity: id) } label: {
+                        OnymRow(
+                            title: "Share invite key",
+                            subtitle: "QR code or link",
+                            last: true,
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "square.and.arrow.up", bg: OnymTokens.Tile.indigo)
+                        }
+                    }.buttonStyle(.plain)
+                }
+
+                OnymSectionLabel(text: "ADVANCED")
+                OnymCard {
+                    OnymRow(
+                        title: "Copy public key",
+                        hasChevron: false,
+                        onTap: { UIPasteboard.general.string = id.npub }
+                    ) {
+                        OnymSymbolTile(symbol: "doc.on.doc.fill", bg: OnymTokens.Tile.gray)
+                    }
+                    OnymRow(
+                        title: "Delete identity",
+                        danger: true,
+                        hasChevron: false,
+                        last: true,
+                        onTap: {}
+                    ) {
+                        OnymSymbolTile(symbol: "trash.fill", bg: OnymTokens.Tile.red)
+                    }
+                }
+
+                OnymFootnote(text: "Deleting an identity removes its keys from this device. If you've backed up the recovery phrase, you can restore it later.")
+            }
+        }
+    }
+
+    private func hero(_ id: OnymIdentity) -> some View {
+        VStack(spacing: 4) {
+            ZStack(alignment: .bottomTrailing) {
+                Circle()
+                    .fill(id.active
+                          ? AnyShapeStyle(LinearGradient(colors: [Color(red: 0.933, green: 0.961, blue: 1.0),
+                                                                   Color(red: 0.835, green: 0.910, blue: 0.996)],
+                                                         startPoint: .topLeading, endPoint: .bottomTrailing))
+                          : AnyShapeStyle(Color(red: 0.937, green: 0.937, blue: 0.949)))
+                    .frame(width: 96, height: 96)
+                    .overlay(Circle().stroke(id.active ? OnymTokens.blue : .clear, lineWidth: 2))
+                    .overlay(OnymMark(size: 64, color: id.active ? OnymTokens.blue : Color(red: 142/255, green: 142/255, blue: 147/255)))
+                if id.backedUp {
+                    Circle().fill(OnymTokens.green)
+                        .frame(width: 28, height: 28)
+                        .overlay(Circle().stroke(.white, lineWidth: 3))
+                        .overlay(Image(systemName: "checkmark")
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(.white))
+                }
+            }
+            .padding(.top, 8)
+
+            if editing {
+                TextField("", text: $editName, onCommit: commit)
+                    .font(.system(size: 24, weight: .bold))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 10).padding(.vertical, 4)
+                    .background(RoundedRectangle(cornerRadius: 8).stroke(OnymTokens.blue, lineWidth: 1.5))
+                    .frame(maxWidth: 240)
+                    .padding(.top, 14)
+            } else {
+                Button {
+                    editName = id.name
+                    editing = true
+                } label: {
+                    HStack(spacing: 6) {
+                        Text(id.name)
+                            .font(.system(size: 24, weight: .bold))
+                            .foregroundStyle(OnymTokens.text)
+                        Image(systemName: "pencil")
+                            .font(.system(size: 13))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 14)
+            }
+
+            Text(id.npub.prefix(22) + "…")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(OnymTokens.text2)
+            Text("Created \(id.created)")
+                .font(.system(size: 12))
+                .foregroundStyle(OnymTokens.text3)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 24)
+    }
+
+    private func inviteCard(_ id: OnymIdentity) -> some View {
+        Group {
+            OnymSectionLabel(text: "INVITE KEY")
+            OnymCard {
+                VStack(spacing: 14) {
+                    OnymQRCode(value: onymInviteURL(for: id), size: 200)
+                        .padding(12)
+                        .background(.white, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .stroke(.black.opacity(0.04), lineWidth: 1))
+                    Text("Scan with Onym on another device to open a private chat with this identity.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.text2)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(2)
+                        .frame(maxWidth: 280)
+                    Text(onymInviteURL(for: id))
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text2)
+                        .lineLimit(1).truncationMode(.middle)
+                        .padding(.horizontal, 10).padding(.vertical, 6)
+                        .background(OnymTokens.card2, in: RoundedRectangle(cornerRadius: 8))
+                }
+                .padding(.horizontal, 16).padding(.top, 20).padding(.bottom, 16)
+
+                Rectangle().fill(OnymTokens.hairline).frame(height: 0.5).padding(.leading, 16)
+
+                HStack(spacing: 0) {
+                    Button { UIPasteboard.general.string = onymInviteURL(for: id) } label: {
+                        Label("Copy link", systemImage: "doc.on.doc")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(OnymTokens.blue)
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                    Rectangle().fill(OnymTokens.hairline).frame(width: 0.5)
+                    Button {} label: {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(OnymTokens.blue)
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                }
+            }
+        }
+    }
+
+    private func commit() {
+        let trimmed = editName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            model.identities = model.identities.map { var c = $0; if $0.id == identityId { c.name = String(trimmed.prefix(30)) }; return c }
+        }
+        editing = false
+    }
+}
+
+// MARK: - Add identity sheet
+
+struct OnymAddIdentityView: View {
+    @Bindable var model: OnymSettingsModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var phrase = ""
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(OnymTokens.blue)
+                    Spacer()
+                    Text("Add Identity").font(.system(size: 16, weight: .semibold))
+                    Spacer()
+                    Button("Add") {
+                        model.appendIdentity(name: name)
+                        dismiss()
+                    }
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(OnymTokens.blue)
+                }
+                .padding(.horizontal, 16).padding(.vertical, 14)
+
+                Circle().fill(Color(red: 0.937, green: 0.937, blue: 0.949))
+                    .frame(width: 80, height: 80)
+                    .overlay(OnymMark(size: 46, color: Color(red: 142/255, green: 142/255, blue: 147/255)))
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 16).padding(.bottom, 24)
+
+                OnymSectionLabel(text: "NAME")
+                OnymCard {
+                    TextField("Identity name", text: $name)
+                        .font(.system(size: 16.5))
+                        .padding(.horizontal, 16).padding(.vertical, 12)
+                        .onChange(of: name) { _, v in
+                            if v.count > 30 { name = String(v.prefix(30)) }
+                        }
+                }
+                OnymFootnote(text: "Defaults to \"Identity N\" if left blank.")
+
+                OnymSectionLabel(text: "RESTORE FROM RECOVERY PHRASE")
+                OnymCard {
+                    TextEditor(text: $phrase)
+                        .font(.system(size: 15))
+                        .frame(minHeight: 96)
+                        .padding(.horizontal, 12).padding(.vertical, 8)
+                        .scrollContentBackground(.hidden)
+                        .background(Color.clear)
+                        .overlay(alignment: .topLeading) {
+                            if phrase.isEmpty {
+                                Text("Paste 12 or 24 words…")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(OnymTokens.text3)
+                                    .padding(.horizontal, 16).padding(.vertical, 14)
+                            }
+                        }
+                }
+                OnymFootnote(text: "Leave blank to mint a fresh BIP-39 identity. Paste a 12 or 24-word phrase to restore.")
+            }
+        }
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymModels.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymModels.swift
@@ -1,0 +1,136 @@
+import Foundation
+import SwiftUI
+
+// Local data model used to power the Onym Settings UI tree. The active
+// identity is wired to the live KeyManager; additional identities are
+// scaffolded in-memory so the multi-identity flows can be exercised.
+
+struct OnymIdentity: Identifiable, Equatable {
+    let id: String
+    var name: String
+    var npub: String
+    var backedUp: Bool
+    var active: Bool
+    var created: String
+}
+
+struct OnymRelay: Identifiable, Equatable {
+    let id: String
+    var name: String
+    var url: String
+    var starred: Bool
+    var network: String      // "TESTNET" / "MAINNET"
+    var visibility: String   // "PUBLIC" / "PRIVATE"
+    var latency: Int
+}
+
+struct OnymGovType: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let sub: String
+}
+
+struct OnymContractVersion: Identifiable, Equatable {
+    var id: String { v }
+    let v: String
+    let date: String
+    let current: Bool
+    let audit: String
+    let sha: String
+}
+
+enum OnymCatalog {
+    static let governance: [OnymGovType] = [
+        .init(id: "anarchy",   label: "Anarchy",     sub: "Open control"),
+        .init(id: "democracy", label: "Democracy",   sub: "Majority vote"),
+        .init(id: "oligarchy", label: "Oligarchy",   sub: "Council"),
+        .init(id: "dialog",    label: "One-on-one",  sub: "Dialog"),
+        .init(id: "tyranny",   label: "Tyranny",     sub: "Single admin"),
+    ]
+
+    static let versions: [OnymContractVersion] = [
+        .init(v: "v0.0.5", date: "May 3, 2026", current: true,  audit: "Audit pending", sha: "0xa12c…f80d"),
+        .init(v: "v0.0.4", date: "May 3, 2026", current: false, audit: "Audit pending", sha: "0x9c84…e210"),
+        .init(v: "v0.0.3", date: "May 2, 2026", current: false, audit: "Audit pending", sha: "0x7f28…b341"),
+        .init(v: "v0.0.2", date: "May 1, 2026", current: false, audit: "Audit pending", sha: "0x4a90…c88a"),
+        .init(v: "v0.0.1", date: "May 1, 2026", current: false, audit: "Audit pending", sha: "0x18ad…0072"),
+    ]
+
+    static let recoveryWords = ["mistake","amateur","limit","foam","beef","first",
+                                 "stuff","unfair","weird","spice","brick","coast"]
+
+    /// Repos referenced from the in-app explainer screens. Linked from the
+    /// "Run your own relay" and "Deploy from source" flows so users can fork
+    /// the open-source projects.
+    static let onymchatGitHubOrg = "github.com/onymchat"
+    static let relayRepoURL    = URL(string: "https://github.com/onymchat/onym-relay")!
+    static let contractRepoURL = URL(string: "https://github.com/onymchat/contracts")!
+}
+
+func onymInviteURL(for identity: OnymIdentity) -> String {
+    let payload = String(identity.npub.prefix(44))
+    return "https://onym.chat?payload=\(payload)"
+}
+
+@MainActor
+@Observable
+final class OnymSettingsModel {
+    var identities: [OnymIdentity]
+    var relays: [OnymRelay]
+    var useMainnet: Bool = false
+
+    init(activeIdentity: OnymIdentity) {
+        self.identities = [
+            activeIdentity,
+            OnymIdentity(
+                id: "id-secondary",
+                name: "Identity 2",
+                npub: "npub1a35c74815b150f8d9e2c3a4b5c6d7e8f9012345abcde6789f0123456789abcdef",
+                backedUp: false,
+                active: false,
+                created: "Apr 18 2026"
+            )
+        ]
+
+        self.relays = [
+            .init(id: "r1", name: "Onym Official", url: "https://relay.onym.chat",
+                  starred: true,  network: "TESTNET", visibility: "PUBLIC",  latency: 42),
+            .init(id: "r2", name: "EU Mirror",     url: "https://eu.relay.onym.chat",
+                  starred: false, network: "TESTNET", visibility: "PUBLIC",  latency: 71),
+            .init(id: "r3", name: "Private",       url: "https://my-relay.fly.dev",
+                  starred: false, network: "TESTNET", visibility: "PRIVATE", latency: 28),
+        ]
+    }
+
+    var activeIdentity: OnymIdentity? { identities.first(where: { $0.active }) }
+
+    func setActive(_ id: String) {
+        identities = identities.map { var c = $0; c.active = $0.id == id; return c }
+    }
+
+    func toggleStarred(_ id: String) {
+        relays = relays.map { var c = $0; c.starred = ($0.id == id) ? !$0.starred : false; return c }
+    }
+
+    func appendIdentity(name: String) {
+        let new = OnymIdentity(
+            id: "id-\(UUID().uuidString.prefix(8))",
+            name: name.isEmpty ? "Identity \(identities.count + 1)" : name,
+            npub: "npub1" + String((0..<60).map { _ in "0123456789abcdef".randomElement()! }),
+            backedUp: false,
+            active: false,
+            created: Self.todayString()
+        )
+        identities.append(new)
+    }
+
+    func markBackedUp(_ id: String) {
+        identities = identities.map { var c = $0; if $0.id == id { c.backedUp = true }; return c }
+    }
+
+    static func todayString() -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d yyyy"
+        return f.string(from: Date())
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymPrivacyAppearanceAboutView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymPrivacyAppearanceAboutView.swift
@@ -1,0 +1,618 @@
+import SwiftUI
+
+// MARK: - Privacy & Encryption
+
+struct OnymPrivacyEncryptionView: View {
+    @Bindable var model: OnymSettingsModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var readReceipts = false
+    @State private var screenLock = true
+    @State private var autoLock: AutoLock = .oneMin
+
+    enum AutoLock: CaseIterable { case immediate, oneMin, fiveMin, fifteenMin, never
+        var label: String {
+            switch self {
+            case .immediate: return "Immediately"
+            case .oneMin:    return "After 1 min"
+            case .fiveMin:   return "After 5 min"
+            case .fifteenMin:return "After 15 min"
+            case .never:     return "Never"
+            }
+        }
+        var next: AutoLock {
+            switch self {
+            case .immediate: return .oneMin
+            case .oneMin:    return .fiveMin
+            case .fiveMin:   return .fifteenMin
+            case .fifteenMin:return .never
+            case .never:     return .immediate
+            }
+        }
+    }
+
+    var body: some View {
+        let active = model.activeIdentity ?? model.identities[0]
+        return OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Privacy & Encryption", onBack: { dismiss() })
+
+                heroCard.padding(.top, 8)
+
+                OnymSectionLabel(text: "HOW IT WORKS")
+                OnymCard {
+                    OnymRow(title: "End-to-end encryption",
+                            subtitle: "MLS · forward secrecy",
+                            hasChevron: false,
+                            onTap: {}) {
+                        OnymSymbolTile(symbol: "key.fill", bg: OnymTokens.Tile.purple)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Anonymous on-chain",
+                            subtitle: "No phone, no email, no IP",
+                            hasChevron: false,
+                            onTap: {}) {
+                        OnymSymbolTile(symbol: "sparkles", bg: OnymTokens.Tile.indigo)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Verifiable by anyone",
+                            subtitle: "Group state anchored on Stellar",
+                            hasChevron: false,
+                            last: true,
+                            onTap: {}) {
+                        OnymSymbolTile(symbol: "shield.fill", bg: OnymTokens.Tile.green)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                }
+
+                OnymSectionLabel(text: "YOUR KEYS")
+                OnymCard {
+                    OnymRow(title: "Active identity",
+                            subtitle: active.name,
+                            onTap: {}) {
+                        OnymIdentityTile(active: true, size: 30)
+                    } right: {
+                        Text("Backed up").foregroundStyle(OnymTokens.green).font(.system(size: 13.5))
+                    }
+                    OnymRow(title: "BIP-39 wordlist", hasChevron: false) {
+                        OnymSymbolTile(symbol: "checkmark", bg: OnymTokens.Tile.gray)
+                    } right: {
+                        Text("English").foregroundStyle(OnymTokens.text2).font(.system(size: 14))
+                    }
+                    OnymRow(title: "Identity key", hasChevron: false) {
+                        OnymTile(bg: OnymTokens.Tile.indigo) {
+                            Text("npub").font(.system(size: 9, weight: .bold)).foregroundStyle(.white)
+                        }
+                    } right: {
+                        Text("Nostr (npub)").foregroundStyle(OnymTokens.text2).font(.system(size: 14))
+                    }
+                    OnymRow(title: "Signature scheme", hasChevron: false, last: true) {
+                        OnymTile(bg: OnymTokens.Tile.gray) {
+                            Text("BLS").font(.system(size: 9.5, weight: .bold)).foregroundStyle(.white)
+                        }
+                    } right: {
+                        Text("BLS12-381").foregroundStyle(OnymTokens.text2).font(.system(size: 14))
+                    }
+                }
+                OnymFootnote(text: "Your recovery phrase generates a master seed. Onym derives a Nostr keypair (your public identity, shown as npub1…), a Stellar keypair (for anchoring), and a BLS key (for group signatures).")
+
+                OnymSectionLabel(text: "APP LOCK")
+                OnymCard {
+                    OnymRow(title: "Require Face ID",
+                            subtitle: "Unlock Onym with biometrics",
+                            hasChevron: false) {
+                        OnymSymbolTile(symbol: "faceid", bg: OnymTokens.Tile.gray)
+                    } accessory: {
+                        OnymSwitch(on: $screenLock)
+                    }
+                    OnymRow(title: "Auto-lock",
+                            inset: 16,
+                            last: true,
+                            onTap: { autoLock = autoLock.next }) {
+                        EmptyView()
+                    } right: {
+                        Text(autoLock.label).foregroundStyle(OnymTokens.text2).font(.system(size: 14))
+                    }
+                }
+
+                OnymSectionLabel(text: "METADATA")
+                OnymCard {
+                    OnymRow(title: "Send read receipts",
+                            subtitle: "Show others when you've read their messages",
+                            hasChevron: false,
+                            last: true) {
+                        OnymSymbolTile(symbol: "checkmark.circle.fill", bg: OnymTokens.Tile.blue)
+                    } accessory: {
+                        OnymSwitch(on: $readReceipts)
+                    }
+                }
+                OnymFootnote(text: "Read receipts are end-to-end encrypted, but they reveal you're online. Turn off for stricter privacy.")
+
+                OnymSectionLabel(text: "DATA")
+                OnymCard {
+                    OnymRow(title: "Clear local message cache",
+                            subtitle: "Re-download from your relay on next open",
+                            hasChevron: false,
+                            last: true,
+                            onTap: {}) {
+                        OnymSymbolTile(symbol: "trash.fill", bg: OnymTokens.Tile.red)
+                    }
+                }
+
+                OnymFootnote(text: "Onym never stores your messages on our servers. Cached messages live only on this device, encrypted by your identity keys.")
+            }
+        }
+    }
+
+    private var heroCard: some View {
+        HStack(spacing: 14) {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(LinearGradient(colors: [Color(red: 0.875, green: 0.98, blue: 0.918),
+                                                Color(red: 0.71, green: 0.94, blue: 0.804)],
+                                      startPoint: .topLeading, endPoint: .bottomTrailing))
+                .frame(width: 56, height: 56)
+                .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(OnymTokens.green.opacity(0.35), lineWidth: 1.5))
+                .overlay(Image(systemName: "lock.shield.fill")
+                    .font(.system(size: 28))
+                    .foregroundStyle(OnymTokens.green))
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Everything is encrypted")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("Messages, group state, and keys are encrypted on this device. No one — not even Onym — can read your chats.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+                    .lineSpacing(2)
+            }
+        }
+        .padding(18)
+        .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Appearance
+
+struct OnymAppearanceView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var theme: AppearanceTheme = .light
+    @State private var accent: AppearanceAccent = .blue
+    @State private var font: AppearanceFont = .system
+    @State private var textSize = 2
+    @State private var bubble: BubbleStyle = .rounded
+    @State private var reduceMotion = false
+
+    enum AppearanceTheme: CaseIterable { case light, dark, system
+        var label: String { self == .light ? "Light" : self == .dark ? "Dark" : "System" }
+    }
+    enum AppearanceAccent: CaseIterable, Identifiable {
+        case blue, purple, pink, orange, green, teal
+        var id: String { String(describing: self) }
+        var color: Color {
+            switch self {
+            case .blue:   return Color(red: 10/255,  green: 132/255, blue: 255/255)
+            case .purple: return Color(red: 160/255, green: 76/255,  blue: 224/255)
+            case .pink:   return Color(red: 224/255, green: 50/255,  blue: 83/255)
+            case .orange: return Color(red: 255/255, green: 122/255, blue: 45/255)
+            case .green:  return Color(red: 48/255,  green: 180/255, blue: 90/255)
+            case .teal:   return Color(red: 43/255,  green: 179/255, blue: 207/255)
+            }
+        }
+    }
+    enum AppearanceFont: CaseIterable { case system, mono, serif
+        var label: String {
+            switch self {
+            case .system: return "San Francisco"
+            case .mono:   return "Mono everywhere"
+            case .serif:  return "New York"
+            }
+        }
+        var next: AppearanceFont {
+            switch self { case .system: return .mono; case .mono: return .serif; case .serif: return .system }
+        }
+    }
+    enum BubbleStyle: String, CaseIterable, Identifiable {
+        case rounded, square
+        var id: String { rawValue }
+        var label: String { rawValue.capitalized }
+        var radius: CGFloat { self == .rounded ? 18 : 6 }
+    }
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Appearance", onBack: { dismiss() })
+                OnymLargeTitle(text: "Appearance")
+
+                OnymSectionLabel(text: "THEME")
+                themeRow.padding(.horizontal, 16)
+
+                OnymSectionLabel(text: "ACCENT COLOR")
+                OnymCard {
+                    HStack(spacing: 12) {
+                        ForEach(AppearanceAccent.allCases) { a in
+                            Button { accent = a } label: {
+                                ZStack {
+                                    Circle().fill(a.color).frame(width: 36, height: 36)
+                                    if accent == a {
+                                        Circle().stroke(.white, lineWidth: 2).frame(width: 36, height: 36)
+                                        Circle().stroke(a.color, lineWidth: 2).frame(width: 42, height: 42)
+                                        Image(systemName: "checkmark")
+                                            .font(.system(size: 13, weight: .bold))
+                                            .foregroundStyle(.white)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.horizontal, 16).padding(.vertical, 14)
+                }
+                OnymFootnote(text: "Used for buttons, links, and active states throughout the app.")
+
+                OnymSectionLabel(text: "TEXT")
+                OnymCard {
+                    OnymRow(title: "Font",
+                            inset: 16,
+                            onTap: { font = font.next }) {
+                        EmptyView()
+                    } right: {
+                        Text(font.label).foregroundStyle(OnymTokens.text2).font(.system(size: 14))
+                    }
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Text size").font(.system(size: 16.5)).foregroundStyle(OnymTokens.text)
+                            Spacer()
+                            Text(["Smallest","Small","Default","Large","Largest"][textSize])
+                                .font(.system(size: 13)).foregroundStyle(OnymTokens.text2)
+                        }
+                        textSizeSlider
+                    }
+                    .padding(.horizontal, 16).padding(.vertical, 12)
+                    Rectangle().fill(OnymTokens.hairline).frame(height: 0.5)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text("The quick brown fox jumps over the lazy dog.")
+                            .font(fontPreview)
+                            .foregroundStyle(OnymTokens.text2)
+                            .padding(.horizontal, 16).padding(.vertical, 14)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(OnymTokens.card2)
+                    }
+                }
+
+                OnymSectionLabel(text: "CHATS")
+                OnymCard {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Bubble style").font(.system(size: 16.5)).foregroundStyle(OnymTokens.text)
+                        HStack(spacing: 10) {
+                            ForEach(BubbleStyle.allCases) { b in
+                                Button { bubble = b } label: {
+                                    bubblePreview(b)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 16).padding(.vertical, 14)
+                }
+
+                OnymSectionLabel(text: "ACCESSIBILITY")
+                OnymCard {
+                    OnymRow(title: "Reduce motion",
+                            subtitle: "Disable transitions and animated avatars",
+                            hasChevron: false,
+                            last: true) {
+                        OnymSymbolTile(symbol: "tortoise.fill", bg: OnymTokens.Tile.gray)
+                    } accessory: {
+                        OnymSwitch(on: $reduceMotion)
+                    }
+                }
+            }
+        }
+    }
+
+    private var themeRow: some View {
+        HStack(spacing: 10) {
+            ForEach(AppearanceTheme.allCases, id: \.self) { t in
+                Button { theme = t } label: { themeCard(t) }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func themeCard(_ t: AppearanceTheme) -> some View {
+        let sel = theme == t
+        let bg: AnyShapeStyle = {
+            switch t {
+            case .light:  return AnyShapeStyle(Color.white)
+            case .dark:   return AnyShapeStyle(Color(red: 0.110, green: 0.110, blue: 0.118))
+            case .system: return AnyShapeStyle(LinearGradient(
+                colors: [.white, Color(red: 0.110, green: 0.110, blue: 0.118)],
+                startPoint: .topLeading, endPoint: .bottomTrailing))
+            }
+        }()
+        let fg: Color = t == .dark ? .white : OnymTokens.text
+        return VStack(spacing: 8) {
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: 14, style: .continuous).fill(bg)
+                    .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(sel ? OnymTokens.blue : OnymTokens.hairline, lineWidth: sel ? 2.5 : 1))
+                    .frame(height: 110)
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 4) {
+                        OnymMark(size: 14, color: fg)
+                        Capsule().fill(fg.opacity(0.18)).frame(height: 4)
+                    }
+                    VStack(spacing: 4) {
+                        Capsule().fill(fg.opacity(0.5)).frame(width: 60, height: 3)
+                        Capsule().fill(fg.opacity(0.25)).frame(maxWidth: .infinity, alignment: .leading).frame(height: 3)
+                        Capsule().fill(fg.opacity(0.25)).frame(width: 40, height: 3)
+                    }
+                    .padding(6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(t == .dark
+                                ? Color(red: 0.173, green: 0.173, blue: 0.180)
+                                : (t == .system ? Color.gray.opacity(0.18) : Color(red: 0.949, green: 0.949, blue: 0.957)),
+                                in: RoundedRectangle(cornerRadius: 6))
+                }
+                .padding(10)
+            }
+            Text(t.label)
+                .font(.system(size: 13, weight: sel ? .semibold : .medium))
+                .foregroundStyle(sel ? OnymTokens.blue : OnymTokens.text)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var textSizeSlider: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color(red: 0.898, green: 0.898, blue: 0.918)).frame(height: 2)
+                Capsule().fill(OnymTokens.blue).frame(width: max(0, CGFloat(textSize) * geo.size.width / 4), height: 2)
+                HStack(spacing: 0) {
+                    ForEach(0..<5, id: \.self) { i in
+                        Button { textSize = i } label: {
+                            Circle()
+                                .fill(i == textSize ? Color.white : Color.clear)
+                                .frame(width: 28, height: 28)
+                                .overlay(Circle().fill(i <= textSize ? OnymTokens.blue : Color(red: 0.78, green: 0.78, blue: 0.80))
+                                    .frame(width: 8, height: 8))
+                                .shadow(color: i == textSize ? .black.opacity(0.18) : .clear, radius: 4, y: 2)
+                        }
+                        .buttonStyle(.plain)
+                        if i < 4 { Spacer() }
+                    }
+                }
+            }
+        }
+        .frame(height: 28)
+    }
+
+    private var fontPreview: Font {
+        let pt: CGFloat = 12 + CGFloat(textSize) * 1.5
+        switch font {
+        case .system: return .system(size: pt)
+        case .mono:   return .system(size: pt, design: .monospaced)
+        case .serif:  return .system(size: pt, design: .serif)
+        }
+    }
+
+    private func bubblePreview(_ b: BubbleStyle) -> some View {
+        let sel = bubble == b
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("Hi there")
+                .font(.system(size: 11))
+                .foregroundStyle(OnymTokens.text)
+                .padding(.horizontal, 10).padding(.vertical, 6)
+                .background(Color(red: 0.898, green: 0.898, blue: 0.918), in: RoundedRectangle(cornerRadius: b.radius))
+            Text("Hey!")
+                .font(.system(size: 11))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 10).padding(.vertical, 6)
+                .background(OnymTokens.blue, in: RoundedRectangle(cornerRadius: b.radius))
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            Text(b.label)
+                .font(.system(size: 12.5, weight: sel ? .semibold : .medium))
+                .foregroundStyle(sel ? OnymTokens.blue : OnymTokens.text2)
+        }
+        .padding(12)
+        .background(OnymTokens.card2, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14)
+            .stroke(sel ? OnymTokens.blue : OnymTokens.hairline, lineWidth: sel ? 1.5 : 1))
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - About
+
+struct OnymAboutView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var taps = 0
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "About", onBack: { dismiss() })
+
+                hero
+
+                OnymSectionLabel(text: "VERSION")
+                OnymCard {
+                    OnymRow(title: "Version", hasChevron: false, inset: 16) {
+                        EmptyView()
+                    } right: {
+                        Text("1.4.2").foregroundStyle(OnymTokens.text2)
+                    }
+                    OnymRow(title: "Build", hasChevron: false, inset: 16) {
+                        EmptyView()
+                    } right: {
+                        Text("220 · a4f9b2e")
+                            .font(.system(size: 13.5, design: .monospaced))
+                            .foregroundStyle(OnymTokens.text2)
+                    }
+                    OnymRow(title: "Released", hasChevron: false, inset: 16) {
+                        EmptyView()
+                    } right: {
+                        Text("May 2, 2026").foregroundStyle(OnymTokens.text2)
+                    }
+                    OnymRow(title: "Check for updates", last: true, onTap: {}) {
+                        OnymSymbolTile(symbol: "arrow.up.circle.fill", bg: OnymTokens.Tile.blue)
+                    }
+                }
+
+                OnymSectionLabel(text: "RESOURCES")
+                OnymCard {
+                    OnymRow(title: "Source code",
+                            subtitle: "github.com/onymchat/onym-ios",
+                            subtitleMono: true,
+                            hasChevron: false,
+                            onTap: { open("https://github.com/onymchat/onym-ios") }) {
+                        OnymSymbolTile(symbol: "chevron.left.forwardslash.chevron.right",
+                                       bg: OnymTokens.text)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Documentation",
+                            subtitle: "docs.onym.chat",
+                            hasChevron: false,
+                            onTap: { open("https://docs.onym.chat") }) {
+                        OnymSymbolTile(symbol: "doc.text.fill", bg: OnymTokens.Tile.indigo)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Whitepaper",
+                            subtitle: "The Onym protocol · v1.0",
+                            hasChevron: false,
+                            onTap: {}) {
+                        OnymSymbolTile(symbol: "sparkles", bg: OnymTokens.Tile.green)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Changelog",
+                            subtitle: "What's new",
+                            last: true,
+                            onTap: {}) {
+                        OnymSymbolTile(symbol: "list.star", bg: OnymTokens.Tile.purple)
+                    }
+                }
+
+                OnymSectionLabel(text: "HELP")
+                OnymCard {
+                    OnymRow(title: "FAQ", hasChevron: false, onTap: {}) {
+                        OnymSymbolTile(symbol: "questionmark.circle.fill", bg: OnymTokens.Tile.blue)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Community chat",
+                            subtitle: "Join the dev group on Onym",
+                            hasChevron: false, onTap: {}) {
+                        OnymSymbolTile(symbol: "bubble.left.fill", bg: OnymTokens.Tile.green)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Contact support",
+                            subtitle: "hello@onym.chat",
+                            hasChevron: false, last: true,
+                            onTap: { open("mailto:hello@onym.chat") }) {
+                        OnymSymbolTile(symbol: "envelope.fill", bg: OnymTokens.Tile.orange)
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                }
+
+                OnymSectionLabel(text: "LEGAL")
+                OnymCard {
+                    OnymRow(title: "Privacy policy", hasChevron: false, inset: 16, onTap: {}) {
+                        EmptyView()
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Terms of service", hasChevron: false, inset: 16, onTap: {}) {
+                        EmptyView()
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square").foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Open source licenses", inset: 16, last: true, onTap: {}) {
+                        EmptyView()
+                    }
+                }
+
+                VStack(spacing: 12) {
+                    OnymMark(size: 22, color: OnymTokens.text3)
+                    Text("Built by people who think privacy is a right.\nReleased under the MIT license.")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(OnymTokens.text3)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(4)
+                    Text("© 2026 · Onym Foundation")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text4)
+                    if taps >= 5 {
+                        Text("🎉 Hello, builder. Want to contribute?")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 12).padding(.vertical, 8)
+                            .background(LinearGradient(colors: [OnymTokens.purple, OnymTokens.blue],
+                                                        startPoint: .leading, endPoint: .trailing),
+                                         in: RoundedRectangle(cornerRadius: 10))
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 36)
+                .padding(.bottom, 16)
+            }
+        }
+    }
+
+    private var hero: some View {
+        VStack(spacing: 4) {
+            Button { taps += 1 } label: {
+                RoundedRectangle(cornerRadius: 26, style: .continuous)
+                    .fill(LinearGradient(colors: [Color(red: 0.106, green: 0.122, blue: 0.141),
+                                                    Color(red: 0.051, green: 0.067, blue: 0.090)],
+                                          startPoint: .topLeading, endPoint: .bottomTrailing))
+                    .frame(width: 104, height: 104)
+                    .overlay(OnymMark(size: 64, color: .white, spin: taps >= 5))
+                    .shadow(color: .black.opacity(0.18), radius: 12, y: 6)
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 12)
+
+            Text("Onym")
+                .font(.system(size: 30, weight: .bold))
+                .tracking(-0.6)
+                .foregroundStyle(OnymTokens.text)
+                .padding(.top, 18)
+            Text("open · anonymous · onchain")
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+                .tracking(0.26)
+                .padding(.top, 4)
+            HStack(spacing: 6) {
+                Text("Up to date")
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .padding(.horizontal, 8).padding(.vertical, 3)
+                    .background(OnymTokens.green.opacity(0.14),
+                                in: RoundedRectangle(cornerRadius: 999))
+                    .foregroundStyle(OnymTokens.green)
+                Text("·").font(.system(size: 12)).foregroundStyle(OnymTokens.text3)
+                Text("1.4.2 (220)")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .padding(.top, 12)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 28)
+    }
+
+    private func open(_ s: String) {
+        if let u = URL(string: s) { UIApplication.shared.open(u) }
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymRelaysView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymRelaysView.swift
@@ -1,0 +1,360 @@
+import SwiftUI
+
+struct OnymRelaysView: View {
+    @Bindable var model: OnymSettingsModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var mode: RelayMode = .random
+    @State private var customURL = ""
+
+    enum RelayMode { case random, primary }
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Relays", onBack: { dismiss() })
+                OnymLargeTitle(text: "Relays")
+
+                strategyToggle
+
+                OnymSectionLabel(text: "CONFIGURED · \(model.relays.count)")
+                OnymCard {
+                    ForEach(Array(model.relays.enumerated()), id: \.element.id) { index, r in
+                        OnymRow(
+                            title: r.name,
+                            subtitle: r.url,
+                            subtitleMono: true,
+                            inset: 56,
+                            last: index == model.relays.count - 1,
+                            onTap: {}
+                        ) {
+                            Button { model.toggleStarred(r.id) } label: {
+                                Image(systemName: r.starred ? "star.fill" : "star")
+                                    .font(.system(size: 17))
+                                    .foregroundStyle(r.starred ? OnymTokens.amber : OnymTokens.text3)
+                                    .frame(width: 30, height: 30)
+                            }
+                            .buttonStyle(.plain)
+                        } right: {
+                            HStack(spacing: 4) {
+                                OnymChip(text: r.network,
+                                         fg: Color(red: 0.10, green: 0.51, blue: 0.28),
+                                         bg: OnymTokens.green.opacity(0.14))
+                                OnymChip(text: r.visibility,
+                                         fg: r.visibility == "PRIVATE"
+                                             ? Color(red: 0.494, green: 0.114, blue: 0.2)
+                                             : Color(red: 0.572, green: 0.114, blue: 0.18),
+                                         bg: r.visibility == "PRIVATE"
+                                             ? OnymTokens.purple.opacity(0.12)
+                                             : OnymTokens.red.opacity(0.12))
+                            }
+                        }
+                    }
+                }
+
+                OnymSectionLabel(text: "ADD FROM PUBLISHED LIST")
+                OnymCard {
+                    Text("All published relays added.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(OnymTokens.text3)
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, 16).padding(.vertical, 14)
+                }
+                OnymFootnote(text: "Published by the onym-relay project. Tap to add.")
+
+                OnymSectionLabel(text: "ADD CUSTOM URL")
+                OnymCard {
+                    TextField("https://relay.example.com", text: $customURL)
+                        .font(.system(size: 16, design: .monospaced))
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .padding(.horizontal, 16).padding(.vertical, 12)
+                    Rectangle().fill(OnymTokens.hairline).frame(height: 0.5).padding(.leading, 16)
+                    OnymRow(
+                        title: "Add Custom URL",
+                        hasChevron: false,
+                        inset: 0,
+                        last: true,
+                        onTap: {
+                            // Wire up: model.addCustomRelay(customURL); customURL = ""
+                        }
+                    ) {
+                        Circle().fill(OnymTokens.blue).frame(width: 22, height: 22)
+                            .overlay(Image(systemName: "plus")
+                                .font(.system(size: 13, weight: .bold))
+                                .foregroundStyle(.white))
+                    }
+                }
+                OnymFootnote(text: "Use a private deployment, localhost, or any relay not in the published list.")
+
+                NavigationLink { OnymRunRelayView() } label: {
+                    HStack(spacing: 14) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(.white.opacity(0.08))
+                                .frame(width: 44, height: 44)
+                            Image(systemName: "chevron.left.forwardslash.chevron.right")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.white)
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Run your own relay")
+                                .font(.system(size: 15.5, weight: .semibold))
+                                .foregroundStyle(.white)
+                            Text("Deploy onym-relay from GitHub in 5 minutes")
+                                .font(.system(size: 12.5))
+                                .foregroundStyle(.white.opacity(0.65))
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.5))
+                    }
+                    .padding(18)
+                    .background(LinearGradient(colors: [Color(red: 0.106, green: 0.122, blue: 0.141),
+                                                        Color(red: 0.051, green: 0.067, blue: 0.090)],
+                                                startPoint: .topLeading, endPoint: .bottomTrailing),
+                                in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .padding(.horizontal, 16)
+                    .padding(.top, 24)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var strategyToggle: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                ForEach([RelayMode.random, .primary], id: \.self) { m in
+                    let label = m == .random ? "Random" : "Primary"
+                    Button { mode = m } label: {
+                        Text(label)
+                            .font(.system(size: 13.5, weight: mode == m ? .semibold : .medium))
+                            .foregroundStyle(OnymTokens.text)
+                            .frame(maxWidth: .infinity, minHeight: 32)
+                            .background(mode == m
+                                        ? AnyShapeStyle(Color.white)
+                                        : AnyShapeStyle(Color.clear),
+                                        in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(2)
+            .background(Color(red: 0.898, green: 0.898, blue: 0.918),
+                        in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+            .padding(.horizontal, 16)
+
+            Text(mode == .random
+                 ? "Pick a random relay for each request. Spreads load across redundant deployments and is the default."
+                 : "Use your starred relay first. Fall back to others if it's down.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(OnymTokens.text2)
+                .lineSpacing(2)
+                .padding(.horizontal, 20).padding(.top, 10)
+        }
+    }
+}
+
+// MARK: - Run your own relay (4-step explainer linking to github.com/onymchat)
+
+struct OnymRunRelayView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var copied: String?
+
+    private struct Step: Identifiable {
+        let id = UUID()
+        let n: Int
+        let title: String
+        let body: String
+        let cmd: String?
+    }
+
+    private let steps: [Step] = [
+        .init(n: 1, title: "Clone the repo",
+              body: "onym-relay is open source. Grab it from GitHub.",
+              cmd: "git clone github.com/onymchat/onym-relay"),
+        .init(n: 2, title: "Configure your domain",
+              body: "Set RELAY_URL in .env. This is what users will paste.",
+              cmd: "cp .env.example .env\necho \"RELAY_URL=https://your-domain\" >> .env"),
+        .init(n: 3, title: "Deploy",
+              body: "Pick a host. Fly.io and Railway have one-click deploys.",
+              cmd: "fly launch --copy-config\nfly deploy"),
+        .init(n: 4, title: "Add it to Onym",
+              body: "Back on Relays, paste your URL into \"Add Custom URL\".",
+              cmd: nil),
+    ]
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Run your own relay", onBack: { dismiss() })
+
+                heroCard
+
+                ForEach(Array(steps.enumerated()), id: \.element.id) { idx, s in
+                    stepRow(s)
+                    if idx < steps.count - 1 {
+                        Rectangle()
+                            .fill(LinearGradient(colors: [OnymTokens.blue.opacity(0.4), OnymTokens.blue.opacity(0.1)],
+                                                  startPoint: .top, endPoint: .bottom))
+                            .frame(width: 2, height: 24)
+                            .padding(.leading, 30)
+                    }
+                }
+
+                OnymSectionLabel(text: "ONE-CLICK DEPLOY")
+                OnymCard {
+                    OnymRow(title: "Deploy to Fly.io",
+                            subtitle: "Free tier · global edge",
+                            hasChevron: false,
+                            onTap: { open("https://fly.io/launch") }) {
+                        OnymTile(bg: Color(red: 0.482, green: 0.247, blue: 0.894)) {
+                            Text("✈").font(.system(size: 14)).foregroundStyle(.white)
+                        }
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square")
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Deploy to Railway",
+                            subtitle: "$5/mo · simple setup",
+                            hasChevron: false,
+                            onTap: { open("https://railway.app") }) {
+                        OnymTile(bg: Color(red: 0.122, green: 0.122, blue: 0.122)) {
+                            Text("▲").font(.system(size: 14)).foregroundStyle(.white)
+                        }
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square")
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    OnymRow(title: "Run with Docker",
+                            subtitle: "Self-host anywhere",
+                            hasChevron: false,
+                            last: true,
+                            onTap: {}) {
+                        OnymTile(bg: Color(red: 0, green: 0.502, blue: 1.0)) {
+                            Text("🐳").font(.system(size: 14))
+                        }
+                    } accessory: {
+                        Image(systemName: "arrow.up.right.square")
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                }
+
+                OnymFootnote(text: "Need help? Open an issue on GitHub or join the dev chat.")
+            }
+        }
+    }
+
+    private var heroCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white)
+                Text("onymchat/onym-relay")
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.65))
+            }
+            Text("Your relay, your rules")
+                .font(.system(size: 22, weight: .bold))
+                .tracking(-0.26)
+                .foregroundStyle(.white)
+            Text("Run a relay for yourself, your team, or your org. End-to-end encryption stays intact — Onym never sees your messages.")
+                .font(.system(size: 13.5))
+                .foregroundStyle(.white.opacity(0.7))
+                .lineSpacing(3)
+
+            HStack(spacing: 8) {
+                Button { open(OnymCatalog.relayRepoURL.absoluteString) } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "chevron.left.forwardslash.chevron.right")
+                        Text("View on GitHub")
+                            .font(.system(size: 13.5, weight: .semibold))
+                        Image(systemName: "arrow.up.right.square")
+                            .font(.system(size: 11))
+                    }
+                    .foregroundStyle(OnymTokens.text)
+                    .padding(.horizontal, 12).padding(.vertical, 10)
+                    .frame(maxWidth: .infinity)
+                    .background(.white, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                Button { open("https://docs.onym.chat") } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "book")
+                        Text("Read the docs")
+                            .font(.system(size: 13.5, weight: .semibold))
+                        Image(systemName: "arrow.up.right.square")
+                            .font(.system(size: 11))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12).padding(.vertical, 10)
+                    .frame(maxWidth: .infinity)
+                    .background(Color.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(20)
+        .background(LinearGradient(colors: [Color(red: 0.106, green: 0.122, blue: 0.141),
+                                              Color(red: 0.051, green: 0.067, blue: 0.090)],
+                                    startPoint: .topLeading, endPoint: .bottomTrailing),
+                     in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 16)
+    }
+
+    private func stepRow(_ s: Step) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Circle()
+                .fill(OnymTokens.blue)
+                .frame(width: 28, height: 28)
+                .overlay(Text("\(s.n)").font(.system(size: 14, weight: .bold)).foregroundStyle(.white))
+            VStack(alignment: .leading, spacing: 4) {
+                Text(s.title).font(.system(size: 16.5, weight: .semibold)).foregroundStyle(OnymTokens.text)
+                Text(s.body).font(.system(size: 13.5)).foregroundStyle(OnymTokens.text2).lineSpacing(2)
+                if let cmd = s.cmd {
+                    codeBlock(cmd, label: s.title)
+                        .padding(.top, 8)
+                }
+            }
+        }
+        .padding(.horizontal, 16).padding(.vertical, 12)
+    }
+
+    private func codeBlock(_ text: String, label: String) -> some View {
+        ZStack(alignment: .topTrailing) {
+            Text(text)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(Color(red: 0.65, green: 1.0, blue: 0.6))
+                .lineSpacing(3)
+                .padding(.horizontal, 12).padding(.vertical, 12)
+                .padding(.trailing, 36)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(red: 0.051, green: 0.067, blue: 0.090),
+                            in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            Button {
+                UIPasteboard.general.string = text
+                copied = label
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { if copied == label { copied = nil } }
+            } label: {
+                Image(systemName: copied == label ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(copied == label
+                                     ? Color(red: 0.65, green: 1.0, blue: 0.6)
+                                     : .white)
+                    .frame(width: 26, height: 26)
+                    .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+            .padding(8)
+        }
+    }
+
+    private func open(_ s: String) {
+        guard let u = URL(string: s) else { return }
+        UIApplication.shared.open(u)
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymSettingsHomeView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymSettingsHomeView.swift
@@ -1,0 +1,267 @@
+import SwiftUI
+
+/// Top-level entry the rest of the app composes. Wraps the home screen in a
+/// NavigationStack so every subscreen pushes/pops with the system gesture.
+struct OnymSettingsHomeView: View {
+    @Environment(AppState.self) private var appState
+    @State private var model: OnymSettingsModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                OnymSettingsHome(model: model)
+            } else {
+                Color.clear.onAppear { model = makeModel() }
+            }
+        }
+    }
+
+    private func makeModel() -> OnymSettingsModel {
+        let active = OnymIdentity(
+            id: "id-active",
+            name: "Identity",
+            npub: appState.keyManager.publicKeyHex,
+            backedUp: appState.keyManager.isBip39Backed,
+            active: true,
+            created: "Apr 2 2026"
+        )
+        return OnymSettingsModel(activeIdentity: active)
+    }
+}
+
+struct OnymSettingsHome: View {
+    @Bindable var model: OnymSettingsModel
+
+    var body: some View {
+        let active = model.activeIdentity ?? model.identities[0]
+        let allBackedUp = model.identities.allSatisfy { $0.backedUp }
+        @Bindable var bm = model
+
+        return OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Settings")
+                OnymLargeTitle(text: "Settings")
+
+                identityHero(active)
+                qrHero(active)
+
+                if !allBackedUp {
+                    notBackedUpBanner(count: model.identities.filter { !$0.backedUp }.count)
+                }
+
+                OnymSectionLabel(text: "SECURITY")
+                OnymCard {
+                    NavigationLink { OnymIdentitiesView(model: model) } label: {
+                        OnymRow(
+                            title: "Identities",
+                            subtitle: "\(model.identities.count) · \(model.identities.filter { $0.backedUp }.count) backed up",
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "person.fill", bg: OnymTokens.Tile.purple)
+                        }
+                    }
+                    .buttonStyle(.plain)
+
+                    NavigationLink { OnymPrivacyEncryptionView(model: model) } label: {
+                        OnymRow(
+                            title: "Privacy & Encryption",
+                            subtitle: "End-to-end · BIP-39",
+                            last: true,
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "lock.shield.fill", bg: OnymTokens.Tile.blue)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                OnymSectionLabel(text: "NETWORK")
+                OnymCard {
+                    NavigationLink { OnymRelaysView(model: model) } label: {
+                        OnymRow(
+                            title: "Relays",
+                            subtitle: "\(model.relays.count) configured · Onym Official",
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "antenna.radiowaves.left.and.right", bg: OnymTokens.Tile.indigo)
+                        }
+                    }.buttonStyle(.plain)
+
+                    NavigationLink { OnymAnchorsView(model: model) } label: {
+                        OnymRow(
+                            title: "Anchors",
+                            subtitle: "Stellar · Testnet",
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "link", bg: OnymTokens.Tile.orange)
+                        }
+                    }.buttonStyle(.plain)
+
+                    OnymRow(
+                        title: "Use Mainnet",
+                        subtitle: "Testnet by default while contracts are staged",
+                        hasChevron: false,
+                        last: true
+                    ) {
+                        OnymSymbolTile(symbol: "hammer.fill", bg: OnymTokens.Tile.gray)
+                    } accessory: {
+                        OnymSwitch(on: $bm.useMainnet)
+                    }
+                }
+
+                OnymSectionLabel(text: "APP")
+                OnymCard {
+                    NavigationLink { OnymAppearanceView() } label: {
+                        OnymRow(
+                            title: "Appearance",
+                            subtitle: "Light · Blue accent",
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "circle.lefthalf.filled", bg: OnymTokens.Tile.gray)
+                        }
+                    }.buttonStyle(.plain)
+
+                    NavigationLink { OnymAboutView() } label: {
+                        OnymRow(
+                            title: "About Onym",
+                            subtitle: "Version 1.4.2 (build 220)",
+                            last: true,
+                            onTap: {}
+                        ) {
+                            OnymSymbolTile(symbol: "info.circle.fill", bg: OnymTokens.Tile.teal)
+                        }
+                    }.buttonStyle(.plain)
+                }
+
+                VStack(spacing: 8) {
+                    OnymMark(size: 26, color: OnymTokens.text3)
+                        .padding(.top, 28)
+                    Text("onym · open · anonymous · onchain")
+                        .font(.system(size: 11))
+                        .tracking(0.22)
+                        .foregroundStyle(OnymTokens.text3)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 32)
+            }
+        }
+    }
+
+    private func identityHero(_ active: OnymIdentity) -> some View {
+        NavigationLink {
+            OnymIdentitiesView(model: model)
+        } label: {
+            HStack(spacing: 14) {
+                ZStack(alignment: .bottomTrailing) {
+                    Circle()
+                        .fill(LinearGradient(colors: [Color(red: 0.933, green: 0.961, blue: 1.0),
+                                                       Color(red: 0.878, green: 0.933, blue: 0.996)],
+                                              startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .frame(width: 56, height: 56)
+                        .overlay(Circle().stroke(OnymTokens.blue, lineWidth: 1.5))
+                        .overlay(OnymMark(size: 36, color: OnymTokens.blue))
+                    Circle()
+                        .fill(OnymTokens.green)
+                        .frame(width: 16, height: 16)
+                        .overlay(Circle().stroke(.white, lineWidth: 2))
+                        .offset(x: 2, y: 2)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("ACTIVE IDENTITY")
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(OnymTokens.text2)
+                        .tracking(0.22)
+                    Text(active.name)
+                        .font(.system(size: 19, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text)
+                        .tracking(-0.19)
+                    Text(active.npub.prefix(18) + "…")
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text2)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text3)
+            }
+            .padding(16)
+            .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .padding(.horizontal, 16)
+            .padding(.bottom, 4)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func qrHero(_ active: OnymIdentity) -> some View {
+        NavigationLink {
+            OnymShareKeyView(identity: active)
+        } label: {
+            HStack(spacing: 16) {
+                OnymQRCode(value: onymInviteURL(for: active), size: 92)
+                    .padding(8)
+                    .background(.white, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(.black.opacity(0.04), lineWidth: 1))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("INVITE KEY")
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(OnymTokens.text2)
+                        .tracking(0.46)
+                    Text("Start a chat by scanning")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text)
+                        .tracking(-0.16)
+                    Text("Have someone scan this code with Onym to open a private chat with \(active.name).")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(OnymTokens.text2)
+                        .lineSpacing(2)
+                        .lineLimit(3)
+                }
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text3)
+            }
+            .padding(18)
+            .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func notBackedUpBanner(count: Int) -> some View {
+        NavigationLink {
+            OnymIdentitiesView(model: model)
+        } label: {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(OnymTokens.amber)
+                    .frame(width: 22, height: 22)
+                    .overlay(Image(systemName: "exclamationmark")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(.white))
+                Text("\(count) identity hasn't been backed up yet.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color(red: 0.36, green: 0.227, blue: 0))
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color(red: 0.36, green: 0.227, blue: 0))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color(red: 1, green: 0.965, blue: 0.898),
+                        in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color(red: 1, green: 0.847, blue: 0.627), lineWidth: 0.5))
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/clients/ios/StellarChat/StellarChat/Views/Onym/OnymShareKeyView.swift
+++ b/clients/ios/StellarChat/StellarChat/Views/Onym/OnymShareKeyView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct OnymShareKeyView: View {
+    let identity: OnymIdentity
+    @Environment(\.dismiss) private var dismiss
+
+    private var url: String { onymInviteURL(for: identity) }
+
+    var body: some View {
+        OnymPage {
+            VStack(alignment: .leading, spacing: 0) {
+                OnymNavBar(title: "Invite Key", subtitle: identity.name, onBack: { dismiss() })
+
+                VStack(spacing: 14) {
+                    OnymQRCode(value: url, size: 260)
+                        .padding(14)
+                        .background(.white, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+                        .overlay(RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .stroke(.black.opacity(0.04), lineWidth: 1))
+                        .shadow(color: .black.opacity(0.06), radius: 8, y: 2)
+
+                    HStack(spacing: 8) {
+                        OnymIdentityTile(active: identity.active, size: 28)
+                        Text(identity.name)
+                            .font(.system(size: 17, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text)
+                    }
+                    Text(identity.npub.prefix(22) + "…")
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text2)
+
+                    Text(url)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text2)
+                        .lineLimit(1).truncationMode(.middle)
+                        .padding(.horizontal, 12).padding(.vertical, 8)
+                        .background(OnymTokens.card2, in: RoundedRectangle(cornerRadius: 10))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(24)
+                .background(OnymTokens.card, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
+                HStack(spacing: 10) {
+                    Button { UIPasteboard.general.string = url } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "doc.on.doc")
+                            Text("Copy link").font(.system(size: 15, weight: .semibold))
+                        }
+                        .foregroundStyle(OnymTokens.blue)
+                        .frame(maxWidth: .infinity, minHeight: 48)
+                        .background(Color(red: 0.863, green: 0.918, blue: 0.988),
+                                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                    ShareLink(item: url) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "square.and.arrow.up")
+                            Text("Share").font(.system(size: 15, weight: .semibold))
+                        }
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity, minHeight: 48)
+                        .background(OnymTokens.blue,
+                                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 16).padding(.top, 14)
+
+                OnymFootnote(text: "Anyone who scans this code with Onym can start a private, end-to-end encrypted chat with \(identity.name). The invite key contains your Nostr public key (npub1…) only — no contact info.")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the iOS Settings tab with a 16-screen Onym design tree (home, identities, backup flow, relays, anchors, privacy, appearance, about, share invite key)
- Wire custom contract + relayer flows to `github.com/onymchat/onym-relay` and `github.com/onymchat/contracts`
- Active identity hero + invite QR pull live from `KeyManager`

## Files
- `clients/ios/StellarChat/StellarChat/Views/Onym/` — 9 new files (~3.3k lines): tokens & primitives, models, home, identities + detail + add, backup flow, relays + run-relay, anchors + network/version/contract-detail/deploy/enter, privacy + appearance + about, share invite key
- `ContentView.swift` — Settings tab now mounts `OnymSettingsHomeView()`. Existing `SettingsView.swift` left in place but unreachable.

## Test plan
- [x] `xcodebuild -project StellarChat.xcodeproj -scheme StellarChat -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/onym-settings-build build` → BUILD SUCCEEDED
- [ ] Launch in simulator, walk Settings → Identities → Identity Detail → Backup flow (intro/reveal/verify/done)
- [ ] Settings → Relays → Run your own relay (verify GitHub link points to `github.com/onymchat/onym-relay`)
- [ ] Settings → Anchors → Testnet → Democracy → Use existing address (verify Stellar `C…` validation), Deploy from source (verify `onymchat/contracts` ref + animated console)
- [ ] Settings → Appearance theme/accent/text-size/bubble preview, About 5-tap easter egg
- [ ] Solo journey UI test still passes against new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)